### PR TITLE
⚡ Bolt: [performance improvement] Optimize chunk transit state lookup by replacing unordered_set with inline atomic flag

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2026-06-30 - Shader Uniform Lookup Optimization
 **Learning:** Mapping a string literal or `std::string_view` to a cache (like `std::unordered_map<std::string, GLint>`) forces an implicit `std::string` allocation per lookup, which is disastrous in hot loops like rendering.
 **Action:** Use a transparent hash functor (`is_transparent = void`) and `std::equal_to<>` with `std::unordered_map` (C++20 heterogeneous lookup) to allow lookups by `std::string_view` directly, completely avoiding allocations on cache hits. Only construct a `std::string` upon cache miss to pass to the C API.
+## 2024-05-19 - [Avoid unordered_set for Object State Tracking]
+**Learning:** Maintaining an external `std::unordered_set<Chunk*>` to track which chunks are currently in transit introduces unnecessary $O(1)$ node-based hashing overhead and cache misses, especially when checked repeatedly inside hot game loops (like frustum culling or chunk meshing).
+**Action:** When tracking simple binary state for an object (like "is in transit" or "is processing"), embed an `std::atomic<bool>` flag directly into the object class itself rather than tracking it externally in a hash map. This converts a hash map lookup into a simple inline boolean check, significantly improving cache locality.

--- a/src/Chunk/Chunk.cpp
+++ b/src/Chunk/Chunk.cpp
@@ -1038,6 +1038,7 @@ void Chunk::reset(const glm::vec3 &newPosition)
   state.store(ChunkState::UNLOADED);
   meshNeedsUpdate.store(true);
   m_isLODMesh = false;
+  m_inTransit.store(false);
 
   // Clear buffers but retain capacity for reuse (avoid reallocation)
   vertices.clear();

--- a/src/Chunk/Chunk.hpp
+++ b/src/Chunk/Chunk.hpp
@@ -56,6 +56,8 @@ public:
 	bool hasWaterMesh() const { return waterIndexCount > 0; }
 	bool isLODMesh() const { return m_isLODMesh; }
 	bool needsGPUUpload() const { return meshNeedsUpdate.load(); }
+	bool isInTransit() const { return m_inTransit.load(); }
+	void setInTransit(bool val) { m_inTransit.store(val); }
 	void uploadToGPU();
 	bool isShellEmpty() const { return neighborShellVoxels.empty(); }
 	void freeShellVoxels();
@@ -98,6 +100,11 @@ private:
 
 	std::atomic<bool> meshNeedsUpdate;
 	bool m_isLODMesh{false}; // K: true when this chunk carries the simplified LOD mesh
+
+	// Bolt: Moving the transit state directly to the Chunk via an atomic flag eliminates
+	// the need for an external std::unordered_set<Chunk*> in ChunkManager. This prevents
+	// costly node-based hash map lookups and cache misses in hot loops when iterating over activeChunks.
+	std::atomic<bool> m_inTransit{false};
 
 	size_t getIndex(uint32_t x, uint32_t y, uint32_t z) const;
 };

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -176,7 +176,7 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 
 	for (Chunk *chunk : activeChunks)
 	{
-		if (chunk->isVisible() && chunk->getState() == ChunkState::UNLOADED && chunksInTransit.find(chunk) == chunksInTransit.end())
+		if (chunk->isVisible() && chunk->getState() == ChunkState::UNLOADED && !chunk->isInTransit())
 		{
 			glm::vec3 chunkCenter = chunk->getPosition() + glm::vec3(CHUNK_SIZE / 2.0f);
 			float dx = chunkCenter.x - camPos.x;
@@ -205,7 +205,7 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 		float distanceSq = genQueueVec[i].distance;
 		TaskPriority priority = calculateTaskPriority(distanceSq, lodThresholdSq);
 
-		chunksInTransit.insert(chunk);
+		chunk->setInTransit(true);
 		auto future = p_threadPool->enqueue(priority, [chunk, currentSeed]()
 											{
 												TerrainGenerator& localGenerator = TerrainGenerator::getThreadLocal(currentSeed);
@@ -235,7 +235,7 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 
 	for (Chunk *chunk : activeChunks)
 	{
-		if (chunk->isVisible() && chunk->getState() == ChunkState::GENERATED && chunksInTransit.find(chunk) == chunksInTransit.end())
+		if (chunk->isVisible() && chunk->getState() == ChunkState::GENERATED && !chunk->isInTransit())
 		{
 			glm::vec3 chunkCenter = chunk->getPosition() + glm::vec3(CHUNK_SIZE / 2.0f);
 			float dx = chunkCenter.x - camPos.x;
@@ -253,7 +253,7 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 	for (Chunk *chunk : activeChunks)
 	{
 		if (chunk->isLODMesh() && chunk->getState() == ChunkState::MESHED &&
-			chunksInTransit.find(chunk) == chunksInTransit.end())
+			!chunk->isInTransit())
 		{
 			glm::vec3 cc = chunk->getPosition() + glm::vec3(CHUNK_SIZE / 2.0f);
 			float dx = cc.x - camPos.x;
@@ -281,7 +281,7 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 		glm::vec3 wp = chunk->getPosition();
 		glm::ivec3 ci(static_cast<int>(std::round(wp.x)) / CHUNK_SIZE, 0,
 					  static_cast<int>(std::round(wp.z)) / CHUNK_SIZE);
-		chunksInTransit.insert(chunk);
+		chunk->setInTransit(true);
 		TaskPriority priority = calculateTaskPriority(chunkDistSq, lodThresholdSq);
 		if (chunkDistSq > lodThresholdSq)
 		{
@@ -446,7 +446,7 @@ void ChunkManager::uploadPendingMeshes(int budget)
 	{
 		if (uploaded >= budget)
 			break;
-		if (chunk->getState() == ChunkState::MESHED && chunk->needsGPUUpload() && chunksInTransit.find(chunk) == chunksInTransit.end())
+		if (chunk->getState() == ChunkState::MESHED && chunk->needsGPUUpload() && !chunk->isInTransit())
 		{
 			chunk->uploadToGPU();
 			++uploaded;
@@ -677,7 +677,7 @@ void ChunkManager::unloadOutOfRangeChunks(const Camera &camera, const RenderSett
 			if (distToPlayerSq > unloadDistSq)
 			{
 				// Do not unload chunks that are currently being processed
-				if (chunksInTransit.find(chunkPtr) == chunksInTransit.end())
+				if (!chunkPtr->isInTransit())
 				{
 					chunksToUnload.push_back(pos);
 				}
@@ -696,7 +696,7 @@ void ChunkManager::unloadOutOfRangeChunks(const Camera &camera, const RenderSett
 			{
 				Chunk* chunkPtr = it->second;
 				// Re-check in_transit just in case state changed
-				if (chunksInTransit.find(chunkPtr) == chunksInTransit.end())
+				if (!chunkPtr->isInTransit())
 				{
 					auto activeIt = std::find(activeChunks.begin(), activeChunks.end(), chunkPtr);
 					if (activeIt != activeChunks.end())
@@ -787,7 +787,7 @@ void ChunkManager::processFinishedJobs()
 		if (pendingGenerationTasks[i].first.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
 		{
 			pendingGenerationTasks[i].first.get(); // Propagate exceptions if any
-			chunksInTransit.erase(pendingGenerationTasks[i].second);
+			pendingGenerationTasks[i].second->setInTransit(false);
 			pendingGenerationTasks[i] = std::move(pendingGenerationTasks.back());
 			pendingGenerationTasks.pop_back();
 		}
@@ -804,7 +804,7 @@ void ChunkManager::processFinishedJobs()
 		{
 			pendingMeshingTasks[i].first.get();
 			Chunk *finishedChunk = pendingMeshingTasks[i].second;
-			chunksInTransit.erase(finishedChunk);
+			finishedChunk->setInTransit(false);
 			// H: A newly meshed chunk may have water geometry — invalidate the sorted
 			// cache so it appears in the next water transparency pass without waiting
 			// for the camera to move.

--- a/src/Chunk/ChunkManager.hpp
+++ b/src/Chunk/ChunkManager.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <unordered_map>
-#include <unordered_set>
 #include <queue>
 #include <mutex>
 #include <shared_mutex>
@@ -65,7 +64,6 @@ private:
 
 	std::vector<std::pair<std::future<void>, Chunk *>> pendingGenerationTasks;
 	std::vector<std::pair<std::future<void>, Chunk *>> pendingMeshingTasks;
-	std::unordered_set<Chunk *> chunksInTransit;
 
 	mutable std::shared_mutex chunkMutex;
 


### PR DESCRIPTION
💡 **What:** Replaced the external `std::unordered_set<Chunk*> chunksInTransit` in `ChunkManager` with a `std::atomic<bool> m_inTransit` flag directly on the `Chunk` class.

🎯 **Why:** Previously, the `ChunkManager` used a `std::unordered_set` to track which chunks were currently being generated or meshed on background threads. In hot loop functions (like `generatePendingVoxels` and `meshPendingChunks`), the engine iterates over `activeChunks` and checks if each chunk is in transit using `chunksInTransit.find(chunk)`. Because `std::unordered_set` is a node-based container, this introduced significant hashing overhead and pointer-chasing cache misses per frame per chunk. By embedding the state flag directly into the `Chunk` object, the lookup becomes a fast, cache-friendly inline atomic boolean check.

📊 **Impact:** Substantially reduces CPU overhead and eliminates cache misses during chunk processing and culling loops by transforming $O(1)$ hash map lookups into a direct flag access. Frame times will be more stable when the player moves quickly and triggers many chunk loads/unloads.

🔬 **Measurement:** Compile the project in `Release` mode and profile the engine while flying quickly across the terrain to generate a large number of chunks. The time spent in `ChunkManager::generatePendingVoxels` and `ChunkManager::meshPendingChunks` should show a measurable decrease in execution time compared to the unoptimized `std::unordered_set` version. Headless networking tests continue to pass correctly.

---
*PR created automatically by Jules for task [6583232403841882159](https://jules.google.com/task/6583232403841882159) started by @gkehren*