### PR TITLE
⚡ Bolt: [performance improvement] Optimize active player tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 ## 2024-05-19 - [Avoid unordered_set for Object State Tracking]
 **Learning:** Maintaining an external `std::unordered_set<Chunk*>` to track which chunks are currently in transit introduces unnecessary $O(1)$ node-based hashing overhead and cache misses, especially when checked repeatedly inside hot game loops (like frustum culling or chunk meshing).
 **Action:** When tracking simple binary state for an object (like "is in transit" or "is processing"), embed an `std::atomic<bool>` flag directly into the object class itself rather than tracking it externally in a hash map. This converts a hash map lookup into a simple inline boolean check, significantly improving cache locality.
+## 2024-05-24 - Network Packet Hot Loop Optimization
+**Learning:** Using `std::unordered_set` dynamically inside frequent network packet handlers (like `Client::handleMessage`) causes node-based heap allocations for every packet processed, leading to unnecessary garbage and potential stutters.
+**Action:** For bounded and small collections derived from network packets, use `std::vector` with `reserve()`, sort the vector, and use `std::binary_search()`. This leverages contiguous memory and avoids node allocations entirely.

--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -1,6 +1,7 @@
 #include "Client.hpp"
 #include "../Engine/Logger.hpp"
-#include <unordered_set>
+#include <vector>
+#include <algorithm>
 
 Client::Client()
 	: socket(ioContext), connected(false), worldSeed(0), sequenceNumber(0), playerId(0)
@@ -175,7 +176,11 @@ void Client::handleMessage(const std::vector<uint8_t> &data)
 		if (!buf.hasMore(numPlayers * (sizeof(uint32_t) + 3 * sizeof(float))))
 			return;
 
-		std::unordered_set<uint32_t> currentPlayers;
+		// ⚡ Bolt: Replace std::unordered_set with std::vector + std::sort + std::binary_search
+		// to avoid node allocations and improve cache locality on every network tick.
+		std::vector<uint32_t> currentPlayers;
+		currentPlayers.reserve(numPlayers);
+
 		std::lock_guard<std::mutex> lock(playerMutex);
 		for (uint32_t i = 0; i < numPlayers; ++i)
 		{
@@ -185,12 +190,14 @@ void Client::handleMessage(const std::vector<uint8_t> &data)
 			position.y = buf.readFloat();
 			position.z = buf.readFloat();
 			playerPositions[position.playerId] = position;
-			currentPlayers.insert(position.playerId);
+			currentPlayers.push_back(position.playerId);
 		}
+
+		std::sort(currentPlayers.begin(), currentPlayers.end());
 
 		for (auto it = playerPositions.begin(); it != playerPositions.end(); )
 		{
-			if (currentPlayers.find(it->first) == currentPlayers.end() && it->first != playerId)
+			if (!std::binary_search(currentPlayers.begin(), currentPlayers.end(), it->first) && it->first != playerId)
 			{
 				Logger::getInstance().logClient("Player " + std::to_string(it->first) + " disconnected.");
 				it = playerPositions.erase(it);


### PR DESCRIPTION
💡 **What:** Replaced `std::unordered_set` with a pre-allocated `std::vector` + `std::sort` + `std::binary_search` in the `Client::handleMessage` hot path.
🎯 **Why:** The previous implementation constructed an `unordered_set` for every incoming `WORLD_STATE` packet to track current players. This caused an O(1) heap allocation for *each player* on *each packet*, leading to unnecessary CPU overhead and memory fragmentation.
📊 **Impact:** Completely eliminates dynamic node allocations for active player tracking in the network processing loop. Memory layout is now contiguous, resulting in much better cache locality. O(log N) binary search on a small vector is extremely fast and avoids hashing overhead.
🔬 **Measurement:** Code compiles properly and passes the automated headless network tests (`./build/tests/test_network`), verifying that player disconnection tracking behaves correctly as before but with a lighter memory footprint.

---
*PR created automatically by Jules for task [11677466072131679047](https://jules.google.com/task/11677466072131679047) started by @gkehren*