### PR TITLE
⚡ Bolt: Optimize ChunkManager priority queues and task erasure

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Sorting Optimization
 **Learning:** `std::sort` recalculates its lambda arguments dynamically. When the arguments involve complex calculations like vector math (distance computation), computing them inside the sorting loop results in redundant $O(N \log N)$ calculations instead of $O(N)$.
 **Action:** Always pre-calculate expensive metrics before sorting, often using a "Schwartzian transform" pattern (e.g., storing the metric in a `std::pair` or a custom struct alongside the object pointer) to dramatically reduce processing time.
+## 2024-05-24 - Priority Queue Construction and Vector Deletion
+**Learning:** Initializing a `std::priority_queue` element by element causes $O(N \log N)$ complexity due to individual push operations. Vector `.erase(it)` leads to $O(N^2)$ complexity due to shifting subsequent elements.
+**Action:** Use vector iterators `(vec.begin(), vec.end())` to instantiate `std::priority_queue` resulting in an $O(N)$ heapification process. Use the swap and pop idiom `(vec[i] = std::move(vec.back()); vec.pop_back();)` to erase elements from a vector in $O(1)$ time when order does not matter.

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -172,7 +172,8 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 		}
 	};
 
-	std::priority_queue<ChunkGenInfo> genQueue;
+	std::vector<ChunkGenInfo> genInfos;
+	genInfos.reserve(activeChunks.size());
 
 	for (Chunk *chunk : activeChunks)
 	{
@@ -182,9 +183,11 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 			float dx = chunkCenter.x - camera.getPosition().x;
 			float dz = chunkCenter.z - camera.getPosition().z;
 			float distanceSq = dx * dx + dz * dz;
-			genQueue.push({chunk, distanceSq});
+			genInfos.push_back({chunk, distanceSq});
 		}
 	} // Générer les chunks par ordre de priorité
+	std::priority_queue<ChunkGenInfo> genQueue(genInfos.begin(), genInfos.end());
+
 	int genDispatched = 0;
 	while (!genQueue.empty() && genDispatched < budget)
 	{
@@ -226,7 +229,8 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 		}
 	};
 
-	std::priority_queue<ChunkMeshInfo> meshQueue;
+	std::vector<ChunkMeshInfo> meshInfos;
+	meshInfos.reserve(activeChunks.size());
 
 	for (Chunk *chunk : activeChunks)
 	{
@@ -236,9 +240,10 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 			float dx = chunkCenter.x - camera.getPosition().x;
 			float dz = chunkCenter.z - camera.getPosition().z;
 			float distanceSq = dx * dx + dz * dz;
-			meshQueue.push({chunk, distanceSq});
+			meshInfos.push_back({chunk, distanceSq});
 		}
 	} // Mailler les chunks par ordre de priorité
+	std::priority_queue<ChunkMeshInfo> meshQueue(meshInfos.begin(), meshInfos.end());
 
 	// K: Upgrade any LOD-meshed chunks that have since come within normal range.
 	// Resetting to GENERATED lets them fall into the dispatch loop below with a
@@ -710,7 +715,8 @@ void ChunkManager::loadChunksAroundPlayer(const glm::ivec3 &cameraChunkPos, cons
 		}
 	};
 
-	std::priority_queue<ChunkLoadInfo> priorityQueue;
+	std::vector<ChunkLoadInfo> loadInfos;
+	loadInfos.reserve((2 * radius + 1) * (2 * radius + 1));
 
 	// Calculer la priorité pour chaque chunk potentiel
 	const float maxDistSq = static_cast<float>(settings.maxRenderDistance) * static_cast<float>(settings.maxRenderDistance);
@@ -730,10 +736,12 @@ void ChunkManager::loadChunksAroundPlayer(const glm::ivec3 &cameraChunkPos, cons
 
 			if (distToPlayerSq <= maxDistSq)
 			{
-				priorityQueue.push({chunkPos, distToPlayerSq});
+				loadInfos.push_back({chunkPos, distToPlayerSq});
 			}
 		}
 	}
+
+	std::priority_queue<ChunkLoadInfo> priorityQueue(loadInfos.begin(), loadInfos.end());
 
 	// Charger les chunks par ordre de priorité
 	std::lock_guard<std::shared_mutex> lock(chunkMutex);
@@ -753,40 +761,44 @@ void ChunkManager::processFinishedJobs()
 	std::lock_guard<std::shared_mutex> lock(chunkMutex);
 
 	// Check generation tasks
-	auto genIt = pendingGenerationTasks.begin();
-	while (genIt != pendingGenerationTasks.end())
+	for (size_t i = 0; i < pendingGenerationTasks.size(); )
 	{
-		if (genIt->first.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+		if (pendingGenerationTasks[i].first.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
 		{
-			genIt->first.get(); // Propagate exceptions if any
-			chunksInTransit.erase(genIt->second);
-			genIt = pendingGenerationTasks.erase(genIt);
+			pendingGenerationTasks[i].first.get(); // Propagate exceptions if any
+			chunksInTransit.erase(pendingGenerationTasks[i].second);
+
+			// ⚡ Bolt: Fast O(1) unordered erase using swap-and-pop
+			pendingGenerationTasks[i] = std::move(pendingGenerationTasks.back());
+			pendingGenerationTasks.pop_back();
 		}
 		else
 		{
-			++genIt;
+			++i;
 		}
 	}
 
 	// Check meshing tasks
-	auto meshIt = pendingMeshingTasks.begin();
-	while (meshIt != pendingMeshingTasks.end())
+	for (size_t i = 0; i < pendingMeshingTasks.size(); )
 	{
-		if (meshIt->first.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+		if (pendingMeshingTasks[i].first.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
 		{
-			meshIt->first.get();
-			Chunk *finishedChunk = meshIt->second;
+			pendingMeshingTasks[i].first.get();
+			Chunk *finishedChunk = pendingMeshingTasks[i].second;
 			chunksInTransit.erase(finishedChunk);
 			// H: A newly meshed chunk may have water geometry — invalidate the sorted
 			// cache so it appears in the next water transparency pass without waiting
 			// for the camera to move.
 			if (finishedChunk->hasWaterMesh())
 				m_cachedWaterChunks.clear();
-			meshIt = pendingMeshingTasks.erase(meshIt);
+
+			// ⚡ Bolt: Fast O(1) unordered erase using swap-and-pop
+			pendingMeshingTasks[i] = std::move(pendingMeshingTasks.back());
+			pendingMeshingTasks.pop_back();
 		}
 		else
 		{
-			++meshIt;
+			++i;
 		}
 	}
 }


### PR DESCRIPTION
💡 What: 
- Switched priority queue creation inside `loadChunksAroundPlayer`, `generatePendingVoxels`, and `meshPendingChunks` from individual `push()` calls to an $O(N)$ iterator range constructor over a pre-allocated vector.
- Switched completed task removal inside `processFinishedJobs` from an $O(N^2)$ `erase()` in a vector to an $O(1)$ fast swap-and-pop algorithm.

🎯 Why: 
- Priority queue: Calling `.push()` inside a loop performs a `push_heap` each time which is $O(N \log N)$ operations in total. Using a vector to bulk load the elements lets `std::priority_queue` use `std::make_heap` which takes $O(N)$ operations.
- Task removal: Calling `.erase()` on a vector from the middle shifts all subsequent elements, taking $O(N)$ operations per deletion. This scales quadratically ($O(N^2)$) when deleting multiple tasks simultaneously, hurting the main thread. Using swap-and-pop performs the operation in constant time $O(1)$ when order preservation isn't required.

📊 Impact: 
- Reduces CPU overhead of chunk sorting and task polling on the main thread, especially under heavy load (many chunks generated/meshed at once or camera moving quickly).

🔬 Measurement: 
- Build the game using `mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release && make -j4` and ensure no compilation errors exist. 
- Play the game and profile CPU time spent in `ChunkManager::loadChunksAroundPlayer`, `ChunkManager::generatePendingVoxels`, `ChunkManager::meshPendingChunks`, and `ChunkManager::processFinishedJobs`. CPU time spent processing finished async tasks should drop significantly.

---
*PR created automatically by Jules for task [5138711468816429895](https://jules.google.com/task/5138711468816429895) started by @gkehren*