### PR TITLE
⚡ Bolt: [performance improvement] Optimize ChunkPool ownership lookups with std::vector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -37,3 +37,7 @@
 ## 2024-05-24 - Network Packet Hot Loop Optimization
 **Learning:** Using `std::unordered_set` dynamically inside frequent network packet handlers (like `Client::handleMessage`) causes node-based heap allocations for every packet processed, leading to unnecessary garbage and potential stutters.
 **Action:** For bounded and small collections derived from network packets, use `std::vector` with `reserve()`, sort the vector, and use `std::binary_search()`. This leverages contiguous memory and avoids node allocations entirely.
+
+## 2024-05-18 - ChunkManager Load Queue Deduplication Pitfall
+**Learning:** In `ChunkManager`, attempting to remove `m_enqueuedLoads` (`std::unordered_set`) and deduplicate the `m_loadQueue` by calling `std::unique` immediately after sorting by *distance* fails. Identical coordinates might have the exact same distance but are not guaranteed to be adjacent in a stable sort if floating-point calculations differ minutely or symmetrically.
+**Action:** Do not deduplicate `m_loadQueue` in-place using `std::unique` after a distance sort. Either maintain the `std::unordered_set`, or re-sort by coordinates before using `std::unique`, or rely on coordinate-based binary searches if removing the set.

--- a/src/Chunk/ChunkPool.cpp
+++ b/src/Chunk/ChunkPool.cpp
@@ -43,8 +43,10 @@ void ChunkPool::growUnlocked(size_t addCount)
 		m_storage.push_back(std::make_unique<Chunk>(glm::vec3(0.0f)));
 		Chunk *ptr = m_storage.back().get();
 		m_freeList.push_back(ptr);
-		m_owned.insert(ptr);
+		m_owned.push_back(ptr);
 	}
+
+	std::sort(m_owned.begin(), m_owned.end());
 
 	m_capacity.store(m_storage.size(), std::memory_order_relaxed);
 	m_growEvents.fetch_add(1, std::memory_order_relaxed);
@@ -99,7 +101,7 @@ void ChunkPool::release(Chunk *chunk)
 
 	std::lock_guard<std::mutex> lock(m_mutex);
 
-	if (m_owned.count(chunk) != 0)
+	if (std::binary_search(m_owned.begin(), m_owned.end(), chunk))
 	{
 		m_freeList.push_back(chunk);
 	}

--- a/src/Chunk/ChunkPool.hpp
+++ b/src/Chunk/ChunkPool.hpp
@@ -5,7 +5,6 @@
 #include <memory>
 #include <cstddef>
 #include <atomic>
-#include <unordered_set>
 #include <glm/glm.hpp>
 
 class Chunk;
@@ -61,7 +60,7 @@ private:
 	/// All pool-owned chunks; unique_ptr keeps addresses stable across vector growth.
 	std::vector<std::unique_ptr<Chunk>> m_storage;
 	std::vector<Chunk *> m_freeList;
-	std::unordered_set<const Chunk *> m_owned;
+	std::vector<const Chunk *> m_owned;
 	std::mutex m_mutex;
 
 	std::atomic<size_t> m_capacity{0};


### PR DESCRIPTION
💡 What: Replaced the node-allocating `std::unordered_set<const Chunk*> m_owned` in `ChunkPool` with a `std::vector` that is sorted upon growth, utilizing `std::binary_search` for O(log N) cache-friendly lookups during release.

🎯 Why: `ChunkPool`'s capacity grows extremely rarely (only when the pool runs out), but `release()` is called constantly during stream unloads or frame retirements. A flat sorted array prevents hash overhead, node jumping, and cache misses during release.

📊 Impact: Eliminates O(1) hash lookups with poor locality in favor of contiguous O(log N) searches, reducing CPU cache misses in the chunk release hot path.

🔬 Measurement: Verified compilation and headless networking/streaming tests. Performance can be measured via profiler tracing in the `processDeferredReleases` thread loop.

---
*PR created automatically by Jules for task [4568654049269766751](https://jules.google.com/task/4568654049269766751) started by @gkehren*