### PR TITLE
⚡ Bolt: O(1) Vector Erase Optimization in ChunkManager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Sorting Optimization
 **Learning:** `std::sort` recalculates its lambda arguments dynamically. When the arguments involve complex calculations like vector math (distance computation), computing them inside the sorting loop results in redundant $O(N \log N)$ calculations instead of $O(N)$.
 **Action:** Always pre-calculate expensive metrics before sorting, often using a "Schwartzian transform" pattern (e.g., storing the metric in a `std::pair` or a custom struct alongside the object pointer) to dramatically reduce processing time.
+## 2024-05-24 - O(1) Erase in Vectors
+**Learning:** Removing an element from a `std::vector` inside a loop using `.erase()` is $O(N^2)$ and causes major slowdowns, especially in multi-threaded task management loops where a lock is held. Order does not matter for independent finished tasks.
+**Action:** Replace `std::vector::erase` with a swap-and-pop technique (`std::swap(*it, vec.back()); vec.pop_back();`), but handle the last element gracefully to prevent invalidating iterators by breaking early.

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -760,7 +760,14 @@ void ChunkManager::processFinishedJobs()
 		{
 			genIt->first.get(); // Propagate exceptions if any
 			chunksInTransit.erase(genIt->second);
-			genIt = pendingGenerationTasks.erase(genIt);
+			// O(1) erase by swapping with the last element
+			if (std::distance(genIt, pendingGenerationTasks.end()) > 1) {
+				std::swap(*genIt, pendingGenerationTasks.back());
+				pendingGenerationTasks.pop_back();
+			} else {
+				pendingGenerationTasks.pop_back();
+				break;
+			}
 		}
 		else
 		{
@@ -782,7 +789,15 @@ void ChunkManager::processFinishedJobs()
 			// for the camera to move.
 			if (finishedChunk->hasWaterMesh())
 				m_cachedWaterChunks.clear();
-			meshIt = pendingMeshingTasks.erase(meshIt);
+
+			// O(1) erase by swapping with the last element
+			if (std::distance(meshIt, pendingMeshingTasks.end()) > 1) {
+				std::swap(*meshIt, pendingMeshingTasks.back());
+				pendingMeshingTasks.pop_back();
+			} else {
+				pendingMeshingTasks.pop_back();
+				break;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
💡 What: Replaced $O(N)$ `std::vector::erase` calls with $O(1)$ swap-and-pop logic when cleaning up finished background generation and meshing tasks.
🎯 Why: Calling `.erase()` on a `std::vector` inside a while loop causes an $O(N^2)$ algorithmic complexity because all subsequent elements are shifted left. Since the order of finished background tasks doesn't matter, this operation was creating unnecessary CPU overhead and holding `chunkMutex` longer than needed.
📊 Impact: Decreases lock contention on `chunkMutex` during heavy terrain generation/meshing, improving main thread frame pacing and minimizing stutter.
🔬 Measurement: Observe CPU time spent inside `processFinishedJobs()` during rapid camera movement across chunk boundaries; the time should no longer scale quadratically with the queue size.

---
*PR created automatically by Jules for task [1365298289285563491](https://jules.google.com/task/1365298289285563491) started by @gkehren*