### PR TITLE
⚡ Bolt: Avoid redundant per-chunk model uniform updates in shadow pass

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-29 - Avoid per-chunk redundant uniform updates
+**Learning:** During the shadow pass, setting a uniform matrix to the identity matrix `glm::mat4(1.0f)` for *every single chunk* inside the rendering loop caused thousands of redundant `glUniformMatrix4fv` and `glGetUniformLocation` calls. These calls have a significant CPU overhead due to string hashing and driver communication.
+**Action:** Always verify if a uniform is genuinely changing per-object in a rendering loop. If it is constant (like an identity model matrix for chunks in world space), set it once before the loop to drastically reduce API overhead.

--- a/src/Chunk/Chunk.cpp
+++ b/src/Chunk/Chunk.cpp
@@ -978,12 +978,11 @@ uint32_t Chunk::drawWater()
   return waterIndexCount;
 }
 
-void Chunk::drawShadow(const Shader &shader) const
+void Chunk::drawShadow() const
 {
   if (opaqueIndexCount == 0 || meshNeedsUpdate.load())
     return;
 
-  shader.setMat4("model", glm::mat4(1.0f));
   glBindVertexArray(VAO);
   glDrawElements(GL_TRIANGLES, opaqueIndexCount, GL_UNSIGNED_INT, 0);
   glBindVertexArray(0);

--- a/src/Chunk/Chunk.hpp
+++ b/src/Chunk/Chunk.hpp
@@ -49,7 +49,7 @@ public:
 	bool placeVoxel(const glm::vec3 &position, TextureType type);
 	uint32_t draw();
 	uint32_t drawWater();
-	void drawShadow(const Shader &shader) const;
+	void drawShadow() const;
 	void generateTerrain(TerrainGenerator &generator);
 	void generateMesh();
 	void generateLODMesh(); // K: simplified column-top mesh for distant chunks

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -318,11 +318,14 @@ void ChunkManager::drawVisibleChunks(Shader &shader, const Camera &camera, const
 void ChunkManager::drawShadows(const Shader &shader) const
 {
 	std::shared_lock<std::shared_mutex> lock(chunkMutex);
+	shader.use();
+	// Set model matrix once for all chunks to avoid redundant per-chunk API overhead
+	shader.setMat4("model", glm::mat4(1.0f));
 	for (Chunk *chunk : activeChunks)
 	{
 		if (!chunk->isVisible() || chunk->getState() < ChunkState::MESHED)
 			continue;
-		chunk->drawShadow(shader);
+		chunk->drawShadow();
 	}
 }
 


### PR DESCRIPTION
💡 What: Moved the model matrix uniform assignment `shader.setMat4("model", glm::mat4(1.0f));` out of the per-chunk `drawShadow` method and into the outer `ChunkManager::drawShadows` rendering loop.

🎯 Why: Setting the same uniform to an identity matrix for thousands of chunks every frame during the shadow pass creates significant unnecessary overhead from OpenGL driver communication and string hashing (`glGetUniformLocation`).

📊 Impact: Removes `O(N)` redundant OpenGL API calls per frame during the shadow map pass, reducing CPU overhead and improving frame times in heavily populated scenes.

🔬 Measurement: Profile the shadow rendering phase. You should see a noticeable drop in the number of GL API calls and time spent traversing chunks.

---
*PR created automatically by Jules for task [5367681489260245152](https://jules.google.com/task/5367681489260245152) started by @gkehren*