### PR TITLE
⚡ Bolt: Remove unused keyStates map in InputSystem

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 ## 2024-05-24 - Network Packet Hot Loop Optimization
 **Learning:** Using `std::unordered_set` dynamically inside frequent network packet handlers (like `Client::handleMessage`) causes node-based heap allocations for every packet processed, leading to unnecessary garbage and potential stutters.
 **Action:** For bounded and small collections derived from network packets, use `std::vector` with `reserve()`, sort the vector, and use `std::binary_search()`. This leverages contiguous memory and avoids node allocations entirely.
+## 2026-06-30 - SDL Keyboard Polling Optimization
+**Learning:** Manually tracking keyboard states using `std::unordered_map<SDL_Keycode, bool>` via `SDL_EVENT_KEY_DOWN`/`UP` events introduces unnecessary node allocations, hashing, and cache misses during the hot event loop.
+**Action:** When continuous keyboard state polling is needed (e.g., for player movement), use the native SDL API `SDL_GetKeyboardState(NULL)` which returns a flat contiguous array, granting $O(1)$ instantaneous access with zero allocation overhead.

--- a/src/Engine/InputSystem.cpp
+++ b/src/Engine/InputSystem.cpp
@@ -16,13 +16,11 @@ void InputSystem::update() {
             EventBus::getInstance().publish(QuitEvent());
         }
         else if (event.type == SDL_EVENT_KEY_DOWN && !ImGui::GetIO().WantCaptureKeyboard) {
-            keyStates[event.key.key] = true;
             if (event.key.repeat == 0) {
                 EventBus::getInstance().publish(KeyEvent(EventType::KeyPress, event.key.key));
             }
         }
         else if (event.type == SDL_EVENT_KEY_UP && !ImGui::GetIO().WantCaptureKeyboard) {
-            keyStates[event.key.key] = false;
             EventBus::getInstance().publish(KeyEvent(EventType::KeyRelease, event.key.key));
         }
         else if (event.type == SDL_EVENT_WINDOW_RESIZED) {
@@ -41,11 +39,6 @@ void InputSystem::update() {
             EventBus::getInstance().publish(MouseWheelEvent(event.wheel.x, event.wheel.y));
         }
     }
-}
-
-bool InputSystem::isKeyPressed(SDL_Keycode key) const {
-    auto it = keyStates.find(key);
-    return it != keyStates.end() ? it->second : false;
 }
 
 void InputSystem::setMouseCaptured(bool captured, SDL_Window* window) {

--- a/src/Engine/InputSystem.hpp
+++ b/src/Engine/InputSystem.hpp
@@ -1,7 +1,6 @@
 // src/Engine/InputSystem.hpp
 #pragma once
 #include <SDL3/SDL.h>
-#include <unordered_map>
 #include "EventBus.hpp"
 
 class InputSystem {
@@ -10,11 +9,9 @@ public:
     ~InputSystem();
 
     void update();
-    bool isKeyPressed(SDL_Keycode key) const;
     bool isMouseCaptured() const { return mouseCaptured; }
     void setMouseCaptured(bool captured, SDL_Window* window);
 
 private:
     bool mouseCaptured;
-    std::unordered_map<SDL_Keycode, bool> keyStates;
 };


### PR DESCRIPTION
💡 What: Removed the unused `std::unordered_map<SDL_Keycode, bool> keyStates` and `isKeyPressed` method from `InputSystem`.
🎯 Why: `keyStates` was being inserted/deleted on every key press and release event during the hot event loop, incurring dynamic memory allocation and hash mapping overhead. However, the `isKeyPressed` function was never used anywhere in the codebase (the app correctly relies on `SDL_GetKeyboardState` for continuous polling or `EventBus` for events).
📊 Impact: Completely eliminates hashing and heap allocations for keyboard state tracking during the event loop.
🔬 Measurement: Run the app and ensure all key binds and character movement correctly works without regressions since no features actually depend on it.

---
*PR created automatically by Jules for task [2358950187129876721](https://jules.google.com/task/2358950187129876721) started by @gkehren*