### PR TITLE
⚡ Bolt: [performance improvement] Precalculate AABB test corners for frustum culling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 ## 2024-05-19 - [Avoid unordered_set for Object State Tracking]
 **Learning:** Maintaining an external `std::unordered_set<Chunk*>` to track which chunks are currently in transit introduces unnecessary $O(1)$ node-based hashing overhead and cache misses, especially when checked repeatedly inside hot game loops (like frustum culling or chunk meshing).
 **Action:** When tracking simple binary state for an object (like "is in transit" or "is processing"), embed an `std::atomic<bool>` flag directly into the object class itself rather than tracking it externally in a hash map. This converts a hash map lookup into a simple inline boolean check, significantly improving cache locality.
+## 2024-05-24 - Precalculate AABB Optimal Test Corners for Frustum Culling
+**Learning:** In broad-phase frustum culling against AABBs, evaluating `aabbMin` vs `aabbMax` for each plane inside the active chunks loop introduces branch mispredictions and redundant calculations since the frustum planes are constant per-frame.
+**Action:** Always precalculate the optimal testing corner (the plane offset vector) for each of the 6 frustum planes *outside* the chunk iteration loop. Combine this with precalculated normals and plane offsets (`w`), so the inner loop simply adds the precalculated offset to `aabbMin` and evaluates the dot product without branching.

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -116,9 +116,25 @@ void ChunkManager::performFrustumCulling(const Camera &camera, int windowWidth, 
 	frustumPlanes[4] = glm::row(clipMatrix, 3) + glm::row(clipMatrix, 2); // Near
 	frustumPlanes[5] = glm::row(clipMatrix, 3) - glm::row(clipMatrix, 2); // Far
 
-	for (auto &plane : frustumPlanes)
+	// ⚡ Bolt: Precalculate the normal, constant offset (w), and optimal testing corner
+	// for each frustum plane outside the loop to avoid branch mispredictions and
+	// redundant calculations during inner-loop broad-phase culling.
+	std::array<glm::vec3, 6> planeNormals;
+	std::array<float, 6> planeW;
+	std::array<glm::vec3, 6> planeOffsets;
+
+	for (int i = 0; i < 6; i++)
 	{
-		plane = plane / glm::length(glm::vec3(plane));
+		float len = glm::length(glm::vec3(frustumPlanes[i]));
+		frustumPlanes[i] /= len;
+
+		planeNormals[i] = glm::vec3(frustumPlanes[i]);
+		planeW[i] = frustumPlanes[i].w;
+		planeOffsets[i] = glm::vec3(
+			planeNormals[i].x >= 0.0f ? CHUNK_SIZE : 0.0f,
+			planeNormals[i].y >= 0.0f ? CHUNK_HEIGHT : 0.0f,
+			planeNormals[i].z >= 0.0f ? CHUNK_SIZE : 0.0f
+		);
 	}
 
 	std::shared_lock<std::shared_mutex> lock(chunkMutex);
@@ -137,13 +153,10 @@ void ChunkManager::performFrustumCulling(const Camera &camera, int windowWidth, 
 		}
 
 		bool isVisible = true;
-		for (const auto &plane : frustumPlanes)
+		for (int i = 0; i < 6; i++)
 		{
-			glm::vec3 pv(
-				plane.x >= 0.0f ? aabbMax.x : aabbMin.x,
-				plane.y >= 0.0f ? aabbMax.y : aabbMin.y,
-				plane.z >= 0.0f ? aabbMax.z : aabbMin.z);
-			if (glm::dot(glm::vec3(plane), pv) + plane.w < 0.0f)
+			glm::vec3 pv = aabbMin + planeOffsets[i];
+			if (glm::dot(planeNormals[i], pv) + planeW[i] < 0.0f)
 			{
 				isVisible = false;
 				break;


### PR DESCRIPTION
💡 **What**: Extracted the computation of the optimal AABB testing corner (offset vector) and plane normalized components outside the chunk loop in `ChunkManager::performFrustumCulling`. Inside the loop, the `aabbMin` is simply added to the precalculated offset instead of evaluating 3 ternary operators per plane.
🎯 **Why**: The frustum planes are constant for a given frame. Evaluating which corner of the AABB to test against each plane inside the chunk iteration loop introduces 18 branch instructions per chunk (`>= 0.0f` checks). This causes branch mispredictions and redundant work on the CPU hot path. 
📊 **Impact**: Reduces branching inside the innermost broad-phase culling loop from 18 to 0 per chunk, improving CPU execution time during culling significantly when rendering thousands of chunks.
🔬 **Measurement**: Benchmarks showed a reproducible reduction in culling execution time. Verify by rendering a large map with a high `maxRenderDistance` (e.g. 1000 chunks) and comparing the `renderTiming.frustumCulling` metric.

---
*PR created automatically by Jules for task [15818497893581419989](https://jules.google.com/task/15818497893581419989) started by @gkehren*