### PR TITLE
⚡ Bolt: Replace std::map with std::array for TextureType lookup

### DIFF
--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -49,11 +49,15 @@ constexpr unsigned char kBiomeColors[BIOME_COUNT][3] = {
 	{45, 175, 185},	 // CORAL_REEF
 };
 
-const char *textureName(TextureType t)
+const char *textureName(TextureType type)
 {
-	if (t >= 0 && t < COUNT && !textureTypeString[t].empty())
-		return textureTypeString[t].data();
-	return "unknown";
+	const auto index = static_cast<std::size_t>(type);
+
+	if (index >= textureTypeString.size())
+		return "unknown";
+
+	const std::string_view name = textureTypeString[index];
+	return name.empty() ? "unknown" : name.data();
 }
 
 void helpRow(const char *keys, const char *action)
@@ -290,11 +294,9 @@ void GameUI::drawHud(GameUIFrame &frame)
 		static std::vector<std::pair<int, std::string>> names;
 		if (names.empty())
 		{
-			for (int i = 0; i < COUNT; ++i)
+			for (std::size_t i = 0; i < textureTypeString.size(); ++i)
 			{
-				if (i == AIR || textureTypeString[i].empty())
-					continue;
-				names.emplace_back(i, std::string(textureTypeString[i]));
+				names.emplace_back(static_cast<int>(i), std::string{textureTypeString[i]});
 			}
 			std::sort(names.begin(), names.end(),
 					  [](const auto &a, const auto &b) { return a.second < b.second; });

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -51,8 +51,9 @@ constexpr unsigned char kBiomeColors[BIOME_COUNT][3] = {
 
 const char *textureName(TextureType t)
 {
-	auto it = textureTypeString.find(t);
-	return it != textureTypeString.end() ? it->second.c_str() : "unknown";
+	if (t >= 0 && t < COUNT && !textureTypeString[t].empty())
+		return textureTypeString[t].data();
+	return "unknown";
 }
 
 void helpRow(const char *keys, const char *action)
@@ -289,11 +290,11 @@ void GameUI::drawHud(GameUIFrame &frame)
 		static std::vector<std::pair<int, std::string>> names;
 		if (names.empty())
 		{
-			for (const auto &kv : textureTypeString)
+			for (int i = 0; i < COUNT; ++i)
 			{
-				if (kv.first == AIR || kv.first == COUNT)
+				if (i == AIR || textureTypeString[i].empty())
 					continue;
-				names.emplace_back(static_cast<int>(kv.first), kv.second);
+				names.emplace_back(i, std::string(textureTypeString[i]));
 			}
 			std::sort(names.begin(), names.end(),
 					  [](const auto &a, const auto &b) { return a.second < b.second; });

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <vector>
 #include <array>
+#include <string_view>
 #include <tuple>
 #include <map>
 #include <glm/glm.hpp>
@@ -305,109 +306,111 @@ static_assert(KELP == DRIPSTONE_BLOCK + 1,
 // Ensure TextureType fits in Voxel::type (uint8_t)
 static_assert(static_cast<int>(AIR) <= 255, "TextureType values exceed uint8_t range for Voxel::type");
 
-static const std::map<TextureType, std::string> textureTypeString = {
-	{BEDROCK, "Bedrock"},
-	{BRICKS, "Bricks"},
-	{COBBLESTONE, "Cobblestone"},
-	{DIRT, "Dirt"},
-	{GLASS, "Glass"},
-	{GRASS_TOP, "Grass Top"},
-	{GRASS_SIDE, "Grass Side"},
-	{GRAVEL, "Gravel"},
-	{OAK_LEAVES, "Oak Leaves"},
-	{OAK_LOG_TOP, "Oak Log Top"},
-	{OAK_LOG, "Oak Log"},
-	{OAK_PLANKS, "Oak Planks"},
-	{SAND, "Sand"},
-	{SNOW, "Snow"},
-	{STONE_BRICKS, "Stone Bricks"},
-	{STONE, "Stone"},
-	{COAL_ORE, "Coal Ore"},
-	{COPPER_ORE, "Copper Ore"},
-	{DIAMOND_ORE, "Diamond Ore"},
-	{EMERALD_ORE, "Emerald Ore"},
-	{GOLD_ORE, "Gold Ore"},
-	{IRON_ORE, "Iron Ore"},
-	{LAPIS_ORE, "Lapis Ore"},
-	{REDSTONE_ORE, "Redstone Ore"},
-	{WATER, "Water"},
-	{BIRCH_LOG, "Birch Log"},
-	{BIRCH_LOG_TOP, "Birch Log Top"},
-	{BIRCH_LEAVES, "Birch Leaves"},
-	{SPRUCE_LOG, "Spruce Log"},
-	{SPRUCE_LOG_TOP, "Spruce Log Top"},
-	{SPRUCE_LEAVES, "Spruce Leaves"},
-	{JUNGLE_LOG, "Jungle Log"},
-	{JUNGLE_LOG_TOP, "Jungle Log Top"},
-	{JUNGLE_LEAVES, "Jungle Leaves"},
-	{ACACIA_LOG, "Acacia Log"},
-	{ACACIA_LOG_TOP, "Acacia Log Top"},
-	{ACACIA_LEAVES, "Acacia Leaves"},
-	{DARK_OAK_LOG, "Dark Oak Log"},
-	{DARK_OAK_LOG_TOP, "Dark Oak Log Top"},
-	{DARK_OAK_LEAVES, "Dark Oak Leaves"},
-	{CACTUS, "Cactus"},
-	{CACTUS_TOP, "Cactus Top"},
-	{RED_SAND, "Red Sand"},
-	{SANDSTONE, "Sandstone"},
-	{RED_SANDSTONE, "Red Sandstone"},
-	{TERRACOTTA, "Terracotta"},
-	{ORANGE_TERRACOTTA, "Orange Terracotta"},
-	{RED_TERRACOTTA, "Red Terracotta"},
-	{YELLOW_TERRACOTTA, "Yellow Terracotta"},
-	{WHITE_TERRACOTTA, "White Terracotta"},
-	{BROWN_TERRACOTTA, "Brown Terracotta"},
-	{COARSE_DIRT, "Coarse Dirt"},
-	{PODZOL, "Podzol"},
-	{CLAY, "Clay"},
-	{MUD, "Mud"},
-	{MOSS_BLOCK, "Moss Block"},
-	{ICE, "Ice"},
-	{PACKED_ICE, "Packed Ice"},
-	{BLUE_ICE, "Blue Ice"},
-	{ANDESITE, "Andesite"},
-	{DIORITE, "Diorite"},
-	{GRANITE, "Granite"},
-	{DEEPSLATE, "Deepslate"},
-	{DEEPSLATE_TOP, "Deepslate Top"},
-	{TUFF, "Tuff"},
-	{MOSSY_COBBLESTONE, "Mossy Cobblestone"},
-	{CHERRY_LOG, "Cherry Log"},
-	{CHERRY_LOG_TOP, "Cherry Log Top"},
-	{CHERRY_LEAVES, "Cherry Leaves"},
-	{MANGROVE_LOG, "Mangrove Log"},
-	{MANGROVE_LOG_TOP, "Mangrove Log Top"},
-	{MANGROVE_ROOTS, "Mangrove Roots"},
-	{MANGROVE_ROOTS_TOP, "Mangrove Roots Top"},
-	{MANGROVE_LEAVES, "Mangrove Leaves"},
-	{BAMBOO_BLOCK, "Bamboo Block"},
-	{BAMBOO_BLOCK_TOP, "Bamboo Block Top"},
-	{BAMBOO_STALK, "Bamboo Stalk"},
-	{RED_MUSHROOM_BLOCK, "Red Mushroom Block"},
-	{BROWN_MUSHROOM_BLOCK, "Brown Mushroom Block"},
-	{MUSHROOM_STEM, "Mushroom Stem"},
-	{BASALT, "Basalt"},
-	{BASALT_TOP, "Basalt Top"},
-	{BLACKSTONE, "Blackstone"},
-	{MAGMA, "Magma"},
-	{TUBE_CORAL_BLOCK, "Tube Coral Block"},
-	{BRAIN_CORAL_BLOCK, "Brain Coral Block"},
-	{BUBBLE_CORAL_BLOCK, "Bubble Coral Block"},
-	{FIRE_CORAL_BLOCK, "Fire Coral Block"},
-	{HORN_CORAL_BLOCK, "Horn Coral Block"},
-	{LAVA, "Lava"},
-	{DEEPSLATE_COAL_ORE, "Deepslate Coal Ore"},
-	{DEEPSLATE_COPPER_ORE, "Deepslate Copper Ore"},
-	{DEEPSLATE_DIAMOND_ORE, "Deepslate Diamond Ore"},
-	{DEEPSLATE_EMERALD_ORE, "Deepslate Emerald Ore"},
-	{DEEPSLATE_GOLD_ORE, "Deepslate Gold Ore"},
-	{DEEPSLATE_IRON_ORE, "Deepslate Iron Ore"},
-	{DEEPSLATE_LAPIS_ORE, "Deepslate Lapis Ore"},
-	{DEEPSLATE_REDSTONE_ORE, "Deepslate Redstone Ore"},
-	{DRIPSTONE_BLOCK, "Dripstone Block"},
-	{KELP, "Kelp"},
-	{KELP_TOP, "Kelp Top"},
-};
+static constexpr std::array<std::string_view, COUNT> textureTypeString = []() {
+	std::array<std::string_view, COUNT> arr{};
+	arr[BEDROCK] = "Bedrock";
+	arr[BRICKS] = "Bricks";
+	arr[COBBLESTONE] = "Cobblestone";
+	arr[DIRT] = "Dirt";
+	arr[GLASS] = "Glass";
+	arr[GRASS_TOP] = "Grass Top";
+	arr[GRASS_SIDE] = "Grass Side";
+	arr[GRAVEL] = "Gravel";
+	arr[OAK_LEAVES] = "Oak Leaves";
+	arr[OAK_LOG_TOP] = "Oak Log Top";
+	arr[OAK_LOG] = "Oak Log";
+	arr[OAK_PLANKS] = "Oak Planks";
+	arr[SAND] = "Sand";
+	arr[SNOW] = "Snow";
+	arr[STONE_BRICKS] = "Stone Bricks";
+	arr[STONE] = "Stone";
+	arr[COAL_ORE] = "Coal Ore";
+	arr[COPPER_ORE] = "Copper Ore";
+	arr[DIAMOND_ORE] = "Diamond Ore";
+	arr[EMERALD_ORE] = "Emerald Ore";
+	arr[GOLD_ORE] = "Gold Ore";
+	arr[IRON_ORE] = "Iron Ore";
+	arr[LAPIS_ORE] = "Lapis Ore";
+	arr[REDSTONE_ORE] = "Redstone Ore";
+	arr[WATER] = "Water";
+	arr[BIRCH_LOG] = "Birch Log";
+	arr[BIRCH_LOG_TOP] = "Birch Log Top";
+	arr[BIRCH_LEAVES] = "Birch Leaves";
+	arr[SPRUCE_LOG] = "Spruce Log";
+	arr[SPRUCE_LOG_TOP] = "Spruce Log Top";
+	arr[SPRUCE_LEAVES] = "Spruce Leaves";
+	arr[JUNGLE_LOG] = "Jungle Log";
+	arr[JUNGLE_LOG_TOP] = "Jungle Log Top";
+	arr[JUNGLE_LEAVES] = "Jungle Leaves";
+	arr[ACACIA_LOG] = "Acacia Log";
+	arr[ACACIA_LOG_TOP] = "Acacia Log Top";
+	arr[ACACIA_LEAVES] = "Acacia Leaves";
+	arr[DARK_OAK_LOG] = "Dark Oak Log";
+	arr[DARK_OAK_LOG_TOP] = "Dark Oak Log Top";
+	arr[DARK_OAK_LEAVES] = "Dark Oak Leaves";
+	arr[CACTUS] = "Cactus";
+	arr[CACTUS_TOP] = "Cactus Top";
+	arr[RED_SAND] = "Red Sand";
+	arr[SANDSTONE] = "Sandstone";
+	arr[RED_SANDSTONE] = "Red Sandstone";
+	arr[TERRACOTTA] = "Terracotta";
+	arr[ORANGE_TERRACOTTA] = "Orange Terracotta";
+	arr[RED_TERRACOTTA] = "Red Terracotta";
+	arr[YELLOW_TERRACOTTA] = "Yellow Terracotta";
+	arr[WHITE_TERRACOTTA] = "White Terracotta";
+	arr[BROWN_TERRACOTTA] = "Brown Terracotta";
+	arr[COARSE_DIRT] = "Coarse Dirt";
+	arr[PODZOL] = "Podzol";
+	arr[CLAY] = "Clay";
+	arr[MUD] = "Mud";
+	arr[MOSS_BLOCK] = "Moss Block";
+	arr[ICE] = "Ice";
+	arr[PACKED_ICE] = "Packed Ice";
+	arr[BLUE_ICE] = "Blue Ice";
+	arr[ANDESITE] = "Andesite";
+	arr[DIORITE] = "Diorite";
+	arr[GRANITE] = "Granite";
+	arr[DEEPSLATE] = "Deepslate";
+	arr[DEEPSLATE_TOP] = "Deepslate Top";
+	arr[TUFF] = "Tuff";
+	arr[MOSSY_COBBLESTONE] = "Mossy Cobblestone";
+	arr[CHERRY_LOG] = "Cherry Log";
+	arr[CHERRY_LOG_TOP] = "Cherry Log Top";
+	arr[CHERRY_LEAVES] = "Cherry Leaves";
+	arr[MANGROVE_LOG] = "Mangrove Log";
+	arr[MANGROVE_LOG_TOP] = "Mangrove Log Top";
+	arr[MANGROVE_ROOTS] = "Mangrove Roots";
+	arr[MANGROVE_ROOTS_TOP] = "Mangrove Roots Top";
+	arr[MANGROVE_LEAVES] = "Mangrove Leaves";
+	arr[BAMBOO_BLOCK] = "Bamboo Block";
+	arr[BAMBOO_BLOCK_TOP] = "Bamboo Block Top";
+	arr[BAMBOO_STALK] = "Bamboo Stalk";
+	arr[RED_MUSHROOM_BLOCK] = "Red Mushroom Block";
+	arr[BROWN_MUSHROOM_BLOCK] = "Brown Mushroom Block";
+	arr[MUSHROOM_STEM] = "Mushroom Stem";
+	arr[BASALT] = "Basalt";
+	arr[BASALT_TOP] = "Basalt Top";
+	arr[BLACKSTONE] = "Blackstone";
+	arr[MAGMA] = "Magma";
+	arr[TUBE_CORAL_BLOCK] = "Tube Coral Block";
+	arr[BRAIN_CORAL_BLOCK] = "Brain Coral Block";
+	arr[BUBBLE_CORAL_BLOCK] = "Bubble Coral Block";
+	arr[FIRE_CORAL_BLOCK] = "Fire Coral Block";
+	arr[HORN_CORAL_BLOCK] = "Horn Coral Block";
+	arr[LAVA] = "Lava";
+	arr[DEEPSLATE_COAL_ORE] = "Deepslate Coal Ore";
+	arr[DEEPSLATE_COPPER_ORE] = "Deepslate Copper Ore";
+	arr[DEEPSLATE_DIAMOND_ORE] = "Deepslate Diamond Ore";
+	arr[DEEPSLATE_EMERALD_ORE] = "Deepslate Emerald Ore";
+	arr[DEEPSLATE_GOLD_ORE] = "Deepslate Gold Ore";
+	arr[DEEPSLATE_IRON_ORE] = "Deepslate Iron Ore";
+	arr[DEEPSLATE_LAPIS_ORE] = "Deepslate Lapis Ore";
+	arr[DEEPSLATE_REDSTONE_ORE] = "Deepslate Redstone Ore";
+	arr[DRIPSTONE_BLOCK] = "Dripstone Block";
+	arr[KELP] = "Kelp";
+	arr[KELP_TOP] = "Kelp Top";
+	return arr;
+}();
 
 enum ChunkState
 {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -5,7 +5,6 @@
 #include <array>
 #include <string_view>
 #include <tuple>
-#include <map>
 #include <glm/glm.hpp>
 #include <cstring>
 
@@ -306,111 +305,125 @@ static_assert(KELP == DRIPSTONE_BLOCK + 1,
 // Ensure TextureType fits in Voxel::type (uint8_t)
 static_assert(static_cast<int>(AIR) <= 255, "TextureType values exceed uint8_t range for Voxel::type");
 
-static constexpr std::array<std::string_view, COUNT> textureTypeString = []() {
-	std::array<std::string_view, COUNT> arr{};
-	arr[BEDROCK] = "Bedrock";
-	arr[BRICKS] = "Bricks";
-	arr[COBBLESTONE] = "Cobblestone";
-	arr[DIRT] = "Dirt";
-	arr[GLASS] = "Glass";
-	arr[GRASS_TOP] = "Grass Top";
-	arr[GRASS_SIDE] = "Grass Side";
-	arr[GRAVEL] = "Gravel";
-	arr[OAK_LEAVES] = "Oak Leaves";
-	arr[OAK_LOG_TOP] = "Oak Log Top";
-	arr[OAK_LOG] = "Oak Log";
-	arr[OAK_PLANKS] = "Oak Planks";
-	arr[SAND] = "Sand";
-	arr[SNOW] = "Snow";
-	arr[STONE_BRICKS] = "Stone Bricks";
-	arr[STONE] = "Stone";
-	arr[COAL_ORE] = "Coal Ore";
-	arr[COPPER_ORE] = "Copper Ore";
-	arr[DIAMOND_ORE] = "Diamond Ore";
-	arr[EMERALD_ORE] = "Emerald Ore";
-	arr[GOLD_ORE] = "Gold Ore";
-	arr[IRON_ORE] = "Iron Ore";
-	arr[LAPIS_ORE] = "Lapis Ore";
-	arr[REDSTONE_ORE] = "Redstone Ore";
-	arr[WATER] = "Water";
-	arr[BIRCH_LOG] = "Birch Log";
-	arr[BIRCH_LOG_TOP] = "Birch Log Top";
-	arr[BIRCH_LEAVES] = "Birch Leaves";
-	arr[SPRUCE_LOG] = "Spruce Log";
-	arr[SPRUCE_LOG_TOP] = "Spruce Log Top";
-	arr[SPRUCE_LEAVES] = "Spruce Leaves";
-	arr[JUNGLE_LOG] = "Jungle Log";
-	arr[JUNGLE_LOG_TOP] = "Jungle Log Top";
-	arr[JUNGLE_LEAVES] = "Jungle Leaves";
-	arr[ACACIA_LOG] = "Acacia Log";
-	arr[ACACIA_LOG_TOP] = "Acacia Log Top";
-	arr[ACACIA_LEAVES] = "Acacia Leaves";
-	arr[DARK_OAK_LOG] = "Dark Oak Log";
-	arr[DARK_OAK_LOG_TOP] = "Dark Oak Log Top";
-	arr[DARK_OAK_LEAVES] = "Dark Oak Leaves";
-	arr[CACTUS] = "Cactus";
-	arr[CACTUS_TOP] = "Cactus Top";
-	arr[RED_SAND] = "Red Sand";
-	arr[SANDSTONE] = "Sandstone";
-	arr[RED_SANDSTONE] = "Red Sandstone";
-	arr[TERRACOTTA] = "Terracotta";
-	arr[ORANGE_TERRACOTTA] = "Orange Terracotta";
-	arr[RED_TERRACOTTA] = "Red Terracotta";
-	arr[YELLOW_TERRACOTTA] = "Yellow Terracotta";
-	arr[WHITE_TERRACOTTA] = "White Terracotta";
-	arr[BROWN_TERRACOTTA] = "Brown Terracotta";
-	arr[COARSE_DIRT] = "Coarse Dirt";
-	arr[PODZOL] = "Podzol";
-	arr[CLAY] = "Clay";
-	arr[MUD] = "Mud";
-	arr[MOSS_BLOCK] = "Moss Block";
-	arr[ICE] = "Ice";
-	arr[PACKED_ICE] = "Packed Ice";
-	arr[BLUE_ICE] = "Blue Ice";
-	arr[ANDESITE] = "Andesite";
-	arr[DIORITE] = "Diorite";
-	arr[GRANITE] = "Granite";
-	arr[DEEPSLATE] = "Deepslate";
-	arr[DEEPSLATE_TOP] = "Deepslate Top";
-	arr[TUFF] = "Tuff";
-	arr[MOSSY_COBBLESTONE] = "Mossy Cobblestone";
-	arr[CHERRY_LOG] = "Cherry Log";
-	arr[CHERRY_LOG_TOP] = "Cherry Log Top";
-	arr[CHERRY_LEAVES] = "Cherry Leaves";
-	arr[MANGROVE_LOG] = "Mangrove Log";
-	arr[MANGROVE_LOG_TOP] = "Mangrove Log Top";
-	arr[MANGROVE_ROOTS] = "Mangrove Roots";
-	arr[MANGROVE_ROOTS_TOP] = "Mangrove Roots Top";
-	arr[MANGROVE_LEAVES] = "Mangrove Leaves";
-	arr[BAMBOO_BLOCK] = "Bamboo Block";
-	arr[BAMBOO_BLOCK_TOP] = "Bamboo Block Top";
-	arr[BAMBOO_STALK] = "Bamboo Stalk";
-	arr[RED_MUSHROOM_BLOCK] = "Red Mushroom Block";
-	arr[BROWN_MUSHROOM_BLOCK] = "Brown Mushroom Block";
-	arr[MUSHROOM_STEM] = "Mushroom Stem";
-	arr[BASALT] = "Basalt";
-	arr[BASALT_TOP] = "Basalt Top";
-	arr[BLACKSTONE] = "Blackstone";
-	arr[MAGMA] = "Magma";
-	arr[TUBE_CORAL_BLOCK] = "Tube Coral Block";
-	arr[BRAIN_CORAL_BLOCK] = "Brain Coral Block";
-	arr[BUBBLE_CORAL_BLOCK] = "Bubble Coral Block";
-	arr[FIRE_CORAL_BLOCK] = "Fire Coral Block";
-	arr[HORN_CORAL_BLOCK] = "Horn Coral Block";
-	arr[LAVA] = "Lava";
-	arr[DEEPSLATE_COAL_ORE] = "Deepslate Coal Ore";
-	arr[DEEPSLATE_COPPER_ORE] = "Deepslate Copper Ore";
-	arr[DEEPSLATE_DIAMOND_ORE] = "Deepslate Diamond Ore";
-	arr[DEEPSLATE_EMERALD_ORE] = "Deepslate Emerald Ore";
-	arr[DEEPSLATE_GOLD_ORE] = "Deepslate Gold Ore";
-	arr[DEEPSLATE_IRON_ORE] = "Deepslate Iron Ore";
-	arr[DEEPSLATE_LAPIS_ORE] = "Deepslate Lapis Ore";
-	arr[DEEPSLATE_REDSTONE_ORE] = "Deepslate Redstone Ore";
-	arr[DRIPSTONE_BLOCK] = "Dripstone Block";
-	arr[KELP] = "Kelp";
-	arr[KELP_TOP] = "Kelp Top";
-	return arr;
+inline constexpr std::array<std::string_view, COUNT> textureTypeString = [] {
+	std::array<std::string_view, COUNT> names{};
+	names[BEDROCK] = "Bedrock";
+	names[BRICKS] = "Bricks";
+	names[COBBLESTONE] = "Cobblestone";
+	names[DIRT] = "Dirt";
+	names[GLASS] = "Glass";
+	names[GRASS_TOP] = "Grass Top";
+	names[GRASS_SIDE] = "Grass Side";
+	names[GRAVEL] = "Gravel";
+	names[OAK_LEAVES] = "Oak Leaves";
+	names[OAK_LOG_TOP] = "Oak Log Top";
+	names[OAK_LOG] = "Oak Log";
+	names[OAK_PLANKS] = "Oak Planks";
+	names[SAND] = "Sand";
+	names[SNOW] = "Snow";
+	names[STONE_BRICKS] = "Stone Bricks";
+	names[STONE] = "Stone";
+	names[COAL_ORE] = "Coal Ore";
+	names[COPPER_ORE] = "Copper Ore";
+	names[DIAMOND_ORE] = "Diamond Ore";
+	names[EMERALD_ORE] = "Emerald Ore";
+	names[GOLD_ORE] = "Gold Ore";
+	names[IRON_ORE] = "Iron Ore";
+	names[LAPIS_ORE] = "Lapis Ore";
+	names[REDSTONE_ORE] = "Redstone Ore";
+	names[WATER] = "Water";
+	names[BIRCH_LOG] = "Birch Log";
+	names[BIRCH_LOG_TOP] = "Birch Log Top";
+	names[BIRCH_LEAVES] = "Birch Leaves";
+	names[SPRUCE_LOG] = "Spruce Log";
+	names[SPRUCE_LOG_TOP] = "Spruce Log Top";
+	names[SPRUCE_LEAVES] = "Spruce Leaves";
+	names[JUNGLE_LOG] = "Jungle Log";
+	names[JUNGLE_LOG_TOP] = "Jungle Log Top";
+	names[JUNGLE_LEAVES] = "Jungle Leaves";
+	names[ACACIA_LOG] = "Acacia Log";
+	names[ACACIA_LOG_TOP] = "Acacia Log Top";
+	names[ACACIA_LEAVES] = "Acacia Leaves";
+	names[DARK_OAK_LOG] = "Dark Oak Log";
+	names[DARK_OAK_LOG_TOP] = "Dark Oak Log Top";
+	names[DARK_OAK_LEAVES] = "Dark Oak Leaves";
+	names[CACTUS] = "Cactus";
+	names[CACTUS_TOP] = "Cactus Top";
+	names[RED_SAND] = "Red Sand";
+	names[SANDSTONE] = "Sandstone";
+	names[RED_SANDSTONE] = "Red Sandstone";
+	names[TERRACOTTA] = "Terracotta";
+	names[ORANGE_TERRACOTTA] = "Orange Terracotta";
+	names[RED_TERRACOTTA] = "Red Terracotta";
+	names[YELLOW_TERRACOTTA] = "Yellow Terracotta";
+	names[WHITE_TERRACOTTA] = "White Terracotta";
+	names[BROWN_TERRACOTTA] = "Brown Terracotta";
+	names[COARSE_DIRT] = "Coarse Dirt";
+	names[PODZOL] = "Podzol";
+	names[CLAY] = "Clay";
+	names[MUD] = "Mud";
+	names[MOSS_BLOCK] = "Moss Block";
+	names[ICE] = "Ice";
+	names[PACKED_ICE] = "Packed Ice";
+	names[BLUE_ICE] = "Blue Ice";
+	names[ANDESITE] = "Andesite";
+	names[DIORITE] = "Diorite";
+	names[GRANITE] = "Granite";
+	names[DEEPSLATE] = "Deepslate";
+	names[DEEPSLATE_TOP] = "Deepslate Top";
+	names[TUFF] = "Tuff";
+	names[MOSSY_COBBLESTONE] = "Mossy Cobblestone";
+	names[CHERRY_LOG] = "Cherry Log";
+	names[CHERRY_LOG_TOP] = "Cherry Log Top";
+	names[CHERRY_LEAVES] = "Cherry Leaves";
+	names[MANGROVE_LOG] = "Mangrove Log";
+	names[MANGROVE_LOG_TOP] = "Mangrove Log Top";
+	names[MANGROVE_ROOTS] = "Mangrove Roots";
+	names[MANGROVE_ROOTS_TOP] = "Mangrove Roots Top";
+	names[MANGROVE_LEAVES] = "Mangrove Leaves";
+	names[BAMBOO_BLOCK] = "Bamboo Block";
+	names[BAMBOO_BLOCK_TOP] = "Bamboo Block Top";
+	names[BAMBOO_STALK] = "Bamboo Stalk";
+	names[RED_MUSHROOM_BLOCK] = "Red Mushroom Block";
+	names[BROWN_MUSHROOM_BLOCK] = "Brown Mushroom Block";
+	names[MUSHROOM_STEM] = "Mushroom Stem";
+	names[BASALT] = "Basalt";
+	names[BASALT_TOP] = "Basalt Top";
+	names[BLACKSTONE] = "Blackstone";
+	names[MAGMA] = "Magma";
+	names[TUBE_CORAL_BLOCK] = "Tube Coral Block";
+	names[BRAIN_CORAL_BLOCK] = "Brain Coral Block";
+	names[BUBBLE_CORAL_BLOCK] = "Bubble Coral Block";
+	names[FIRE_CORAL_BLOCK] = "Fire Coral Block";
+	names[HORN_CORAL_BLOCK] = "Horn Coral Block";
+	names[LAVA] = "Lava";
+	names[DEEPSLATE_COAL_ORE] = "Deepslate Coal Ore";
+	names[DEEPSLATE_COPPER_ORE] = "Deepslate Copper Ore";
+	names[DEEPSLATE_DIAMOND_ORE] = "Deepslate Diamond Ore";
+	names[DEEPSLATE_EMERALD_ORE] = "Deepslate Emerald Ore";
+	names[DEEPSLATE_GOLD_ORE] = "Deepslate Gold Ore";
+	names[DEEPSLATE_IRON_ORE] = "Deepslate Iron Ore";
+	names[DEEPSLATE_LAPIS_ORE] = "Deepslate Lapis Ore";
+	names[DEEPSLATE_REDSTONE_ORE] = "Deepslate Redstone Ore";
+	names[DRIPSTONE_BLOCK] = "Dripstone Block";
+	names[KELP] = "Kelp";
+	names[KELP_TOP] = "Kelp Top";
+	return names;
 }();
+
+constexpr bool allTextureTypeNamesDefined()
+{
+	for (const std::string_view name : textureTypeString)
+	{
+		if (name.empty())
+			return false;
+	}
+	return true;
+}
+
+static_assert(textureTypeString.size() == static_cast<std::size_t>(COUNT));
+static_assert(allTextureTypeNamesDefined(),
+			  "Every TextureType before COUNT must have a display name");
 
 enum ChunkState
 {

--- a/tests/test_render_helpers.cpp
+++ b/tests/test_render_helpers.cpp
@@ -311,8 +311,19 @@ int main()
 	{
 		if (sizeof(kBlockLayers) / sizeof(kBlockLayers[0]) != static_cast<size_t>(TextureType::COUNT))
 			ok = fail("kBlockLayers size must equal TextureType::COUNT");
-		if (textureTypeString.size() != static_cast<size_t>(TextureType::COUNT))
-			ok = fail("every TextureType must have a display name");
+		if (textureTypeString.size() != static_cast<std::size_t>(TextureType::COUNT))
+			ok = fail("textureTypeString must contain exactly COUNT entries");
+		for (std::size_t i = 0; i < textureTypeString.size(); ++i)
+		{
+			if (textureTypeString[i].empty())
+				ok = fail("textureTypeString[" + std::to_string(i) + "] must not be empty");
+		}
+		if (textureTypeString[BEDROCK] != "Bedrock")
+			ok = fail("BEDROCK display name mismatch");
+		if (textureTypeString[WATER] != "Water")
+			ok = fail("WATER display name mismatch");
+		if (textureTypeString[KELP_TOP] != "Kelp Top")
+			ok = fail("KELP_TOP display name mismatch");
 		for (int i = 0; i < static_cast<int>(TextureType::COUNT); ++i)
 		{
 			const char *file = blockLayerFile(static_cast<TextureType>(i));


### PR DESCRIPTION
💡 **What:**
Replaced the `static const std::map<TextureType, std::string> textureTypeString` in `src/utils.hpp` with a single `inline constexpr std::array<std::string_view, COUNT>` registry, with entries assigned by explicit enum name. Updated `GameUI.cpp` (bounds-checked lookup, direct array iteration) and `tests/test_render_helpers.cpp` (runtime registry validation).

🎯 **Why:**
The old `static const std::map` in a header meant one instance per translation unit, dynamic initialization, tree nodes and ~100 heap-allocated `std::string`s on startup. The constexpr array is compile-time initialized, allocation-free, contiguous, and its enum-index layout matches how the registry is actually used.

**Before:**
```text
static const std::map<TextureType, std::string>
- dynamic initialization
- tree nodes
- string storage
- O(log N) lookup
- header-local instances (one per TU)
```

**After:**
```text
inline constexpr std::array<std::string_view, COUNT>
- compile-time initialization
- no heap allocation
- contiguous storage
- O(1) lookup
- compile-time registry validation
```

Note: no FPS/lookup-speed claims are made — on ~100 entries the absolute gain of an isolated UI lookup is small. The value is the correct data structure, zero allocation/dynamic initialization, and maintainability.

🛡️ **Compile-time safety:**
- `static_assert(textureTypeString.size() == COUNT)` plus a completeness check (`allTextureTypeNamesDefined()`) fail the build immediately if a new `TextureType` is appended without a display name — no need to wait for a runtime test to catch it.
- `textureName()` is bounds-checked via `std::size_t` index: `AIR`, `COUNT` and any invalid enum value return `"unknown"` without out-of-bounds access.
- `drawHud()` iterates the array directly; `AIR`/`COUNT` sit after `COUNT` in the enum so they are outside the array by construction.

🔬 **Measurement:**
The test target actually relevant to this change is `test_render_helpers` (validates registry size, every entry non-empty, and representative mappings BEDROCK/WATER/KELP_TOP):
```bash
cmake -B build-vk -DCMAKE_BUILD_TYPE=Release -DFT_VOX_FETCH_SDL3=ON -DFT_VOX_DEP_MODE=system
cmake --build build-vk -j4 --target ft_vox test_render_helpers
./build-vk/tests/test_render_helpers
```
Then global validation:
```bash
cmake --build build-vk -j4 --target test_network test_stream_opt
./build-vk/tests/test_network
./build-vk/tests/test_stream_opt
```

Verified locally (Windows / MSVC): `ft_vox` builds, `test_render_helpers`, `test_network` and `test_stream_opt` all pass.

---
*PR created automatically by Jules for task [1056228855919167468](https://jules.google.com/task/1056228855919167468) started by @gkehren*
