### PR TITLE
fix(vulkan): defer swapchain recreation to frame boundary

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -243,7 +243,7 @@ if(NOT _FT_VOX_VMA_OK)
     FetchContent_Declare(
         VulkanMemoryAllocator
         GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
-        GIT_TAG v3.1.0
+        GIT_TAG v3.3.0
         GIT_SHALLOW TRUE
     )
     FetchContent_MakeAvailable(VulkanMemoryAllocator)

--- a/docs/engine-architecture.md
+++ b/docs/engine-architecture.md
@@ -62,7 +62,7 @@ Matches `Engine.cpp` order:
    - `updateVisibility` → `collectDrawList` / `collectShadowList`  
    - Computes `uploadBudgetThisFrame` (uploads are **not** done here)  
 5. **Highlight** — raycast block under cursor (`updateHighlight`)  
-6. **Resize** if needed — swapchain + `WorldRenderer::onSwapchainRecreate`  
+6. **Deferred swapchain recreation** if needed — resize, VSync, or WSI invalidation follows one Engine-owned path that refreshes frame synchronization, `WorldRenderer`, and ImGui before acquisition
 7. **Acquire** — `VkFrameContext::beginFrame` → image index + command buffer  
 8. **Retire/staging frame slots** — `resourceRetire.beginFrame`, `stagingRing.beginFrame` (fence already waited)  
 9. **ImGui UI build** — `imgui->beginFrame` / `drawUi` / `endFrame` (CPU only; draw later)  

--- a/docs/vulkan-graphics.md
+++ b/docs/vulkan-graphics.md
@@ -22,7 +22,13 @@ For engine loop, streaming, and world generation, see [`engine-architecture.md`]
 | Passes | Shadow → opaque (+ overlays) → water → sky → post | `Renderer/*Pass*`, `PostStack`, `OverlayRenderer` |
 | Shaders | GLSL → SPIR-V offline | `ressources/shaders/vulkan/` |
 
-**API target:** Vulkan **1.2+**, dynamic rendering preferred. On Apple, **MoltenVK** via ICD (`VK_ICD_FILENAMES`). Depth is **zero-to-one** (`GLM_FORCE_DEPTH_ZERO_TO_ONE`); viewport Y may be flipped for OpenGL-style world Y without winding flip.
+**API target:** Vulkan **1.2+**, with required dynamic rendering provided by
+`VK_KHR_dynamic_rendering` on Vulkan 1.2 or by the core API on Vulkan 1.3+.
+The selected path is based on the application API target as well as the device
+version, and its entry points are validated immediately after loading the
+device. On Apple, **MoltenVK** is selected via ICD (`VK_ICD_FILENAMES`). Depth
+is **zero-to-one** (`GLM_FORCE_DEPTH_ZERO_TO_ONE`); viewport Y may be flipped
+for OpenGL-style world Y without winding flip.
 
 **Rendering model:** Forward-style world passes into **HDR + depth** (and god-ray source), then fullscreen post to the swapchain. No deferred G-buffer.
 

--- a/docs/vulkan-graphics.md
+++ b/docs/vulkan-graphics.md
@@ -54,6 +54,12 @@ Supporting types:
 
 `WorldRenderer` does **not** own WSI sync. The `Engine` calls `VkFrameContext::beginFrame` / `submitAndPresent` and passes a reset command buffer into `WorldRenderer::recordFrame`.
 
+Resize, VSync, and out-of-date requests are deferred to the next pre-acquire
+frame boundary. `Engine` recreates the swapchain there, resets
+`VkFrameContext`'s per-image associations, refreshes `WorldRenderer` targets,
+and notifies ImGui. No UI callback destroys WSI resources for an image already
+acquired by the current frame.
+
 ### Present mode and VSync contract
 
 `VkSwapchain` applies a strict two-mode policy:

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -243,8 +243,13 @@ void Engine::initializeNoiseGenerator(int seed_val)
 void Engine::setVSync(bool enabled)
 {
 	renderSettings.vsyncEnabled = enabled;
-	if (swapchain)
-		swapchain->setVSync(enabled);
+	if (!swapchain || (swapchain->isVSync() == enabled && !m_pendingVSync))
+		return;
+
+	// UI is built after beginFrame() acquired an image. Defer the mode change so
+	// the old swapchain remains alive through record/submit/present.
+	m_pendingVSync = enabled;
+	requestSwapchainRecreate();
 }
 
 Engine::ResourcePackApplyResult Engine::applyResourcePack(const std::string &resourcePackRoot)
@@ -378,7 +383,38 @@ void Engine::onResize(int width, int height)
 		return;
 	windowWidth = width;
 	windowHeight = height;
-	framebufferResized = true;
+	requestSwapchainRecreate();
+}
+
+void Engine::requestSwapchainRecreate()
+{
+	m_swapchainRecreateRequested = true;
+}
+
+void Engine::recreateSwapchainIfNeeded(uint32_t width, uint32_t height)
+{
+	if (!swapchain || width == 0 || height == 0)
+		return;
+
+	const bool desiredVSync = m_pendingVSync.value_or(swapchain->isVSync());
+	const VkExtent2D extent = swapchain->getExtent();
+	if (!m_swapchainRecreateRequested && desiredVSync == swapchain->isVSync() &&
+		extent.width == width && extent.height == height)
+		return;
+
+	PROFILE_SCOPE("SwapchainRecreate");
+	// VkSwapchain::recreate waits for the device before destroying WSI state.
+	// Every swapchain consumer is refreshed before the next image acquisition.
+	swapchain->recreate(width, height, desiredVSync);
+	frameCtx->onSwapchainRecreate(swapchain->getImageCount());
+	worldRenderer->onSwapchainRecreate(*swapchain);
+	if (imgui && imgui->onSwapchainRecreate(*swapchain) && gameUi)
+		gameUi->onImGuiVulkanBackendRecreate();
+
+	windowWidth = static_cast<int>(swapchain->getExtent().width);
+	windowHeight = static_cast<int>(swapchain->getExtent().height);
+	m_pendingVSync.reset();
+	m_swapchainRecreateRequested = false;
 }
 
 void Engine::tickDayCycle(double dt)
@@ -660,12 +696,15 @@ void Engine::tickBenchmark(double dt)
 	if (m_benchmark.phase() == BenchmarkPhase::Reloading)
 	{
 		const BenchmarkConfig &cfg = m_benchmark.config();
-		if (cfg.forceVsyncOff)
+		if (cfg.forceVsyncOff && renderSettings.vsyncEnabled)
 		{
-			m_benchmark.markForceVsync(renderSettings.vsyncEnabled);
-			if (renderSettings.vsyncEnabled)
-				setVSync(false);
+			m_benchmark.markForceVsync(true);
+			setVSync(false);
 		}
+		// Let the main loop apply a requested mode at its pre-acquire boundary.
+		// The benchmark snapshot must describe the swapchain it actually measures.
+		if (m_pendingVSync)
+			return;
 		m_benchmark.setSettingsSnapshot(
 			renderSettings.maxRenderDistance, windowWidth, windowHeight,
 			renderSettings.vsyncEnabled,
@@ -862,24 +901,15 @@ void Engine::run()
 			continue;
 		}
 
-		if (framebufferResized ||
-			static_cast<uint32_t>(pixelW) != swapchain->getExtent().width ||
-			static_cast<uint32_t>(pixelH) != swapchain->getExtent().height)
-		{
-			PROFILE_SCOPE("Resize");
-			swapchain->recreate(static_cast<uint32_t>(pixelW), static_cast<uint32_t>(pixelH));
-			worldRenderer->onSwapchainRecreate(*swapchain);
-			windowWidth = pixelW;
-			windowHeight = pixelH;
-			framebufferResized = false;
-		}
+		recreateSwapchainIfNeeded(static_cast<uint32_t>(pixelW),
+								  static_cast<uint32_t>(pixelH));
 
 		uint32_t imageIndex = 0;
 		{
 			PROFILE_SCOPE("Acquire");
 			if (!frameCtx->beginFrame(*swapchain, imageIndex))
 			{
-				framebufferResized = true;
+				requestSwapchainRecreate();
 				GetProfiler().endFrame();
 				continue;
 			}
@@ -956,7 +986,7 @@ void Engine::run()
 		{
 			PROFILE_SCOPE("Present");
 			if (!frameCtx->submitAndPresent(*swapchain, imageIndex))
-				framebufferResized = true;
+				requestSwapchainRecreate();
 		}
 
 		++frameNumber;

--- a/src/Engine/Engine.hpp
+++ b/src/Engine/Engine.hpp
@@ -3,6 +3,7 @@
 #include <SDL3/SDL.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 #include <cstdint>
@@ -67,6 +68,8 @@ public:
 private:
 	void handleEvents();
 	void onResize(int width, int height);
+	void requestSwapchainRecreate();
+	void recreateSwapchainIfNeeded(uint32_t width, uint32_t height);
 	void tickStreaming(double dt);
 	void tickDayCycle(double dt);
 	void processInput(double dt);
@@ -83,7 +86,8 @@ private:
 
 	bool running{false};
 	bool mouseCaptured{true};
-	bool framebufferResized{false};
+	bool m_swapchainRecreateRequested{false};
+	std::optional<bool> m_pendingVSync;
 	bool showChunkBorders{false};
 	bool showDemoPlayers{true};
 	bool paused{false};

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -108,6 +108,17 @@ void GameUI::shutdown()
 	m_imm = nullptr;
 }
 
+void GameUI::onImGuiVulkanBackendRecreate()
+{
+	// The old descriptor belonged to the backend pool destroyed during reinit.
+	// The sampled image and sampler are application-owned and remain valid.
+	m_mapDesc = VK_NULL_HANDLE;
+	if (m_mapSampler != VK_NULL_HANDLE && m_mapImage.image != VK_NULL_HANDLE)
+		m_mapDesc = ImGui_ImplVulkan_AddTexture(
+			m_mapSampler, m_mapImage.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+	m_mapHasTexture = (m_mapDesc != VK_NULL_HANDLE);
+}
+
 bool GameUI::handleShortcut(int sdlKeycode, GameUIFrame &frame)
 {
 	switch (sdlKeycode)

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -83,6 +83,8 @@ public:
 
 	void init(VkContext &context, ImmediateCommands &imm);
 	void shutdown();
+	/// Re-register UI textures after the ImGui Vulkan descriptor pool changes.
+	void onImGuiVulkanBackendRecreate();
 
 	/// Draw all panels. Call between ImGui beginFrame / endFrame.
 	void draw(GameUIFrame &frame);

--- a/src/Engine/ImGuiLayer.cpp
+++ b/src/Engine/ImGuiLayer.cpp
@@ -38,6 +38,7 @@ void ImGuiLayer::init(SDL_Window *window, VkContext &context, VkSwapchain &swapc
 		return;
 
 	m_device = context.getDevice();
+	m_context = &context;
 
 	IMGUI_CHECKVERSION();
 	ImGui::CreateContext();
@@ -51,6 +52,16 @@ void ImGuiLayer::init(SDL_Window *window, VkContext &context, VkSwapchain &swapc
 
 	if (!ImGui_ImplSDL3_InitForVulkan(window))
 		throw std::runtime_error("ImGui_ImplSDL3_InitForVulkan failed");
+	m_initialized = true;
+	(void)imm;
+	initVulkanBackend(context, swapchain);
+}
+
+void ImGuiLayer::initVulkanBackend(VkContext &context, VkSwapchain &swapchain)
+{
+	const uint32_t imageCount = std::max(2u, swapchain.getImageCount());
+	const uint32_t minImageCount =
+		std::min(imageCount, std::max(2u, swapchain.getMinImageCount()));
 
 	ImGui_ImplVulkan_InitInfo initInfo{};
 	initInfo.ApiVersion = VK_API_VERSION_1_2;
@@ -61,8 +72,8 @@ void ImGuiLayer::init(SDL_Window *window, VkContext &context, VkSwapchain &swapc
 	initInfo.Queue = context.getGraphicsQueue();
 	initInfo.DescriptorPool = VK_NULL_HANDLE;
 	initInfo.DescriptorPoolSize = 64; // let backend create pool
-	initInfo.MinImageCount = 2;
-	initInfo.ImageCount = std::max(2u, swapchain.getImageCount());
+	initInfo.MinImageCount = minImageCount;
+	initInfo.ImageCount = imageCount;
 	initInfo.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
 	initInfo.PipelineCache = VK_NULL_HANDLE;
 	initInfo.Subpass = 0;
@@ -84,34 +95,59 @@ void ImGuiLayer::init(SDL_Window *window, VkContext &context, VkSwapchain &swapc
 
 	if (!ImGui_ImplVulkan_Init(&initInfo))
 		throw std::runtime_error("ImGui_ImplVulkan_Init failed");
+	m_vulkanInitialized = true;
 
-	// Font upload via one-shot commands
-	imm.submitAndWait([&](VkCommandBuffer cmd) {
-		// CreateFontsTexture may queue uploads using internal helpers in some versions;
-		// 1.91.9 creates device objects that are ready after first NewFrame if DescriptorPoolSize is set.
-		(void)cmd;
-	});
 	ImGui_ImplVulkan_CreateFontsTexture();
 
 	// Destroy staging objects if the API provides it (present in 1.91.x)
 	// After create, some versions require a submit — CreateFontsTexture already uses host-visible
 	// uploads in recent backends. If not, first frame still works once font atlas is ready.
 
-	m_initialized = true;
+	m_colorFormat = swapchain.getImageFormat();
+	m_swapchainImageCount = swapchain.getImageCount();
+	m_minImageCount = swapchain.getMinImageCount();
+}
+
+bool ImGuiLayer::onSwapchainRecreate(VkSwapchain &swapchain)
+{
+	if (!m_initialized || !m_vulkanInitialized || !m_context)
+		return false;
+
+	if (m_colorFormat == swapchain.getImageFormat() &&
+		m_swapchainImageCount == swapchain.getImageCount() &&
+		m_minImageCount == swapchain.getMinImageCount())
+		return false;
+
+	// ImageCount is immutable in the backend init info, and a dynamic-rendering
+	// pipeline is tied to its color format. Reinitialize the renderer backend for
+	// either change while preserving the ImGui context and SDL platform backend.
+	ImGui_ImplVulkan_Shutdown();
+	m_vulkanInitialized = false;
+	initVulkanBackend(*m_context, swapchain);
+	return true;
 }
 
 void ImGuiLayer::shutdown()
 {
-	if (!m_initialized)
+	if (!m_initialized && !m_vulkanInitialized)
 		return;
 	if (m_device != VK_NULL_HANDLE)
 		vkDeviceWaitIdle(m_device);
 
-	ImGui_ImplVulkan_Shutdown();
-	ImGui_ImplSDL3_Shutdown();
-	ImGui::DestroyContext();
+	if (m_vulkanInitialized)
+		ImGui_ImplVulkan_Shutdown();
+	if (m_initialized)
+	{
+		ImGui_ImplSDL3_Shutdown();
+		ImGui::DestroyContext();
+	}
+	m_vulkanInitialized = false;
 	m_initialized = false;
 	m_device = VK_NULL_HANDLE;
+	m_context = nullptr;
+	m_colorFormat = VK_FORMAT_UNDEFINED;
+	m_swapchainImageCount = 0;
+	m_minImageCount = 0;
 }
 
 void ImGuiLayer::processEvent(const SDL_Event &event)

--- a/src/Engine/ImGuiLayer.hpp
+++ b/src/Engine/ImGuiLayer.hpp
@@ -15,6 +15,9 @@ public:
 
 	void init(SDL_Window *window, VkContext &context, VkSwapchain &swapchain, ImmediateCommands &imm);
 	void shutdown();
+	/// Refresh renderer-backend state after Engine recreates the swapchain.
+	/// Returns true if backend-owned descriptors were invalidated by reinit.
+	bool onSwapchainRecreate(VkSwapchain &swapchain);
 
 	void processEvent(const SDL_Event &event);
 	void beginFrame();
@@ -27,6 +30,13 @@ public:
 	bool wantCaptureMouse() const;
 
 private:
+	void initVulkanBackend(VkContext &context, VkSwapchain &swapchain);
+
 	bool m_initialized{false};
+	bool m_vulkanInitialized{false};
 	VkDevice m_device{VK_NULL_HANDLE};
+	VkContext *m_context{nullptr};
+	VkFormat m_colorFormat{VK_FORMAT_UNDEFINED};
+	uint32_t m_swapchainImageCount{0};
+	uint32_t m_minImageCount{0};
 };

--- a/src/Vulkan/VkContext.cpp
+++ b/src/Vulkan/VkContext.cpp
@@ -86,6 +86,12 @@ void VkContext::init(SDL_Window *window)
 	pickPhysicalDevice();
 	createLogicalDevice();
 	volkLoadDevice(m_device);
+	if ((!vkCmdBeginRendering && !vkCmdBeginRenderingKHR) ||
+		(!vkCmdEndRendering && !vkCmdEndRenderingKHR))
+	{
+		throw std::runtime_error(
+			"Dynamic rendering was enabled, but its Vulkan entry points could not be loaded");
+	}
 	createAllocator();
 
 	std::cout << "Vulkan device: " << m_deviceProperties.deviceName << "\n";
@@ -334,6 +340,8 @@ QueueFamilyIndices VkContext::findQueueFamilies(VkPhysicalDevice device) const
 std::vector<const char *> VkContext::getRequiredDeviceExtensions() const
 {
 	std::vector<const char *> exts = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+	if (kApiVersion < VK_API_VERSION_1_3)
+		exts.push_back(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
 #if defined(__APPLE__)
 	exts.push_back("VK_KHR_portability_subset");
 #endif
@@ -432,13 +440,17 @@ void VkContext::createLogicalDevice()
 
 	std::vector<const char *> deviceExtensions = getRequiredDeviceExtensions();
 
-	// Dynamic rendering: core 1.3 or KHR extension
+	// Dynamic rendering is core only when both the application and device use
+	// Vulkan 1.3+. A newer device version cannot promote commands for an instance
+	// created with the engine's Vulkan 1.2 API target.
 	const bool dynRenderExt = hasExt(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-	const bool dynRenderCore = m_deviceProperties.apiVersion >= VK_API_VERSION_1_3;
+	const bool dynRenderCore =
+		kApiVersion >= VK_API_VERSION_1_3 &&
+		m_deviceProperties.apiVersion >= VK_API_VERSION_1_3;
 	m_dynamicRendering = dynRenderCore || dynRenderExt;
-	if (!dynRenderCore && dynRenderExt)
-		deviceExtensions.push_back(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-
+	if (!m_dynamicRendering)
+		throw std::runtime_error(
+			"Selected Vulkan device lacks dynamic rendering (requires Vulkan 1.3 or VK_KHR_dynamic_rendering)");
 	// Timeline semaphores: core 1.2
 	m_timelineSemaphores = true;
 
@@ -477,9 +489,11 @@ void VkContext::createLogicalDevice()
 
 	if (m_dynamicRendering)
 	{
-		dynFeatures.dynamicRendering =
-			(availableDyn.dynamicRendering == VK_TRUE || dynRenderCore) ? VK_TRUE : VK_FALSE;
+		dynFeatures.dynamicRendering = availableDyn.dynamicRendering;
 		m_dynamicRendering = dynFeatures.dynamicRendering == VK_TRUE;
+		if (!m_dynamicRendering)
+			throw std::runtime_error(
+				"Selected Vulkan device exposes dynamic rendering but not its required feature");
 	}
 
 	// Only request features the device actually has

--- a/src/Vulkan/VkFrame.cpp
+++ b/src/Vulkan/VkFrame.cpp
@@ -99,6 +99,14 @@ void VkFrameContext::ensureSwapchainImageSync(uint32_t imageCount)
 	}
 }
 
+void VkFrameContext::onSwapchainRecreate(uint32_t imageCount)
+{
+	// Engine recreation has already waited for the device. Fence handles remain
+	// valid, but their association with images from the old swapchain does not.
+	m_imagesInFlight.assign(imageCount, VK_NULL_HANDLE);
+	ensureSwapchainImageSync(imageCount);
+}
+
 bool VkFrameContext::beginFrame(VkSwapchain &swapchain, uint32_t &outImageIndex)
 {
 	VkDevice device = m_context->getDevice();

--- a/src/Vulkan/VkFrame.hpp
+++ b/src/Vulkan/VkFrame.hpp
@@ -22,6 +22,8 @@ public:
 
 	void init(VkContext &context);
 	void shutdown();
+	/// Reset per-image ownership after a swapchain has been recreated.
+	void onSwapchainRecreate(uint32_t imageCount);
 
 	/// Wait on in-flight fence, acquire swapchain image, reset command buffer.
 	/// Returns false if the swapchain is out of date (caller should recreate).

--- a/src/Vulkan/VkSwapchain.cpp
+++ b/src/Vulkan/VkSwapchain.cpp
@@ -49,26 +49,25 @@ void VkSwapchain::shutdown()
 
 void VkSwapchain::recreate(uint32_t width, uint32_t height)
 {
-	if (!m_context || width == 0 || height == 0)
-		return;
-	m_context->waitIdle();
-	cleanupSwapchain();
-	createSwapchain(width, height);
-	createImageViews();
+	recreate(width, height, m_vsync);
 }
 
-void VkSwapchain::setVSync(bool enabled)
+void VkSwapchain::recreate(uint32_t width, uint32_t height, bool vsync)
 {
-	if (m_vsync == enabled || !m_context)
+	if (!m_context || width == 0 || height == 0)
 		return;
 
-	// Validate the strict target before destroying the working swapchain.
+	// Reject an unavailable strict present mode before destroying the working
+	// swapchain. The Engine invokes this only at a pre-acquire frame boundary.
 	const auto support =
 		querySupport(m_context->getPhysicalDevice(), m_context->getSurface());
-	selectPresentMode(support.presentModes, enabled);
+	selectPresentMode(support.presentModes, vsync);
 
-	m_vsync = enabled;
-	recreate(m_extent.width, m_extent.height);
+	m_context->waitIdle();
+	cleanupSwapchain();
+	m_vsync = vsync;
+	createSwapchain(width, height);
+	createImageViews();
 }
 
 void VkSwapchain::cleanupSwapchain()
@@ -201,6 +200,7 @@ void VkSwapchain::createSwapchain(uint32_t width, uint32_t height)
 
 	m_imageFormat = surfaceFormat.format;
 	m_extent = extent;
+	m_minImageCount = createInfo.minImageCount;
 	m_presentMode = presentMode;
 
 	std::cout << "Swapchain present mode: " << presentModeName(m_presentMode)

--- a/src/Vulkan/VkSwapchain.hpp
+++ b/src/Vulkan/VkSwapchain.hpp
@@ -24,16 +24,17 @@ public:
 
 	void init(VkContext &context, uint32_t width, uint32_t height, bool vsync = true);
 	void recreate(uint32_t width, uint32_t height);
+	void recreate(uint32_t width, uint32_t height, bool vsync);
 	void shutdown();
 
 	VkSwapchainKHR getSwapchain() const { return m_swapchain; }
 	VkFormat getImageFormat() const { return m_imageFormat; }
 	VkExtent2D getExtent() const { return m_extent; }
 	uint32_t getImageCount() const { return static_cast<uint32_t>(m_images.size()); }
+	uint32_t getMinImageCount() const { return m_minImageCount; }
 	const std::vector<VkImage> &getImages() const { return m_images; }
 	const std::vector<VkImageView> &getImageViews() const { return m_imageViews; }
 
-	void setVSync(bool enabled);
 	bool isVSync() const { return m_vsync; }
 	VkPresentModeKHR getPresentMode() const { return m_presentMode; }
 
@@ -60,6 +61,7 @@ private:
 	std::vector<VkImageView> m_imageViews;
 	VkFormat m_imageFormat{VK_FORMAT_UNDEFINED};
 	VkExtent2D m_extent{};
+	uint32_t m_minImageCount{0};
 	bool m_vsync{true};
 	VkPresentModeKHR m_presentMode{VK_PRESENT_MODE_FIFO_KHR};
 };

--- a/tests/test_vulkan_resources.cpp
+++ b/tests/test_vulkan_resources.cpp
@@ -112,13 +112,13 @@ int main()
 
 		if (hasMode(VK_PRESENT_MODE_IMMEDIATE_KHR))
 		{
-			swapchain.setVSync(false);
+			swapchain.recreate(64, 64, false);
 			if (swapchain.isVSync() ||
 				swapchain.getPresentMode() != VK_PRESENT_MODE_IMMEDIATE_KHR)
 				throw std::runtime_error(
 					"VSync off did not select strict IMMEDIATE mode");
 
-			swapchain.setVSync(true);
+			swapchain.recreate(64, 64, true);
 			if (!swapchain.isVSync() ||
 				swapchain.getPresentMode() != VK_PRESENT_MODE_FIFO_KHR)
 				throw std::runtime_error(

--- a/tests/test_vulkan_resources.cpp
+++ b/tests/test_vulkan_resources.cpp
@@ -70,6 +70,14 @@ int main()
 	{
 		VkContext context;
 		context.init(window);
+		if (!context.hasDynamicRendering() ||
+			((!vkCmdBeginRendering && !vkCmdBeginRenderingKHR) ||
+			 (!vkCmdEndRendering && !vkCmdEndRenderingKHR)))
+		{
+			throw std::runtime_error(
+				"dynamic rendering feature or entry points unavailable");
+		}
+		std::cout << "PASS: dynamic rendering feature + entry points\n";
 
 		const SwapchainSupportDetails support = VkSwapchain::querySupport(
 			context.getPhysicalDevice(), context.getSurface());


### PR DESCRIPTION
Centralize resize, VSync, and WSI invalidation handling in Engine so every swapchain recreation happens before image acquisition. VSync requests from F10, ImGui, command-line setup, and benchmarks now update the desired state without destroying resources belonging to an active frame.

Refresh VkFrameContext per-image fence associations and render-finished semaphores after recreation, then rebuild WorldRenderer swapchain-dependent targets before recording the next frame. Track the requested and actual swapchain image counts so changes remain synchronized.

Notify ImGui explicitly after every recreation. Reinitialize its Vulkan backend when the surface format or image-count contract changes, and re-register the GameUI biome-map texture when the backend descriptor pool is replaced.

Keep benchmark metadata consistent by waiting for deferred VSync changes before capturing the measured present mode. Update the Vulkan smoke toggle path and architecture documentation for the centralized lifecycle.

Validation: modified C++ translation units compile; the Vulkan smoke test source compiles; five non-Vulkan CTest targets pass. Full Vulkan runtime validation remains pending on suitable hardware.

Closes #73