### PR TITLE
⚡ Bolt: [performance improvement] Replace hash map with native array for keyboard input polling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 ## 2024-05-24 - Network Packet Hot Loop Optimization
 **Learning:** Using `std::unordered_set` dynamically inside frequent network packet handlers (like `Client::handleMessage`) causes node-based heap allocations for every packet processed, leading to unnecessary garbage and potential stutters.
 **Action:** For bounded and small collections derived from network packets, use `std::vector` with `reserve()`, sort the vector, and use `std::binary_search()`. This leverages contiguous memory and avoids node allocations entirely.
+## 2024-05-24 - Input Polling Optimization and ImGui Capture
+**Learning:** Replaced `std::unordered_map` for key states with `SDL_GetKeyboardState` for `O(1)` contiguous array lookup without allocations. However, doing this bypassed the event loop's check for `ImGui::GetIO().WantCaptureKeyboard`, causing a functional regression where typing in UI triggered game inputs.
+**Action:** When migrating from event-based state tracking to direct polling, explicitly re-implement UI capture guards like `if (ImGui::GetCurrentContext() && ImGui::GetIO().WantCaptureKeyboard) return false;` to prevent input bleed.

--- a/src/Engine/InputSystem.cpp
+++ b/src/Engine/InputSystem.cpp
@@ -16,13 +16,11 @@ void InputSystem::update() {
             EventBus::getInstance().publish(QuitEvent());
         }
         else if (event.type == SDL_EVENT_KEY_DOWN && !ImGui::GetIO().WantCaptureKeyboard) {
-            keyStates[event.key.key] = true;
             if (event.key.repeat == 0) {
                 EventBus::getInstance().publish(KeyEvent(EventType::KeyPress, event.key.key));
             }
         }
         else if (event.type == SDL_EVENT_KEY_UP && !ImGui::GetIO().WantCaptureKeyboard) {
-            keyStates[event.key.key] = false;
             EventBus::getInstance().publish(KeyEvent(EventType::KeyRelease, event.key.key));
         }
         else if (event.type == SDL_EVENT_WINDOW_RESIZED) {
@@ -44,8 +42,16 @@ void InputSystem::update() {
 }
 
 bool InputSystem::isKeyPressed(SDL_Keycode key) const {
-    auto it = keyStates.find(key);
-    return it != keyStates.end() ? it->second : false;
+    int numkeys;
+    const bool* keys = SDL_GetKeyboardState(&numkeys);
+    SDL_Scancode scancode = SDL_GetScancodeFromKey(key, nullptr);
+    if (ImGui::GetCurrentContext() && ImGui::GetIO().WantCaptureKeyboard) {
+        return false;
+    }
+    if (scancode >= 0 && scancode < numkeys) {
+        return keys[scancode];
+    }
+    return false;
 }
 
 void InputSystem::setMouseCaptured(bool captured, SDL_Window* window) {

--- a/src/Engine/InputSystem.hpp
+++ b/src/Engine/InputSystem.hpp
@@ -1,7 +1,6 @@
 // src/Engine/InputSystem.hpp
 #pragma once
 #include <SDL3/SDL.h>
-#include <unordered_map>
 #include "EventBus.hpp"
 
 class InputSystem {
@@ -16,5 +15,4 @@ public:
 
 private:
     bool mouseCaptured;
-    std::unordered_map<SDL_Keycode, bool> keyStates;
 };


### PR DESCRIPTION
💡 What:
Replaced `std::unordered_map<SDL_Keycode, bool> keyStates` with direct calls to `SDL_GetKeyboardState(NULL)` and `SDL_GetScancodeFromKey(key, NULL)` in `InputSystem`. Also added a short-circuit check for `ImGui::GetIO().WantCaptureKeyboard`.

🎯 Why:
The original approach updated a hash map on every key event and required `O(1)` hash lookups (involving pointer chasing and memory overhead) when checking key states. It also suffered from a subtle bug where keys could get "stuck" if ImGui captured the input while a key was held down. By using SDL's native keyboard state array, we achieve instantaneous `O(1)` contiguous memory access with zero allocations, while cleanly fixing the stuck key bug.

📊 Impact:
Eliminates all hash map operations (`find`, `operator[]`) during keyboard event processing and querying in the hot loop, replacing them with a few pointer/array arithmetic operations. Reduces memory overhead and avoids potential GC/allocation hiccups in the input system.

🔬 Measurement:
Profile `InputSystem::isKeyPressed` and `InputSystem::update`. You should see zero time spent in `std::unordered_map` functions. Functionality can be verified by holding a movement key and opening an ImGui overlay (the player should stop moving).

---
*PR created automatically by Jules for task [5435848501120010133](https://jules.google.com/task/5435848501120010133) started by @gkehren*