### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate network buffers during serialization

### DIFF
--- a/src/Network/ByteBuffer.hpp
+++ b/src/Network/ByteBuffer.hpp
@@ -15,6 +15,7 @@ public:
 
 	const std::vector<uint8_t> &getBytes() const { return buffer; }
 	std::vector<uint8_t> &getBytes() { return buffer; }
+	void reserve(size_t size) { buffer.reserve(size); }
 
 	// Write primitives
 	void writeUInt8(uint8_t value)

--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -86,6 +86,7 @@ void Client::sendMessage(const Message &message)
 					  {
 		auto data = std::make_shared<std::vector<uint8_t>>();
 		ByteBuffer buf;
+		buf.reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
 		buf.writeUInt8(message.type);
 		buf.writeUInt32(message.sequenceNumber);
 		buf.getBytes().insert(buf.getBytes().end(), message.payload.begin(), message.payload.end());

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -220,6 +220,7 @@ void Server::sendMessage(const boost::asio::ip::udp::endpoint &endpoint, const M
 {
 	auto data = std::make_shared<std::vector<uint8_t>>();
 	ByteBuffer buf;
+	buf.reserve(sizeof(uint8_t) + sizeof(uint32_t) + message.payload.size());
 	buf.writeUInt8(message.type);
 	buf.writeUInt32(message.sequenceNumber);
 	buf.getBytes().insert(buf.getBytes().end(), message.payload.begin(), message.payload.end());
@@ -256,6 +257,7 @@ void Server::broadcastWorldState()
 		return;
 
 	ByteBuffer buf;
+	buf.reserve(sizeof(uint32_t) + playerPositions.size() * (sizeof(uint32_t) + 3 * sizeof(float)));
 	// Write the number of players in this snapshot
 	buf.writeUInt32(static_cast<uint32_t>(playerPositions.size()));
 


### PR DESCRIPTION
💡 **What**: I implemented memory pre-allocation in the `ByteBuffer` class by adding a `reserve` method, and utilized it in hot networking paths like `Server::sendMessage`, `Client::sendMessage`, and `Server::broadcastWorldState` to allocate the precise required vector capacity beforehand.
🎯 **Why**: When dynamically writing arbitrary packets using multiple `push_back` or `insert` calls into a `std::vector`, it routinely exceeds its capacity and automatically reallocates. Pre-calculating the exact required space eliminates multiple intermediate, costly memory reallocations, speeding up the serialization.
📊 **Impact**: This should provide a small but measurable reduction in memory allocations and copies over time for every network payload sent, enhancing the engine's serialization performance, especially as network volume scales.
🔬 **Measurement**: You can observe the reduced frequency of dynamic allocations by using a heap profiler (like Valgrind/Massif) over a long play session, or use standard benchmarking libraries against the messaging payload creation functions. Tests via `./tests/test_network` successfully pass verifying this is completely safe.

---
*PR created automatically by Jules for task [3604601021371066360](https://jules.google.com/task/3604601021371066360) started by @gkehren*