### PR TITLE
⚡ Bolt: Network Receive Hot-Loop Memory Allocation Optimization

### DIFF
--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -121,7 +121,10 @@ void Client::handleReceive(const boost::system::error_code &error, std::size_t b
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Replace local std::vector with thread_local to avoid dynamic heap allocation per packet.
+		// Since handleReceive runs in the io_context thread, this is thread-safe and reuses vector capacity.
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(data);
 	}
 }

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -69,7 +69,10 @@ void Server::handleReceive(const boost::asio::ip::udp::endpoint &senderEndpoint,
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Replace local std::vector with thread_local to avoid dynamic heap allocation per packet.
+		// Since handleReceive runs in the io_context thread, this is thread-safe and reuses vector capacity.
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(senderEndpoint, data);
 	}
 }


### PR DESCRIPTION
💡 What: Replaced local `std::vector` allocations in `Client::handleReceive` and `Server::handleReceive` with `thread_local std::vector` that uses `.assign()`.

🎯 Why: The original code instantiated a new `std::vector` (triggering a heap allocation) on every single UDP packet received. Because the receive handler is a hot path running on the `io_context` thread, this creates significant memory allocation overhead. Since handlers run sequentially on the `io_context` thread, it is completely thread-safe to reuse a single vector's capacity.

📊 Impact: Eliminates per-packet heap allocations in the networking receive loop, significantly reducing CPU cycles spent in `malloc`/`free` and reducing GC pressure (memory fragmentation).

🔬 Measurement: Verified functionality by compiling and running `test_network` successfully, which showed all handshake, packet routing, and sequence numbering remaining intact. Execution profiles should show a complete drop of allocation time in `handleReceive`.

---
*PR created automatically by Jules for task [7927762351047357804](https://jules.google.com/task/7927762351047357804) started by @gkehren*