### PR TITLE
⚡ Bolt: Optimize EventBus lookup using std::array

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-02-20 - Per-frame allocation bottleneck in Render Loop
 **Learning:** In C++ rendering loops like `ChunkManager::drawVisibleChunks`, allocating local `std::vector` instances each frame causes unnecessary dynamic memory allocation overhead.
 **Action:** Move local vectors used in hot loops to class members, call `.clear()` to maintain capacity and use them to avoid allocations.
+## 2025-02-21 - Event Bus Optimization
+**Learning:** In highly accessed event systems like `EventBus::publish`, mapping an enum to a vector of handlers via `std::unordered_map` introduces hashing overhead, double lookups (`find` then `[]`), and pointer chasing that degrades performance.
+**Action:** Replace `std::unordered_map` with a flat `std::array` indexed by a `Count` element on the enum. This provides O(1) contiguous memory access, completely eliminating hashing and cache misses.

--- a/src/Engine/EventBus.hpp
+++ b/src/Engine/EventBus.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <memory>
 #include <unordered_map>
+#include <array>
 #include <SDL3/SDL.h>
 
 enum class EventType {
@@ -14,7 +15,8 @@ enum class EventType {
     MouseButtonPress,
     MouseButtonRelease,
     MouseWheel,
-    Quit
+    Quit,
+    Count
 };
 
 struct Event {
@@ -58,17 +60,24 @@ public:
     }
 
     void subscribe(EventType type, EventHandler handler) {
-        subscribers[type].push_back(handler);
+        size_t index = static_cast<size_t>(type);
+        if (index < static_cast<size_t>(EventType::Count)) {
+            subscribers[index].push_back(handler);
+        }
     }
 
     void publish(const Event& event) {
-        if (subscribers.find(event.type) != subscribers.end()) {
-            for (auto& handler : subscribers[event.type]) {
+        size_t index = static_cast<size_t>(event.type);
+        if (index < static_cast<size_t>(EventType::Count)) {
+            for (auto& handler : subscribers[index]) {
                 handler(event);
             }
         }
     }
 
 private:
-    std::unordered_map<EventType, std::vector<EventHandler>> subscribers;
+    // ⚡ Bolt: Replaced std::unordered_map with a flat std::array indexed by EventType.
+    // This turns a hashing operation with potential cache misses into an O(1) contiguous
+    // array lookup, significantly improving performance on the hot path of the event bus.
+    std::array<std::vector<EventHandler>, static_cast<size_t>(EventType::Count)> subscribers;
 };


### PR DESCRIPTION
💡 What: Replaced `std::unordered_map` with `std::array` in `EventBus` to map `EventType` to handlers. Added a `Count` value to `EventType` enum to size the array dynamically.
🎯 Why: To eliminate the $O(1)$ hash calculation, potential cache misses, and double-lookup issues inherent to `std::unordered_map` on the event bus's hot path.
📊 Impact: Converts event publishing lookup from an unordered map access to a direct contiguous array index, reducing CPU cycles per event published.
🔬 Measurement: Verify by running the application and checking that events still fire correctly, while observing lower CPU time spent in `EventBus::publish` under profilers.

---
*PR created automatically by Jules for task [10111394973734254249](https://jules.google.com/task/10111394973734254249) started by @gkehren*