### PR TITLE
⚡ Bolt: [performance improvement] Reuse vectors in render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Sorting Optimization
 **Learning:** `std::sort` recalculates its lambda arguments dynamically. When the arguments involve complex calculations like vector math (distance computation), computing them inside the sorting loop results in redundant $O(N \log N)$ calculations instead of $O(N)$.
 **Action:** Always pre-calculate expensive metrics before sorting, often using a "Schwartzian transform" pattern (e.g., storing the metric in a `std::pair` or a custom struct alongside the object pointer) to dramatically reduce processing time.
+## 2025-02-20 - Per-frame allocation bottleneck in Render Loop
+**Learning:** In C++ rendering loops like `ChunkManager::drawVisibleChunks`, allocating local `std::vector` instances each frame causes unnecessary dynamic memory allocation overhead.
+**Action:** Move local vectors used in hot loops to class members, call `.clear()` to maintain capacity and use them to avoid allocations.

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -313,8 +313,9 @@ void ChunkManager::drawVisibleChunks(Shader &shader, const Camera &camera, const
 
 	// --- Opaque pass ---
 	// Cache distances before sorting to reduce complexity from O(N log N) to O(N) operations.
-	std::vector<std::pair<float, Chunk*>> visibleOpaquePairs;
-	visibleOpaquePairs.reserve(activeChunks.size());
+	m_visibleOpaquePairs.clear();
+	m_visibleOpaquePairs.reserve(activeChunks.size());
+
 	glm::vec3 camPos = camera.getPosition();
 	for (Chunk *chunk : activeChunks)
 	{
@@ -322,17 +323,17 @@ void ChunkManager::drawVisibleChunks(Shader &shader, const Camera &camera, const
 		{
 			glm::vec3 center = chunk->getPosition() + glm::vec3(CHUNK_SIZE / 2.0f);
 			float distSq = glm::dot(center - camPos, center - camPos);
-			visibleOpaquePairs.push_back({distSq, chunk});
+			m_visibleOpaquePairs.push_back({distSq, chunk});
 		}
 	}
 
 	// Tri front-to-back (plus proche au plus lointain)
-	std::sort(visibleOpaquePairs.begin(), visibleOpaquePairs.end(), [](const auto& a, const auto& b)
+	std::sort(m_visibleOpaquePairs.begin(), m_visibleOpaquePairs.end(), [](const auto& a, const auto& b)
 			  {
 				  return a.first < b.first;
 			  });
 
-	for (const auto& pair : visibleOpaquePairs)
+	for (const auto& pair : m_visibleOpaquePairs)
 	{
 		Chunk *chunk = pair.second;
 		renderSettings.visibleVoxelsCount += chunk->draw();
@@ -352,24 +353,24 @@ void ChunkManager::drawVisibleChunks(Shader &shader, const Camera &camera, const
 	if (camMovedSq > kResortThreshSq || m_cachedWaterChunks.empty())
 	{
 		// Cache distances before sorting to reduce complexity from O(N log N) to O(N) operations.
-		std::vector<std::pair<float, Chunk*>> waterPairs;
+		m_waterPairs.clear();
 		for (Chunk *chunk : activeChunks)
 		{
 			if (chunk->isVisible() && chunk->getState() >= ChunkState::MESHED && chunk->hasWaterMesh())
 			{
 				glm::vec3 center = chunk->getPosition() + glm::vec3(CHUNK_SIZE / 2.0f);
 				float distSq = glm::dot(center - camPos, center - camPos);
-				waterPairs.push_back({distSq, chunk});
+				m_waterPairs.push_back({distSq, chunk});
 			}
 		}
-		std::sort(waterPairs.begin(), waterPairs.end(), [](const auto& a, const auto& b)
+		std::sort(m_waterPairs.begin(), m_waterPairs.end(), [](const auto& a, const auto& b)
 				  {
 					  return a.first > b.first; // back-to-front
 				  });
 
 		m_cachedWaterChunks.clear();
-		m_cachedWaterChunks.reserve(waterPairs.size());
-		for (const auto& pair : waterPairs)
+		m_cachedWaterChunks.reserve(m_waterPairs.size());
+		for (const auto& pair : m_waterPairs)
 		{
 			m_cachedWaterChunks.push_back(pair.second);
 		}

--- a/src/Chunk/ChunkManager.hpp
+++ b/src/Chunk/ChunkManager.hpp
@@ -69,6 +69,10 @@ private:
 
 	mutable std::shared_mutex chunkMutex;
 
+	// Optimization: Pre-allocated vectors for sorting to avoid per-frame allocations
+	mutable std::vector<std::pair<float, Chunk*>> m_visibleOpaquePairs;
+	mutable std::vector<std::pair<float, Chunk*>> m_waterPairs;
+
 	// H: water-sort cache — rebuilt only when camera moves > CHUNK_SIZE/2
 	mutable glm::vec3 m_lastWaterSortCamPos{std::numeric_limits<float>::max()};
 	mutable std::vector<Chunk *> m_cachedWaterChunks;


### PR DESCRIPTION
💡 What: Moved the local `std::vector` instances `visibleOpaquePairs` and `waterPairs` used in `ChunkManager::drawVisibleChunks` to be class members (`m_visibleOpaquePairs` and `m_waterPairs`).

🎯 Why: During the hot render loop, initializing these vectors dynamically caused heap allocations and deallocations every frame. Using class members and calling `.clear()` retains their capacities, completely bypassing the allocation bottleneck without altering behavior.

📊 Impact: Reduces memory allocation overhead during frame execution, resulting in smoother frame times and less frequent GC/memory-fragmentation issues.

🔬 Measurement: Benchmark frame times before and after under typical voxel-loading scenarios (moving through chunks). The number of dynamic allocations per frame will decrease.

---
*PR created automatically by Jules for task [8288152046342182667](https://jules.google.com/task/8288152046342182667) started by @gkehren*