### PR TITLE
⚡ Bolt: [performance improvement] Network receive loop allocations

### DIFF
--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -121,7 +121,9 @@ void Client::handleReceive(const boost::system::error_code &error, std::size_t b
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Use thread_local vector to avoid per-packet dynamic heap allocations in the hot receive path.
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(data);
 	}
 }

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -69,7 +69,9 @@ void Server::handleReceive(const boost::asio::ip::udp::endpoint &senderEndpoint,
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Use thread_local vector to avoid per-packet dynamic heap allocations in the hot receive path.
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(senderEndpoint, data);
 	}
 }


### PR DESCRIPTION
💡 What: Replaced local `std::vector<uint8_t>` declarations in `Server::handleReceive` and `Client::handleReceive` with `thread_local std::vector<uint8_t>` and `.assign()`.
🎯 Why: In high-frequency network environments, re-allocating a new vector for every incoming UDP packet causes constant dynamic heap allocations (`new`/`delete`). Using a `thread_local` buffer safely reuses the underlying memory capacity while maintaining thread safety within Boost ASIO's I/O contexts.
📊 Impact: Eliminates N dynamic memory allocations per second where N is the incoming packet rate (easily hundreds or thousands of packets per second in multiplayer servers). Improves cache locality and prevents heap fragmentation.
🔬 Measurement: Run the internal benchmark or observe server CPU usage and GC/allocation metrics during stress tests. Verified correctness by ensuring `test_network` passes successfully without any memory corruption or data race regressions.

---
*PR created automatically by Jules for task [8748204070956553404](https://jules.google.com/task/8748204070956553404) started by @gkehren*