### PR TITLE
Fix asynchronous network buffer lifetime in Client and Server

### DIFF
--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -66,15 +66,15 @@ void Client::requestSeed()
 
 void Client::sendMessage(const Message &message)
 {
-	std::vector<uint8_t> data;
-	data.reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
-	data.push_back(message.type);
+	auto data = std::make_shared<std::vector<uint8_t>>();
+	data->reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
+	data->push_back(message.type);
 	uint32_t seqNetOrder = htonl(message.sequenceNumber);
-	data.insert(data.end(), reinterpret_cast<uint8_t *>(&seqNetOrder), reinterpret_cast<uint8_t *>(&seqNetOrder) + sizeof(uint32_t));
-	data.insert(data.end(), message.payload.begin(), message.payload.end());
+	data->insert(data->end(), reinterpret_cast<const uint8_t *>(&seqNetOrder), reinterpret_cast<const uint8_t *>(&seqNetOrder) + sizeof(uint32_t));
+	data->insert(data->end(), message.payload.begin(), message.payload.end());
 
-	socket.async_send_to(boost::asio::buffer(data), serverEndpoint,
-						 [this](const boost::system::error_code &error, std::size_t bytesTransferred)
+	socket.async_send_to(boost::asio::buffer(*data), serverEndpoint,
+						 [this, data](const boost::system::error_code &error, std::size_t bytesTransferred)
 						 {
 							 if (error)
 							 {

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -139,15 +139,15 @@ void Server::handleMessage(const boost::asio::ip::udp::endpoint &senderEndpoint,
 
 void Server::sendMessage(const boost::asio::ip::udp::endpoint &endpoint, const Message &message)
 {
-	std::vector<uint8_t> data;
-	data.reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
-	data.push_back(message.type);
+	auto data = std::make_shared<std::vector<uint8_t>>();
+	data->reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
+	data->push_back(message.type);
 	uint32_t seqNetOrder = htonl(message.sequenceNumber);
-	data.insert(data.end(), reinterpret_cast<uint8_t *>(&seqNetOrder), reinterpret_cast<uint8_t *>(&seqNetOrder) + sizeof(uint32_t));
-	data.insert(data.end(), message.payload.begin(), message.payload.end());
+	data->insert(data->end(), reinterpret_cast<const uint8_t *>(&seqNetOrder), reinterpret_cast<const uint8_t *>(&seqNetOrder) + sizeof(uint32_t));
+	data->insert(data->end(), message.payload.begin(), message.payload.end());
 
-	socket.async_send_to(boost::asio::buffer(data), endpoint,
-						 [](const boost::system::error_code &error, std::size_t /*bytesTransferred*/)
+	socket.async_send_to(boost::asio::buffer(*data), endpoint,
+						 [data](const boost::system::error_code &error, std::size_t /*bytesTransferred*/)
 						 {
 							 if (error)
 								 std::cerr << "Failed to send message: " << error.message() << "\n";


### PR DESCRIPTION
Replaced the local `std::vector<uint8_t>` buffers with dynamically allocated `std::shared_ptr<std::vector<uint8_t>>` in both `Client::sendMessage` and `Server::sendMessage`. Captured the shared pointer by value in the `socket.async_send_to` callbacks to guarantee the buffers remain alive until the asynchronous network operations complete. This fixes use-after-free bugs and prevents memory corruption.

---
*PR created automatically by Jules for task [8969088411808070536](https://jules.google.com/task/8969088411808070536) started by @gkehren*