### PR TITLE
⚡ Bolt: [avoid per-packet allocations on the hot path]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,6 @@
 ## 2024-05-18 - [ChunkManager Hot-Path Thread-Local Queues]
 **Learning:** [The `ChunkManager` relies on dynamically creating `std::vector<Item>` queues inside hot path methods (`generatePendingVoxels`, `meshPendingChunks`, `uploadPendingMeshes`) which are called frequently in the main loop. These dynamic heap allocations can degrade performance. Reusing memory is complex due to `std::shared_mutex` usage and potential concurrency.]
 **Action:** [Use `thread_local std::vector<Item>` with a `queue.clear()` at the start of the method to safely reuse allocated capacity across frames without introducing data races or locking overhead in concurrent methods.]
+## 2026-08-07 - Avoiding Network Packet Heap Allocations
+**Learning:** In the ft_vox networking architecture, the downstream `ByteBuffer` class inherently requires copying the input vector data upon construction. While it's not possible to completely eliminate data copying in this specific pipeline, the dynamic heap allocations for the initial `std::vector<uint8_t>` created per packet in the `handleReceive` loops can be avoided by making the vectors `thread_local` and reusing their capacity via `.assign()`.
+**Action:** Always verify if a locally scoped dynamic array in a high-throughput loop can be replaced with a `thread_local` alternative to reuse its capacity across multiple iterations or function calls.

--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -121,7 +121,9 @@ void Client::handleReceive(const boost::system::error_code &error, std::size_t b
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Use thread_local vector to reuse capacity and avoid heap allocations per packet
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(data);
 	}
 }

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -69,7 +69,9 @@ void Server::handleReceive(const boost::asio::ip::udp::endpoint &senderEndpoint,
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Use thread_local vector to reuse capacity and avoid heap allocations per packet
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(senderEndpoint, data);
 	}
 }


### PR DESCRIPTION
💡 What: Replaced the local `std::vector<uint8_t> data` initialization in the `handleReceive` methods of both the Client and Server with `thread_local std::vector<uint8_t> data` and `.assign()`.

🎯 Why: In high-throughput network receive loops (like processing UDP packets), repeatedly constructing a local `std::vector` causes a dynamic heap allocation and deallocation for every single packet received. This causes unnecessary memory allocator overhead and degrades cache performance on the hot path.

📊 Impact: Eliminates 100% of the dynamic heap allocations caused by the initial data extraction step in the UDP receive handlers, significantly reducing memory allocator pressure and improving CPU cache locality on the network threads.

🔬 Measurement: Verified the network implementation functionality using the `test_network` automated binary. Performance improvements can be measured under high load (e.g. tracking heap allocations per second during multiplayer load tests).

---
*PR created automatically by Jules for task [18296002504033419659](https://jules.google.com/task/18296002504033419659) started by @gkehren*