### PR TITLE
⚡ Bolt: Remove dynamic heap allocations in terrain generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Sorting Optimization
 **Learning:** `std::sort` recalculates its lambda arguments dynamically. When the arguments involve complex calculations like vector math (distance computation), computing them inside the sorting loop results in redundant $O(N \log N)$ calculations instead of $O(N)$.
 **Action:** Always pre-calculate expensive metrics before sorting, often using a "Schwartzian transform" pattern (e.g., storing the metric in a `std::pair` or a custom struct alongside the object pointer) to dramatically reduce processing time.
+## 2026-06-12 - Thread-Local Buffer Expansion
+**Learning:** Extending the existing `thread_local GenBuffers` struct to replace remaining dynamically allocated `std::vector` variables inside terrain generation avoids constant heap allocations without architectural overhauls. Using `std::vector::assign` within these static contexts prevents buffer overflows while continuing to safely reuse existing heap capacity.
+**Action:** Always scan hot procedural generation loops for ephemeral `std::vector` instances and promote them to thread-local or persistent buffer objects.

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -548,6 +548,11 @@ struct GenBuffers
   std::array<float, CHUNK_SIZE * CHUNK_HEIGHT> borderRavine;
   std::array<float, CHUNK_SIZE * CHUNK_HEIGHT> borderSurface3D;
 
+  // Temporary buffers for erosion and vegetation
+  std::vector<float> erosionTempMap;
+  std::array<float, CHUNK_SIZE * CHUNK_SIZE> treeNoise;
+  std::array<float, CHUNK_SIZE * CHUNK_SIZE> forestDensity;
+
   // Persistent generator to avoid expensive setup every chunk
   std::unique_ptr<TerrainGenerator> generator;
 };
@@ -1062,7 +1067,8 @@ void TerrainGenerator::applyErosion(float *heightMap, int size) const
   const float talusAngle = 0.6f;  // Max allowed height diff between adjacent cells
   const float thermalRate = 0.5f; // Fraction of material to move
 
-  std::vector<float> tempMap(heightMap, heightMap + size * size);
+  std::vector<float> &tempMap = s_genBuffers.erosionTempMap;
+  tempMap.assign(heightMap, heightMap + size * size);
 
   for (int z = 1; z < size - 1; ++z)
   {
@@ -1108,14 +1114,14 @@ void TerrainGenerator::generateVegetation(ChunkData &chunkData, int chunkX, int 
   float chunkXf = static_cast<float>(chunkX) + NOISE_OFFSET;
   float chunkZf = static_cast<float>(chunkZ) + NOISE_OFFSET;
 
-  std::vector<float> treeNoiseResults(CHUNK_SIZE * CHUNK_SIZE);
-  std::vector<float> forestDensityResults(CHUNK_SIZE * CHUNK_SIZE);
+  float *treeNoiseResults = s_genBuffers.treeNoise.data();
+  float *forestDensityResults = s_genBuffers.forestDensity.data();
 
   // Local tree-placement noise: high-frequency per-column variation
-  m_treeNoise->GenUniformGrid2D(treeNoiseResults.data(), chunkXf, chunkZf,
+  m_treeNoise->GenUniformGrid2D(treeNoiseResults, chunkXf, chunkZf,
                                 CHUNK_SIZE, CHUNK_SIZE, 1.0f, m_seed + 10000);
   // Forest-cluster noise: low-frequency, shapes large forest patches and clearings
-  m_forestDensityNoise->GenUniformGrid2D(forestDensityResults.data(), chunkXf, chunkZf,
+  m_forestDensityNoise->GenUniformGrid2D(forestDensityResults, chunkXf, chunkZf,
                                          CHUNK_SIZE, CHUNK_SIZE, 1.0f, m_seed + 11000);
 
   for (int localZ = 0; localZ < CHUNK_SIZE; ++localZ)


### PR DESCRIPTION
💡 What: Replaced ephemeral `std::vector` allocations in `applyErosion` and `generateVegetation` with thread-local buffers inside `s_genBuffers`.
🎯 Why: Chunk generation is a highly iterative hot loop. Repeated heap allocations (`std::vector`) inside this path significantly slow down performance, increasing thread waiting time.
📊 Impact: Reduces heap allocation/deallocation overhead during procedural chunk generation, ensuring stable frame rates when traveling. 
🔬 Measurement: Observe chunk loading time reductions or view CPU profiling against `malloc` / `free` in terrain tasks.

---
*PR created automatically by Jules for task [11451641897290811806](https://jules.google.com/task/11451641897290811806) started by @gkehren*