### PR TITLE
🔧 Bolt: Fix Boost.Asio thread safety and sequence number data race in Client

### DIFF
--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -66,21 +66,23 @@ void Client::requestSeed()
 
 void Client::sendMessage(const Message &message)
 {
-	auto data = std::make_shared<std::vector<uint8_t>>();
-	data->reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
-	data->push_back(message.type);
-	uint32_t seqNetOrder = htonl(message.sequenceNumber);
-	data->insert(data->end(), reinterpret_cast<const uint8_t *>(&seqNetOrder), reinterpret_cast<const uint8_t *>(&seqNetOrder) + sizeof(uint32_t));
-	data->insert(data->end(), message.payload.begin(), message.payload.end());
+	boost::asio::post(ioContext, [this, message]()
+					  {
+		auto data = std::make_shared<std::vector<uint8_t>>();
+		data->reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
+		data->push_back(message.type);
+		uint32_t seqNetOrder = htonl(message.sequenceNumber);
+		data->insert(data->end(), reinterpret_cast<const uint8_t *>(&seqNetOrder), reinterpret_cast<const uint8_t *>(&seqNetOrder) + sizeof(uint32_t));
+		data->insert(data->end(), message.payload.begin(), message.payload.end());
 
-	socket.async_send_to(boost::asio::buffer(*data), serverEndpoint,
-						 [this, data](const boost::system::error_code &error, std::size_t bytesTransferred)
-						 {
-							 if (error)
+		socket.async_send_to(boost::asio::buffer(*data), serverEndpoint,
+							 [this, data](const boost::system::error_code &error, std::size_t bytesTransferred)
 							 {
-								 std::cerr << "Error sending message: " << error.message() << "\n";
-							 }
-						 });
+								 if (error)
+								 {
+									 std::cerr << "Error sending message: " << error.message() << "\n";
+								 }
+							 }); });
 }
 
 void Client::receive()
@@ -184,7 +186,7 @@ void Client::sendPlayerPosition(float x, float y, float z)
 
 	Message message;
 	message.type = MessageType::PLAYER_POSITION;
-	message.sequenceNumber = message.sequenceNumber++;
+	message.sequenceNumber = sequenceNumber++;
 	message.payload.resize(sizeof(PlayerPosition));
 	std::memcpy(message.payload.data(), &position, sizeof(PlayerPosition));
 

--- a/src/Network/Client.hpp
+++ b/src/Network/Client.hpp
@@ -43,7 +43,7 @@ private:
 	std::mutex seedMutex;
 	std::condition_variable seedCondVar;
 
-	uint32_t sequenceNumber;
+	std::atomic<uint32_t> sequenceNumber;
 
 	std::array<uint8_t, 1024> recvBuffer;
 


### PR DESCRIPTION
💡 **What**
Wrapped the contents of `Client::sendMessage` in a `boost::asio::post` block to execute strictly within the `ioContext` thread, and changed `sequenceNumber` to `std::atomic<uint32_t>` along with fixing a self-assignment bug in `sendPlayerPosition`.

🎯 **Why**
Direct calls to Asio socket methods like `async_send_to` outside of the `ioContext.run()` thread cause undefined behavior and data races. `sequenceNumber` is accessed across threads. The assignment `message.sequenceNumber = message.sequenceNumber++` was operating on uninitialized memory, leading to a logical flaw.

📊 **Impact**
Eliminates data races on the `sequenceNumber` and guarantees thread safety on Boost.Asio's `udp::socket` when initiating network sends from the main thread.

🔬 **Measurement**
No testing/benchmark directly applies, verified by code review and thread safety reasoning. TSan will no longer trigger data races on socket states.

---
*PR created automatically by Jules for task [9046573694077287989](https://jules.google.com/task/9046573694077287989) started by @gkehren*