### PR TITLE
⚡ Bolt: [performance improvement] - Frustum Culling Loop Optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,6 @@
 ## 2024-05-24 - Network Packet Hot Loop Optimization
 **Learning:** Using `std::unordered_set` dynamically inside frequent network packet handlers (like `Client::handleMessage`) causes node-based heap allocations for every packet processed, leading to unnecessary garbage and potential stutters.
 **Action:** For bounded and small collections derived from network packets, use `std::vector` with `reserve()`, sort the vector, and use `std::binary_search()`. This leverages contiguous memory and avoids node allocations entirely.
+## 2024-05-24 - Precalculate AABB Optimal Test Corners for Frustum Culling
+**Learning:** In broad-phase frustum culling against AABBs, evaluating `aabbMin` vs `aabbMax` for each plane inside the active chunks loop introduces branch mispredictions and redundant calculations since the frustum planes are constant per-frame.
+**Action:** Always precalculate the optimal testing corner (the plane offset vector) for each of the 6 frustum planes *outside* the chunk iteration loop. Combine this with precalculated normals and plane offsets (`w`), so the inner loop simply adds the precalculated offset to `aabbMin` and evaluates the dot product without branching.

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -167,20 +167,28 @@ void ChunkManager::updateVisibility(const Camera &camera, int windowWidth, int w
 			p /= len;
 	}
 
+	// Precalculate the plane test offset combined with the w component.
+	// This eliminates 3 ternary branches and a vector addition per plane inside the active chunks loop.
+	std::array<float, 6> planeTestOffsets;
+	for (size_t i = 0; i < 6; ++i)
+	{
+		const glm::vec3 offset(
+			planes[i].x >= 0.f ? static_cast<float>(CHUNK_SIZE) : 0.f,
+			planes[i].y >= 0.f ? static_cast<float>(CHUNK_HEIGHT) : 0.f,
+			planes[i].z >= 0.f ? static_cast<float>(CHUNK_SIZE) : 0.f
+		);
+		planeTestOffsets[i] = planes[i].w + glm::dot(glm::vec3(planes[i]), offset);
+	}
+
 	std::shared_lock<std::shared_mutex> lock(m_mutex);
 	for (Chunk *chunk : m_activeChunks)
 	{
 		const glm::vec3 aabbMin = chunk->getPosition();
-		const glm::vec3 aabbMax = aabbMin + glm::vec3(CHUNK_SIZE, CHUNK_HEIGHT, CHUNK_SIZE);
 
 		bool visible = true;
-		for (const auto &plane : planes)
+		for (size_t i = 0; i < 6; ++i)
 		{
-			const glm::vec3 pv(
-				plane.x >= 0.f ? aabbMax.x : aabbMin.x,
-				plane.y >= 0.f ? aabbMax.y : aabbMin.y,
-				plane.z >= 0.f ? aabbMax.z : aabbMin.z);
-			if (glm::dot(glm::vec3(plane), pv) + plane.w < 0.f)
+			if (glm::dot(glm::vec3(planes[i]), aabbMin) + planeTestOffsets[i] < 0.f)
 			{
 				visible = false;
 				break;


### PR DESCRIPTION
💡 **What**: Precalculates the plane offsets for AABB optimal test corners outside of the active chunks loop in `ChunkManager::updateVisibility`.
🎯 **Why**: Inside the hot visibility loop, evaluating `aabbMin` vs `aabbMax` per-plane dynamically caused redundant conditional branches and vector additions. Since frustum planes are constant per frame, this could be computed once before the loop.
📊 **Impact**: Eliminates 3 ternary branch checks and 1 vector addition per plane (6 times) per active chunk, which translates to a measurable CPU savings when checking thousands of chunks.
🔬 **Measurement**: Verify by running performance profiling around `ChunkManager::updateVisibility` or running the `test_stream_opt` test suite which passed successfully.

---
*PR created automatically by Jules for task [17585897579014756571](https://jules.google.com/task/17585897579014756571) started by @gkehren*