### PR TITLE
⚡ Bolt: [Performance Optimization] Network packet processing memory reuse

### DIFF
--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -121,7 +121,9 @@ void Client::handleReceive(const boost::system::error_code &error, std::size_t b
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Use thread_local vector to avoid per-packet dynamic heap allocations
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(data);
 	}
 }

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -69,7 +69,9 @@ void Server::handleReceive(const boost::asio::ip::udp::endpoint &senderEndpoint,
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Use thread_local vector to avoid per-packet dynamic heap allocations
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(senderEndpoint, data);
 	}
 }


### PR DESCRIPTION
💡 **What**: Replaced locally scoped `std::vector<uint8_t>` initialization in the `Client::handleReceive` and `Server::handleReceive` network loops with `thread_local std::vector<uint8_t> data; data.assign(...)`.

🎯 **Why**: In a high-throughput network receive loop processing packets via ASIO, instantiating a new locally scoped `std::vector` inside the lambda forces a dynamic heap allocation for every single packet received. By leveraging `thread_local`, we can safely reuse the vector's allocated capacity across the event loop's iterations, effectively eliminating per-packet garbage collection and heap pressure.

📊 **Impact**: Reduces per-packet memory allocation overhead to zero amortized. Over a sustained network stream of thousands of packets per second (e.g., world streaming and position updates), this significantly decreases CPU cache thrashing and memory allocator lock contention.

🔬 **Measurement**: 
Can be verified by running the network test suite (`./build-vk/tests/test_network`), which confirms that packet reception remains fully operational. The removal of dynamic allocation inside the hot path can also be traced with memory profilers like Valgrind or by profiling the CPU execution time of the ASIO `io_context` thread.

---
*PR created automatically by Jules for task [9371564299218560250](https://jules.google.com/task/9371564299218560250) started by @gkehren*