### PR TITLE
⚡ Bolt: Optimize network receive loop per-packet allocations

### DIFF
--- a/src/Network/Client.cpp
+++ b/src/Network/Client.cpp
@@ -121,7 +121,9 @@ void Client::handleReceive(const boost::system::error_code &error, std::size_t b
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Avoid per-packet dynamic heap allocations by reusing thread_local vector capacity
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(data);
 	}
 }

--- a/src/Network/Server.cpp
+++ b/src/Network/Server.cpp
@@ -69,7 +69,9 @@ void Server::handleReceive(const boost::asio::ip::udp::endpoint &senderEndpoint,
 {
 	if (!error && bytesTransferred > 0)
 	{
-		std::vector<uint8_t> data(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
+		// ⚡ Bolt: Avoid per-packet dynamic heap allocations by reusing thread_local vector capacity
+		thread_local std::vector<uint8_t> data;
+		data.assign(recvBuffer.begin(), recvBuffer.begin() + bytesTransferred);
 		handleMessage(senderEndpoint, data);
 	}
 }


### PR DESCRIPTION
💡 What: Refactored the `Server::handleReceive` and `Client::handleReceive` functions in the networking layer to reuse a `thread_local std::vector` via `.assign()` instead of dynamically allocating a fresh `std::vector` every time a network packet is received.

🎯 Why: In a high-frequency networked game loop, receiving packets generates significant memory churn and heap fragmentation if memory is dynamically allocated for every packet. By reusing the memory capacity via a `thread_local` vector, we entirely bypass the system allocator on the hot path.

📊 Impact: Reduces heap allocation overhead in the network receive thread. The dynamic allocation overhead falls from O(PacketsReceived) to O(1) (capacity will max out at the largest packet received and stay there).

🔬 Measurement: Review memory profiler (e.g. Valgrind Massif, or Tracy allocations) during high-throughput client-server network replication to observe eliminated allocations in `handleReceive`. Can be smoke-tested by running `./build-vk/tests/test_network` to ensure behavior remains identical.

---
*PR created automatically by Jules for task [17582297181714107254](https://jules.google.com/task/17582297181714107254) started by @gkehren*