### PR TITLE
⚡ Bolt: [performance improvement] O(N) std::priority_queue initialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Sorting Optimization
 **Learning:** `std::sort` recalculates its lambda arguments dynamically. When the arguments involve complex calculations like vector math (distance computation), computing them inside the sorting loop results in redundant $O(N \log N)$ calculations instead of $O(N)$.
 **Action:** Always pre-calculate expensive metrics before sorting, often using a "Schwartzian transform" pattern (e.g., storing the metric in a `std::pair` or a custom struct alongside the object pointer) to dramatically reduce processing time.
+## 2025-02-23 - std::priority_queue initialization
+**Learning:** Inserting elements one-by-one into a `std::priority_queue` takes $O(N \log N)$ time. By instead using a `std::vector` with `reserve()` to gather elements and using the `std::priority_queue` constructor that takes an rvalue container (`std::move`), the underlying heap is built in $O(N)$ time using `std::make_heap`.
+**Action:** Always prefer initializing `std::priority_queue` with a pre-populated `std::vector` ($O(N)$) rather than using individual `push()` calls ($O(N \log N)$).

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -172,7 +172,8 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 		}
 	};
 
-	std::priority_queue<ChunkGenInfo> genQueue;
+	std::vector<ChunkGenInfo> genVec;
+	genVec.reserve(activeChunks.size());
 
 	for (Chunk *chunk : activeChunks)
 	{
@@ -182,9 +183,11 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 			float dx = chunkCenter.x - camera.getPosition().x;
 			float dz = chunkCenter.z - camera.getPosition().z;
 			float distanceSq = dx * dx + dz * dz;
-			genQueue.push({chunk, distanceSq});
+			genVec.push_back({chunk, distanceSq});
 		}
 	} // Générer les chunks par ordre de priorité
+
+	std::priority_queue<ChunkGenInfo> genQueue(std::less<ChunkGenInfo>(), std::move(genVec));
 	int genDispatched = 0;
 	while (!genQueue.empty() && genDispatched < budget)
 	{
@@ -226,7 +229,8 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 		}
 	};
 
-	std::priority_queue<ChunkMeshInfo> meshQueue;
+	std::vector<ChunkMeshInfo> meshVec;
+	meshVec.reserve(activeChunks.size());
 
 	for (Chunk *chunk : activeChunks)
 	{
@@ -236,9 +240,11 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 			float dx = chunkCenter.x - camera.getPosition().x;
 			float dz = chunkCenter.z - camera.getPosition().z;
 			float distanceSq = dx * dx + dz * dz;
-			meshQueue.push({chunk, distanceSq});
+			meshVec.push_back({chunk, distanceSq});
 		}
 	} // Mailler les chunks par ordre de priorité
+
+	std::priority_queue<ChunkMeshInfo> meshQueue(std::less<ChunkMeshInfo>(), std::move(meshVec));
 
 	// K: Upgrade any LOD-meshed chunks that have since come within normal range.
 	// Resetting to GENERATED lets them fall into the dispatch loop below with a
@@ -710,7 +716,8 @@ void ChunkManager::loadChunksAroundPlayer(const glm::ivec3 &cameraChunkPos, cons
 		}
 	};
 
-	std::priority_queue<ChunkLoadInfo> priorityQueue;
+	std::vector<ChunkLoadInfo> priorityVec;
+	priorityVec.reserve((2 * radius + 1) * (2 * radius + 1));
 
 	// Calculer la priorité pour chaque chunk potentiel
 	const float maxDistSq = static_cast<float>(settings.maxRenderDistance) * static_cast<float>(settings.maxRenderDistance);
@@ -730,10 +737,12 @@ void ChunkManager::loadChunksAroundPlayer(const glm::ivec3 &cameraChunkPos, cons
 
 			if (distToPlayerSq <= maxDistSq)
 			{
-				priorityQueue.push({chunkPos, distToPlayerSq});
+				priorityVec.push_back({chunkPos, distToPlayerSq});
 			}
 		}
 	}
+
+	std::priority_queue<ChunkLoadInfo> priorityQueue(std::less<ChunkLoadInfo>(), std::move(priorityVec));
 
 	// Charger les chunks par ordre de priorité
 	std::lock_guard<std::shared_mutex> lock(chunkMutex);


### PR DESCRIPTION
💡 What: Replaced element-by-element `push()` into `std::priority_queue` with bulk initialization using a pre-populated `std::vector` and `std::move`.
🎯 Why: Inserting elements one-by-one into a `std::priority_queue` takes $O(N \log N)$ time. By gathering elements into a pre-reserved `std::vector` and passing it to the priority_queue constructor, the heap is built in $O(N)$ time using `std::make_heap`.
📊 Impact: Reduces chunk loading, generation, and meshing prioritization time complexity from $O(N \log N)$ to $O(N)$.
🔬 Measurement: Can be verified by profiling `generatePendingVoxels`, `meshPendingChunks`, and `loadChunksAroundPlayer` functions to see reduced execution time.

---
*PR created automatically by Jules for task [8363357769716143108](https://jules.google.com/task/8363357769716143108) started by @gkehren*