### PR TITLE
⚡ Bolt: [performance improvement] Eliminate dynamic heap allocations in network receive loop

### DIFF
--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -121,7 +121,9 @@ void Client::handleReceive(const boost::system::error_code &error, std::size_t b
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Reuse thread_local vector capacity to prevent dynamic heap allocations per packet in hot receive loop
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(data);
 	}
 }

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -69,7 +69,9 @@ void Server::handleReceive(const boost::asio::ip::udp::endpoint &senderEndpoint,
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Reuse thread_local vector capacity to prevent dynamic heap allocations per packet in hot receive loop
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(senderEndpoint, data);
 	}
 }


### PR DESCRIPTION
💡 **What**: 
Replaced local scoped `std::vector<uint8_t>` arrays inside `Server::handleReceive` and `Client::handleReceive` with `thread_local std::vector<uint8_t>` arrays and used `.assign()`.

🎯 **Why**: 
The previous implementation dynamically allocated a new vector on the heap for every single incoming packet before passing it to `handleMessage`. For high-tick-rate networked games, this causes constant, unnecessary memory allocations and deallocations, leading to memory fragmentation and GC/allocator overhead in the hot loop.

📊 **Impact**: 
Reduces dynamic heap memory allocations during network packet processing by 100%. Buffer capacity is safely reused per-thread across frames.

🔬 **Measurement**: 
Compile `test_network` and verify successful network handshakes/packet transfers. Network profilers will show 0 vector allocations within the receive loop after the initial capacity expansion.

---
*PR created automatically by Jules for task [6304167222356537272](https://jules.google.com/task/6304167222356537272) started by @gkehren*