### PR TITLE
⚡ Bolt: [Network Packet Pre-allocation]

### DIFF
--- a/src/Network/ByteBuffer.hpp
+++ b/src/Network/ByteBuffer.hpp
@@ -16,6 +16,11 @@ public:
 	const std::vector<uint8_t> &getBytes() const { return buffer; }
 	std::vector<uint8_t> &getBytes() { return buffer; }
 
+	void reserve(size_t capacity)
+	{
+		buffer.reserve(capacity);
+	}
+
 	// Write primitives
 	void writeUInt8(uint8_t value)
 	{

--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -39,10 +39,12 @@ void Client::disconnect()
 		message.type = MessageType::DISCONNECT;
 		message.sequenceNumber = sequenceNumber++;
 		ByteBuffer buf;
+		buf.reserve(sizeof(uint32_t));
 		buf.writeUInt32(playerId);
 		message.payload = std::move(buf.getBytes());
 		
 		ByteBuffer outBuf;
+		outBuf.reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
 		outBuf.writeUInt8(message.type);
 		outBuf.writeUInt32(message.sequenceNumber);
 		outBuf.getBytes().insert(outBuf.getBytes().end(), message.payload.begin(), message.payload.end());
@@ -86,6 +88,7 @@ void Client::sendMessage(const Message &message)
 					  {
 		auto data = std::make_shared<std::vector<uint8_t>>();
 		ByteBuffer buf;
+		buf.reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
 		buf.writeUInt8(message.type);
 		buf.writeUInt32(message.sequenceNumber);
 		buf.getBytes().insert(buf.getBytes().end(), message.payload.begin(), message.payload.end());
@@ -228,6 +231,7 @@ void Client::handleMessage(const std::vector<uint8_t> &data)
 void Client::sendAck(uint32_t playerId)
 {
 	ByteBuffer buf;
+	buf.reserve(sizeof(uint32_t));
 	buf.writeUInt32(playerId);
 
 	Message message;
@@ -251,6 +255,7 @@ uint32_t Client::getPlayerId() const
 void Client::sendPlayerPosition(float x, float y, float z)
 {
 	ByteBuffer buf;
+	buf.reserve(sizeof(uint32_t) + 3 * sizeof(float));
 	buf.writeUInt32(playerId);
 	buf.writeFloat(x);
 	buf.writeFloat(y);
@@ -274,6 +279,7 @@ void Client::sendVoxelEdit(int32_t x, int32_t y, int32_t z, uint8_t type)
 	message.sequenceNumber = sequenceNumber++;
 	
 	ByteBuffer buf;
+	buf.reserve(sizeof(uint32_t) * 4 + sizeof(uint8_t));
 	buf.writeUInt32(playerId);
 	buf.writeUInt32(static_cast<uint32_t>(x));
 	buf.writeUInt32(static_cast<uint32_t>(y));

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -90,6 +90,7 @@ void Server::handleMessage(const boost::asio::ip::udp::endpoint &senderEndpoint,
 	{
 		// Send the world seed to the client
 		ByteBuffer seedBuf;
+		seedBuf.reserve(sizeof(uint32_t));
 		seedBuf.writeUInt32(worldSeed);
 
 		Message seedMessage;
@@ -101,6 +102,7 @@ void Server::handleMessage(const boost::asio::ip::udp::endpoint &senderEndpoint,
 
 		uint32_t playerId = nextPlayerId++;
 		ByteBuffer authBuf;
+		authBuf.reserve(sizeof(uint32_t));
 		authBuf.writeUInt32(playerId);
 
 		Message authMessage;
@@ -220,6 +222,7 @@ void Server::sendMessage(const boost::asio::ip::udp::endpoint &endpoint, const M
 {
 	auto data = std::make_shared<std::vector<uint8_t>>();
 	ByteBuffer buf;
+	buf.reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
 	buf.writeUInt8(message.type);
 	buf.writeUInt32(message.sequenceNumber);
 	buf.getBytes().insert(buf.getBytes().end(), message.payload.begin(), message.payload.end());
@@ -256,6 +259,7 @@ void Server::broadcastWorldState()
 		return;
 
 	ByteBuffer buf;
+	buf.reserve(sizeof(uint32_t) + playerPositions.size() * (sizeof(uint32_t) + 3 * sizeof(float)));
 	// Write the number of players in this snapshot
 	buf.writeUInt32(static_cast<uint32_t>(playerPositions.size()));
 


### PR DESCRIPTION
💡 **What**: Added a `reserve()` method to the `ByteBuffer` class and updated network serialization methods (`Client::sendMessage`, `Server::broadcastWorldState`, `Client::sendVoxelEdit`, etc.) to predict their packet sizes and explicitly call `reserve` prior to sequentially pushing bytes.

🎯 **Why**: When serializing packets, elements are sequentially appended. Because `std::vector` (the underlying buffer) dynamically resizes itself by copying contents to a newly allocated memory block when capacity is exhausted, this frequent resizing inside a hot network/packet loop causes significant performance overhead due to repeated `malloc`/`free` operations and data copying. Pre-allocating the vector eliminates all intermediary reallocations.

📊 **Impact**: Prevents costly buffer reallocations per packet built. When broadcasting `WORLD_STATE` to large numbers of players, it transforms an operation that would otherwise incur $O(\log_2 N)$ reallocations per tick into exactly $1$ allocation. Reduces latency in network thread execution time.

🔬 **Measurement**: Inspect the execution speeds of `Server::broadcastWorldState` when dealing with $N > 100$ connected players before and after the change; measure CPU cache hits within `malloc` calls using standard profiling tools like `valgrind` or `perf`.


---
*PR created automatically by Jules for task [4723719924678673836](https://jules.google.com/task/4723719924678673836) started by @gkehren*