### PR TITLE
⚡ Bolt: [performance improvement] Replace std::map with std::array for character lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,6 @@
 ## 2024-05-19 - [Avoid unordered_set for Object State Tracking]
 **Learning:** Maintaining an external `std::unordered_set<Chunk*>` to track which chunks are currently in transit introduces unnecessary $O(1)$ node-based hashing overhead and cache misses, especially when checked repeatedly inside hot game loops (like frustum culling or chunk meshing).
 **Action:** When tracking simple binary state for an object (like "is in transit" or "is processing"), embed an `std::atomic<bool>` flag directly into the object class itself rather than tracking it externally in a hash map. This converts a hash map lookup into a simple inline boolean check, significantly improving cache locality.
+## 2024-07-06 - Always Verify Full Method Text Before Edits
+**Learning:** Output from tools like `cat` might get truncated if a file is long. Assuming method implementation details based on incomplete output leads to bad plans.
+**Action:** Use `read_file` or `grep -A 50` on specific methods to ensure the full implementation is viewed before proposing exact edits.

--- a/src/Renderer/TextRenderer.cpp
+++ b/src/Renderer/TextRenderer.cpp
@@ -35,9 +35,10 @@ TextRenderer::TextRenderer(const std::string &fontPath, const glm::mat4 &proj)
 
 TextRenderer::~TextRenderer()
 {
-	for (const auto &entry : characters)
+	for (const auto &character : characters)
 	{
-		glDeleteTextures(1, &entry.second.textureID);
+		if (character.textureID != 0)
+			glDeleteTextures(1, &character.textureID);
 	}
 	glDeleteVertexArrays(1, &VAO);
 	glDeleteBuffers(1, &VBO);
@@ -81,7 +82,7 @@ void TextRenderer::loadCharacters()
 			glm::ivec2(face->glyph->bitmap_left, face->glyph->bitmap_top),
 			static_cast<unsigned int>(face->glyph->advance.x)};
 
-		characters.insert(std::pair<char, Character>(c, character));
+		characters[c] = character;
 	}
 
 	glBindTexture(GL_TEXTURE_2D, 0);
@@ -98,7 +99,10 @@ void TextRenderer::renderText(std::string_view text, float x, float y, float sca
 
 	for (char c : text)
 	{
-		Character ch = characters[c];
+		if (static_cast<unsigned char>(c) >= 128)
+			continue;
+
+		Character ch = characters[static_cast<unsigned char>(c)];
 
 		float xpos = x + ch.bearing.x * scale;
 		float ypos = y - (ch.size.y - ch.bearing.y) * scale;

--- a/src/Renderer/TextRenderer.hpp
+++ b/src/Renderer/TextRenderer.hpp
@@ -5,7 +5,7 @@
 #include <glad/glad.h>
 #include <string>
 #include <string_view>
-#include <map>
+#include <array>
 #include <memory>
 #include <glm/glm.hpp>
 #include <Shader/Shader.hpp>
@@ -13,10 +13,10 @@
 
 struct Character
 {
-	unsigned int textureID;
-	glm::ivec2 size;
-	glm::ivec2 bearing;
-	unsigned int advance;
+	unsigned int textureID{0};
+	glm::ivec2 size{0, 0};
+	glm::ivec2 bearing{0, 0};
+	unsigned int advance{0};
 };
 
 class TextRenderer
@@ -35,7 +35,8 @@ private:
 	GLuint VAO;
 	GLuint VBO;
 	glm::mat4 projection;
-	std::map<char, Character> characters;
+	// ⚡ Bolt: Replaced std::map with std::array for O(1) contiguous memory access in hot paths.
+	std::array<Character, 128> characters;
 
 	void loadCharacters();
 };


### PR DESCRIPTION
💡 What: Replaced `std::map<char, Character>` with `std::array<Character, 128>` in `TextRenderer`.
🎯 Why: Text rendering is a hot path where character lookups happen per frame, per character. A map lookup is O(log N) tree traversal which causes cache misses. A flat array provides O(1) contiguous memory access with no traversal overhead.
📊 Impact: Speeds up text rendering loop significantly by avoiding map lookups and preserving cache locality.
🔬 Measurement: Use profiler on `TextRenderer::renderText` to observe reduced lookup time compared to previous hash/tree traversal.

---
*PR created automatically by Jules for task [11685806775386903598](https://jules.google.com/task/11685806775386903598) started by @gkehren*