### PR TITLE
⚡ Bolt: [performance improvement] Cache OpenGL uniform locations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Avoid std::pow for simple integer powers and glm::distance for simple priority sorting
 **Learning:** Math functions like `std::pow` with a constant exponent `2.0f` and `glm::distance` are unnecessarily expensive in tight loops, particularly terrain generation and chunk meshing tasks.
 **Action:** Replace `std::pow(..., 2.0f)` with a simple `val * val` multiplication, and use squared distances avoiding `std::sqrt` for thresholds and simple distance-based priorities.
+## 2024-05-30 - Cache OpenGL uniform locations in Shader wrapper
+**Learning:** Calling `glGetUniformLocation` repeatedly inside the render loop for setting uniforms involves expensive string hashing and OpenGL driver lookups. Profiling reveals this is a common bottleneck in custom OpenGL engines.
+**Action:** Always wrap `glGetUniformLocation` and cache the returned `GLint` using an `std::unordered_map` (or similar) keyed by the uniform string name, particularly for wrapper classes like `Shader`. This reduces CPU overhead significantly during rendering.

--- a/src/Shader/Shader.cpp
+++ b/src/Shader/Shader.cpp
@@ -91,27 +91,40 @@ GLuint Shader::linkProgram(GLuint vertexShader, GLuint fragmentShader) const
 	return program;
 }
 
+GLint Shader::getUniformLocation(const std::string &name) const
+{
+	auto it = uniformLocationCache.find(name);
+	if (it != uniformLocationCache.end())
+	{
+		return it->second;
+	}
+
+	GLint location = glGetUniformLocation(this->id, name.c_str());
+	uniformLocationCache[name] = location;
+	return location;
+}
+
 void Shader::setMat4(const std::string &name, const glm::mat4 &mat) const
 {
-	glUniformMatrix4fv(glGetUniformLocation(this->id, name.c_str()), 1, GL_FALSE, glm::value_ptr(mat));
+	glUniformMatrix4fv(this->getUniformLocation(name), 1, GL_FALSE, glm::value_ptr(mat));
 }
 
 void Shader::setVec3(const std::string &name, const glm::vec3 &vec) const
 {
-	glUniform3fv(glGetUniformLocation(this->id, name.c_str()), 1, glm::value_ptr(vec));
+	glUniform3fv(this->getUniformLocation(name), 1, glm::value_ptr(vec));
 }
 
 void Shader::setVec2(const std::string &name, const glm::vec2 &vec) const
 {
-	glUniform2fv(glGetUniformLocation(this->id, name.c_str()), 1, glm::value_ptr(vec));
+	glUniform2fv(this->getUniformLocation(name), 1, glm::value_ptr(vec));
 }
 
 void Shader::setInt(const std::string &name, int value) const
 {
-	glUniform1i(glGetUniformLocation(this->id, name.c_str()), value);
+	glUniform1i(this->getUniformLocation(name), value);
 }
 
 void Shader::setFloat(const std::string &name, float value) const
 {
-	glUniform1f(glGetUniformLocation(this->id, name.c_str()), value);
+	glUniform1f(this->getUniformLocation(name), value);
 }

--- a/src/Shader/Shader.hpp
+++ b/src/Shader/Shader.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <fstream>
 #include <sstream>
+#include <unordered_map>
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
@@ -31,4 +32,7 @@ private:
 	std::string getShaderSource(const char *path) const;
 	GLuint compileShader(GLenum shaderType, const char *source) const;
 	GLuint linkProgram(GLuint vertexShader, GLuint fragmentShader) const;
+
+	GLint getUniformLocation(const std::string &name) const;
+	mutable std::unordered_map<std::string, GLint> uniformLocationCache;
 };


### PR DESCRIPTION
💡 What: Implemented a caching mechanism (`uniformLocationCache`) within the `Shader` class to store the results of `glGetUniformLocation`.
🎯 Why: Calling `glGetUniformLocation` on every frame for multiple uniforms involves expensive string hashing and driver lookups, causing CPU overhead.
📊 Impact: Reduces CPU overhead during the render loop by avoiding redundant OpenGL driver calls, leading to a smoother frame rate and lower CPU usage.
🔬 Measurement: Verify by profiling CPU usage during rendering; the time spent in `glGetUniformLocation` should be practically eliminated.

---
*PR created automatically by Jules for task [12056814588875022274](https://jules.google.com/task/12056814588875022274) started by @gkehren*