### PR TITLE
⚡ Bolt: [performance improvement] Replace std::endl with \n

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-02-20 - Per-frame allocation bottleneck in Render Loop
 **Learning:** In C++ rendering loops like `ChunkManager::drawVisibleChunks`, allocating local `std::vector` instances each frame causes unnecessary dynamic memory allocation overhead.
 **Action:** Move local vectors used in hot loops to class members, call `.clear()` to maintain capacity and use them to avoid allocations.
+## 2026-06-22 - [Stream Buffer Flush Optimization]
+**Learning:** [std::endl forces a buffer flush on standard streams, which can cause significant I/O performance bottlenecks if used excessively or in hot paths.]
+**Action:** [Prefer using `\n` over `std::endl` for C++ log outputs to let the stream manage its buffer efficiently.]

--- a/src/Chunk/ChunkPool.cpp
+++ b/src/Chunk/ChunkPool.cpp
@@ -21,7 +21,7 @@ ChunkPool::ChunkPool(size_t capacity)
 	}
 
 	std::cout << "ChunkPool: pre-allocated " << capacity << " chunks ("
-			  << (capacity * sizeof(Chunk)) / (1024 * 1024) << " MB storage)" << std::endl;
+			  << (capacity * sizeof(Chunk)) / (1024 * 1024) << " MB storage)" << "\n";
 }
 
 ChunkPool::~ChunkPool()
@@ -47,7 +47,7 @@ Chunk *ChunkPool::acquire(const glm::vec3 &worldPosition)
 	m_overflowCount.fetch_add(1, std::memory_order_relaxed);
 	m_acquiredCount.fetch_add(1, std::memory_order_relaxed);
 	std::cerr << "ChunkPool: WARNING — pool exhausted, heap-allocating chunk (overflow #"
-			  << m_overflowCount.load(std::memory_order_relaxed) << ")" << std::endl;
+			  << m_overflowCount.load(std::memory_order_relaxed) << ")" << "\n";
 
 	Chunk *overflow = new Chunk(worldPosition);
 	return overflow;

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -101,13 +101,13 @@ Engine::Engine() : deltaTime(0.0f), fps(0.0f), lastFrame(0.0f), frameCount(0.0f)
 	this->inputSystem = std::make_unique<InputSystem>();
 	this->setupEventHandlers();
 
-	std::cout << "SDL version: " << SDL_GetVersion() << std::endl;
-	std::cout << "OpenGL version: " << glGetString(GL_VERSION) << std::endl;
-	std::cout << "GLSL version: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;
-	std::cout << "Vendor: " << glGetString(GL_VENDOR) << std::endl;
-	std::cout << "Renderer: " << glGetString(GL_RENDERER) << std::endl;
-	std::cout << "ImGui version: " << IMGUI_VERSION << std::endl;
-	std::cout << "Threads: " << (threadCount > 0 ? threadCount : 1) << std::endl;
+	std::cout << "SDL version: " << SDL_GetVersion() << "\n";
+	std::cout << "OpenGL version: " << glGetString(GL_VERSION) << "\n";
+	std::cout << "GLSL version: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << "\n";
+	std::cout << "Vendor: " << glGetString(GL_VENDOR) << "\n";
+	std::cout << "Renderer: " << glGetString(GL_RENDERER) << "\n";
+	std::cout << "ImGui version: " << IMGUI_VERSION << "\n";
+	std::cout << "Threads: " << (threadCount > 0 ? threadCount : 1) << "\n";
 }
 
 Engine::~Engine()
@@ -154,7 +154,7 @@ void Engine::initializeNoiseGenerator(int seed_val)
 
 	this->chunkManager = std::make_unique<ChunkManager>(terrainGenerator.get(), threadPool.get(), chunkPool.get(), uiManager->getRenderTiming());
 
-	std::cout << "Terrain generation initialized with seed: " << this->seed << std::endl;
+	std::cout << "Terrain generation initialized with seed: " << this->seed << "\n";
 }
 
 void Engine::run()
@@ -568,11 +568,11 @@ void Engine::startServer()
 		try
 		{
 			server = std::make_unique<Server>(25565, this->seed);
-			std::cout << "Server started." << std::endl;
+			std::cout << "Server started." << "\n";
 		}
 		catch (const std::exception &e)
 		{
-			std::cerr << "Failed to start server: " << e.what() << std::endl;
+			std::cerr << "Failed to start server: " << e.what() << "\n";
 			server.reset();
 		}
 	}
@@ -583,7 +583,7 @@ void Engine::stopServer()
 	if (server)
 	{
 		server.reset();
-		std::cout << "Server stopped." << std::endl;
+		std::cout << "Server stopped." << "\n";
 	}
 }
 
@@ -596,12 +596,12 @@ void Engine::connectToServer(const std::string &ip)
 			client = std::make_unique<Client>();
 			client->connect(ip, 25565); // Assuming default port 25565
 			this->seed = 0;
-			std::cout << "Successfully connected to server at " << ip << std::endl;
+			std::cout << "Successfully connected to server at " << ip << "\n";
 			// Seed will be received from server
 		}
 		catch (const std::exception &e)
 		{
-			std::cerr << "Failed to connect to server: " << e.what() << std::endl;
+			std::cerr << "Failed to connect to server: " << e.what() << "\n";
 			client.reset();
 		}
 	}
@@ -612,7 +612,7 @@ void Engine::disconnectClient()
 	if (client)
 	{
 		client.reset();
-		std::cout << "Disconnected from server." << std::endl;
+		std::cout << "Disconnected from server." << "\n";
 	}
 }
 

--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -58,7 +58,7 @@ void Client::requestSeed()
 	// std::unique_lock<std::mutex> lock(seedMutex);
 	// if (!seedCondVar.wait_for(lock, std::chrono::seconds(5), [this]() { return worldSeed != 0; })) {
 	//	// if we didn't receive the seed in 5 seconds, disconnect
-	//	std::cerr << "Failed to receive seed from server" << std::endl;
+	//	std::cerr << "Failed to receive seed from server" << "\n";
 	//	if (connected)
 	//		disconnect();
 	// }
@@ -77,7 +77,7 @@ void Client::sendMessage(const Message &message)
 						 {
 							 if (error)
 							 {
-								 std::cerr << "Error sending message: " << error.message() << std::endl;
+								 std::cerr << "Error sending message: " << error.message() << "\n";
 							 }
 						 });
 }
@@ -122,7 +122,7 @@ void Client::handleMessage(const std::vector<uint8_t> &data)
 		uint32_t seedNetworkOrder;
 		std::memcpy(&seedNetworkOrder, message.payload.data(), sizeof(uint32_t));
 		worldSeed = ntohl(seedNetworkOrder);
-		std::cout << "Seed received: " << worldSeed << std::endl;
+		std::cout << "Seed received: " << worldSeed << "\n";
 
 		//{
 		//	std::unique_lock<std::mutex> lock(seedMutex);
@@ -146,7 +146,7 @@ void Client::handleMessage(const std::vector<uint8_t> &data)
 	{
 		std::memcpy(&playerId, message.payload.data(), sizeof(uint32_t));
 		playerId = ntohl(playerId);
-		std::cout << "Authenticated with player ID: " << playerId << std::endl;
+		std::cout << "Authenticated with player ID: " << playerId << "\n";
 		sendAck(playerId);
 	}
 }

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -133,7 +133,7 @@ void Server::handleMessage(const boost::asio::ip::udp::endpoint &senderEndpoint,
 		std::memcpy(&playerId, message.payload.data(), sizeof(uint32_t));
 		playerId = ntohl(playerId);
 
-		std::cout << "Player " << playerId << " authenticated successfully." << std::endl;
+		std::cout << "Player " << playerId << " authenticated successfully." << "\n";
 	}
 }
 
@@ -149,7 +149,7 @@ void Server::sendMessage(const boost::asio::ip::udp::endpoint &endpoint, const M
 						 [](const boost::system::error_code &error, std::size_t /*bytesTransferred*/)
 						 {
 							 if (error)
-								 std::cerr << "Failed to send message: " << error.message() << std::endl;
+								 std::cerr << "Failed to send message: " << error.message() << "\n";
 						 });
 }
 

--- a/src/Renderer/PostProcessing.cpp
+++ b/src/Renderer/PostProcessing.cpp
@@ -105,7 +105,7 @@ void PostProcessing::initFBOs()
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, hdrDepthRBO);
 
 	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-		std::cerr << "[PostProcessing] HDR FBO is not complete!" << std::endl;
+		std::cerr << "[PostProcessing] HDR FBO is not complete!" << "\n";
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
@@ -128,7 +128,7 @@ void PostProcessing::initFBOs()
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, bloomTexture[i], 0);
 
 		if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-			std::cerr << "[PostProcessing] Bloom FBO " << i << " is not complete!" << std::endl;
+			std::cerr << "[PostProcessing] Bloom FBO " << i << " is not complete!" << "\n";
 	}
 
 	// ---- God rays FBO (half resolution, R11F_G11F_B10F) ----
@@ -145,7 +145,7 @@ void PostProcessing::initFBOs()
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, godRaysTexture, 0);
 
 	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-		std::cerr << "[PostProcessing] God Rays FBO is not complete!" << std::endl;
+		std::cerr << "[PostProcessing] God Rays FBO is not complete!" << "\n";
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -227,7 +227,7 @@ void Renderer::loadSkybox()
 		}
 		else
 		{
-			std::cout << "Failed to load texture" << std::endl;
+			std::cout << "Failed to load texture" << "\n";
 		}
 	}
 

--- a/src/Renderer/TextureManager.cpp
+++ b/src/Renderer/TextureManager.cpp
@@ -63,7 +63,7 @@ void TextureManager::initialize()
 
 	GLenum err;
 	if ((err = glGetError()) != GL_NO_ERROR)
-		std::cerr << "OpenGL error during texture array initialization: " << err << std::endl;
+		std::cerr << "OpenGL error during texture array initialization: " << err << "\n";
 
 	glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
 }
@@ -87,7 +87,7 @@ void TextureManager::loadTexture(const std::string &path, TextureType type, bool
 	}
 	else
 	{
-		std::cout << "Failed to load texture: " << path << std::endl;
+		std::cout << "Failed to load texture: " << path << "\n";
 	}
 }
 
@@ -129,7 +129,7 @@ void TextureManager::loadWaterTexture(const std::string &path, TextureType type,
 	}
 	else
 	{
-		std::cout << "Failed to load water texture: " << path << std::endl;
+		std::cout << "Failed to load water texture: " << path << "\n";
 	}
 }
 

--- a/src/imgui/ImGuiFileDialog.cpp
+++ b/src/imgui/ImGuiFileDialog.cpp
@@ -653,7 +653,7 @@ IGFD_API bool IGFD::Utils::CreateDirectoryIfNotExist(const std::string& name) {
             }
 #endif  // _IGFD_WIN_
             if (!res) {
-                std::cout << "Error creating directory " << name << std::endl;
+                std::cout << "Error creating directory " << name << "\n";
             }
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv)
 	}
 	else if (argc == 2 && std::string(argv[1]) == "--help")
 	{
-		std::cout << "Usage: " << argv[0] << " [--seed <value>]" << std::endl;
+		std::cout << "Usage: " << argv[0] << " [--seed <value>]" << "\n";
 		return EXIT_SUCCESS;
 	}
 	else if (argc == 3 && std::string(argv[1]) == "--seed")
@@ -23,16 +23,16 @@ int main(int argc, char **argv)
 
 		if (*endptr != '\0' || argv[2] == endptr) // Check if conversion failed or no digits were read
 		{
-			std::cerr << "Error: Seed value '" << argv[2] << "' is not a valid integer." << std::endl;
-			std::cerr << "Usage: " << argv[0] << " [--seed <value>]" << std::endl;
+			std::cerr << "Error: Seed value '" << argv[2] << "' is not a valid integer." << "\n";
+			std::cerr << "Usage: " << argv[0] << " [--seed <value>]" << "\n";
 			return EXIT_FAILURE;
 		}
 		seed_to_use = static_cast<unsigned int>(val);
 	}
 	else
 	{
-		std::cerr << "Invalid arguments." << std::endl;
-		std::cerr << "Usage: " << argv[0] << " [--seed <value>]" << std::endl;
+		std::cerr << "Invalid arguments." << "\n";
+		std::cerr << "Usage: " << argv[0] << " [--seed <value>]" << "\n";
 		return EXIT_FAILURE;
 	}
 
@@ -44,12 +44,12 @@ int main(int argc, char **argv)
 	}
 	catch (const std::exception &e)
 	{
-		std::cerr << "Runtime error: " << e.what() << std::endl;
+		std::cerr << "Runtime error: " << e.what() << "\n";
 		return EXIT_FAILURE;
 	}
 	catch (...)
 	{
-		std::cerr << "Unknown exception occurred." << std::endl;
+		std::cerr << "Unknown exception occurred." << "\n";
 		return EXIT_FAILURE;
 	}
 


### PR DESCRIPTION
💡 **What:** Replaced `std::endl` with `\n` across the codebase (mainly in `src/main.cpp`, logging files, rendering, and network components).

🎯 **Why:** `std::endl` not only inserts a newline character but also forces a stream buffer flush. Unnecessary flushes degrade I/O performance. Using `\n` is standard C++ performance advice to avoid these bottlenecks and let the I/O streams buffer optimally.

📊 **Impact:** This ensures better IO performance, particularly for heavy console output.

🔬 **Measurement:** I could not obtain a measurable performance improvement for this specific change because the affected prints mostly occur during initialization, networking setup, or error paths, which aren't continuously hit in a hot loop. Thus, it's impossible to establish a numerical benchmark for this optimization. However, avoiding `std::endl` is a universal C++ optimization standard that maintains high throughput for logs and outputs when they do trigger.

---
*PR created automatically by Jules for task [8285190063074004791](https://jules.google.com/task/8285190063074004791) started by @gkehren*