### PR TITLE
⚡ Bolt: Replace std::unordered_set with std::vector for activeChunks in ChunkManager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,6 @@
 ## 2025-02-21 - Event Bus Optimization
 **Learning:** In highly accessed event systems like `EventBus::publish`, mapping an enum to a vector of handlers via `std::unordered_map` introduces hashing overhead, double lookups (`find` then `[]`), and pointer chasing that degrades performance.
 **Action:** Replace `std::unordered_map` with a flat `std::array` indexed by a `Count` element on the enum. This provides O(1) contiguous memory access, completely eliminating hashing and cache misses.
+## 2024-06-23 - ChunkManager Container Optimization
+**Learning:** In a highly dynamic system like `ChunkManager`, tracking active chunks with `std::unordered_set` incurs significant hashing overhead, individual heap allocations per node, and poor cache locality during iteration (which happens multiple times per frame).
+**Action:** Replace `std::unordered_set<Chunk*>` with `std::vector<Chunk*>` for `activeChunks` when the primary operations are iteration and additions, and use (1)$ swap-and-pop for removals. This improves cache locality and iteration speed significantly.

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -76,7 +76,7 @@ void ChunkManager::processChunkLoading(const RenderSettings &settings, int budge
 			if (chunks.find(chunkPos) == chunks.end())
 			{
 				chunks[chunkPos] = chunk;
-				activeChunks.insert(chunk);
+				activeChunks.push_back(chunk);
 			}
 			else
 			{
@@ -698,7 +698,12 @@ void ChunkManager::unloadOutOfRangeChunks(const Camera &camera, const RenderSett
 				// Re-check in_transit just in case state changed
 				if (chunksInTransit.find(chunkPtr) == chunksInTransit.end())
 				{
-					activeChunks.erase(chunkPtr);
+					auto activeIt = std::find(activeChunks.begin(), activeChunks.end(), chunkPtr);
+					if (activeIt != activeChunks.end())
+					{
+						*activeIt = activeChunks.back();
+						activeChunks.pop_back();
+					}
 					m_chunkPool->release(chunkPtr);
 					chunks.erase(it);
 					m_cachedWaterChunks.clear(); // H: invalidate water sort cache

--- a/src/Chunk/ChunkManager.hpp
+++ b/src/Chunk/ChunkManager.hpp
@@ -60,7 +60,7 @@ private:
 	TaskPriority calculateTaskPriority(float distance, float lodThreshold) const;
 
 	std::unordered_map<glm::ivec3, Chunk*, IVec3Hash> chunks;
-	std::unordered_set<Chunk *> activeChunks;
+	std::vector<Chunk *> activeChunks;
 	std::queue<glm::ivec3> chunkLoadQueue;
 
 	std::vector<std::pair<std::future<void>, Chunk *>> pendingGenerationTasks;


### PR DESCRIPTION
💡 What: Replaced `std::unordered_set<Chunk*>` with `std::vector<Chunk*>` for the `activeChunks` collection in `ChunkManager`.
🎯 Why: `activeChunks` is iterated over multiple times per frame for tasks like culling, rendering, and logic updates. Using an `unordered_set` causes pointer-chasing and cache misses during iteration due to its node-based structure. `std::vector` provides contiguous memory layout, drastically improving cache locality and iteration speed.
📊 Impact: Expected to reduce frame time and improve FPS by minimizing CPU cache misses during hot path execution.
🔬 Measurement: Verify improvement by profiling iteration times within `ChunkManager::performFrustumCulling` and `ChunkManager::drawVisibleChunks` before and after this change.

---
*PR created automatically by Jules for task [11169286230464651918](https://jules.google.com/task/11169286230464651918) started by @gkehren*