### PR TITLE
⚡ Bolt: Optimize network receive loop dynamic allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,7 @@
 ## 2024-05-18 - [ChunkManager Hot-Path Thread-Local Queues]
 **Learning:** [The `ChunkManager` relies on dynamically creating `std::vector<Item>` queues inside hot path methods (`generatePendingVoxels`, `meshPendingChunks`, `uploadPendingMeshes`) which are called frequently in the main loop. These dynamic heap allocations can degrade performance. Reusing memory is complex due to `std::shared_mutex` usage and potential concurrency.]
 **Action:** [Use `thread_local std::vector<Item>` with a `queue.clear()` at the start of the method to safely reuse allocated capacity across frames without introducing data races or locking overhead in concurrent methods.]
+
+## 2024-05-30 - [Network Receive Hot-Path Micro-Optimization]
+**Learning:** Using `thread_local std::vector` inside hot event/async callbacks (like `handleReceive` in Boost.ASIO) completely eliminates dynamic heap allocations on every packet. Because ASIO completions run sequentially on the thread, there are no data races or re-entrancy issues, making TLS safely overwrite previous packet data effectively.
+**Action:** When working in high-throughput network receive loops and parsing functions, avoid per-packet dynamic heap allocations by replacing locally scoped vectors with `thread_local std::vector`, reusing capacity via `.assign()` or `.clear()`.

--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -121,7 +121,9 @@ void Client::handleReceive(const boost::system::error_code &error, std::size_t b
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Use thread_local to avoid dynamic memory allocation overhead on hot network path
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(data);
 	}
 }
@@ -176,9 +178,9 @@ void Client::handleMessage(const std::vector<uint8_t> &data)
 		if (!buf.hasMore(numPlayers * (sizeof(uint32_t) + 3 * sizeof(float))))
 			return;
 
-		// ⚡ Bolt: Replace std::unordered_set with std::vector + std::sort + std::binary_search
-		// to avoid node allocations and improve cache locality on every network tick.
-		std::vector<uint32_t> currentPlayers;
+		// ⚡ Bolt: Use thread_local vector to prevent allocation on every tick
+		thread_local std::vector<uint32_t> currentPlayers;
+		currentPlayers.clear();
 		currentPlayers.reserve(numPlayers);
 
 		std::lock_guard<std::mutex> lock(playerMutex);

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -69,7 +69,9 @@ void Server::handleReceive(const boost::asio::ip::udp::endpoint &senderEndpoint,
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Use thread_local to avoid dynamic memory allocation overhead on hot network path
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(senderEndpoint, data);
 	}
 }


### PR DESCRIPTION
💡 **What:** Replaced local `std::vector` instances in `Client::handleReceive`, `Server::handleReceive`, and `Client::handleMessage` with `thread_local std::vector`.

🎯 **Why:** In the previous implementation, the server and client allocated and deallocated new heap memory (`std::vector<uint8_t> data(...)` and `std::vector<uint32_t> currentPlayers`) for every single received network packet and world state update. In high-frequency network loops (like UDP ticking at 50ms intervals), this constant dynamic memory allocation is a significant bottleneck.

📊 **Impact:** By using `thread_local`, the vectors retain their capacity across function calls on the same thread. This drops dynamic memory allocations (calls to `new` and `delete`) on the network receive hot path to exactly zero after the initial packet, significantly reducing CPU overhead, avoiding memory fragmentation, and keeping the packet data highly cache-local.

🔬 **Measurement:** Compile the tests using `cmake -B build-vk -DCMAKE_BUILD_TYPE=Release -DFT_VOX_FETCH_SDL3=ON -DFT_VOX_DEP_MODE=system && cmake --build build-vk -j4 --target ft_vox test_network test_stream_opt`. Then, execute `./build-vk/tests/test_network` to verify the network implementation remains fully operational and functional with no regressions.

---
*PR created automatically by Jules for task [18261442056779416498](https://jules.google.com/task/18261442056779416498) started by @gkehren*