### PR TITLE
⚡ Bolt: [performance improvement] Eliminate per-packet heap allocations in UDP receive loops

### DIFF
--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -121,7 +121,10 @@ void Client::handleReceive(const boost::system::error_code &error, std::size_t b
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Replace per-packet dynamic heap allocations with a thread_local std::vector
+		// capacity reuse. This eliminates allocation overhead in the hot receive loop.
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(data);
 	}
 }

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -69,7 +69,10 @@ void Server::handleReceive(const boost::asio::ip::udp::endpoint &senderEndpoint,
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Replace per-packet dynamic heap allocations with a thread_local std::vector
+		// capacity reuse. This eliminates allocation overhead in the hot receive loop.
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(senderEndpoint, data);
 	}
 }


### PR DESCRIPTION
💡 What: Replaced per-packet dynamically allocated `std::vector` objects in `Server::handleReceive` and `Client::handleReceive` with `thread_local std::vector` instances. Uses `.assign()` to populate the data.

🎯 Why: To prevent continuous dynamic heap allocations and memory churn caused by allocating a new vector for every incoming UDP packet in the networking hot loop.

📊 Impact: Reduces heap allocation overhead in the client/server receive loops to essentially zero after the first few packets, improving throughput and preventing potential memory fragmentation/garbage collection stutters.

🔬 Measurement: Can be observed using a memory profiler (like Valgrind/Massif or Tracy) tracking heap allocations inside `Client::handleReceive` and `Server::handleReceive` while streaming world chunks over UDP. Allocations will flatline after the initial buffer sizing.

---
*PR created automatically by Jules for task [1321433067716376581](https://jules.google.com/task/1321433067716376581) started by @gkehren*