### PR TITLE
fix(vulkan/ui): remove synchronous submitAndWait from biome-map texture updates

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -980,22 +980,29 @@ void Engine::run()
 			worldRenderer->recordFrame(
 				frameCtx->commandBuffer(), frameIndex, imageIndex, *swapchain, drawList, shadowList, clearColor,
 				[&](VkCommandBuffer cmd) {
-					PROFILE_SCOPE("MeshUpload");
-					if (!chunkManager || uploadBudget <= 0 || paused)
-						return;
-					const int n = chunkManager->uploadPendingMeshes(
-						vkContext->getAllocator(), stagingRing, cmd, resourceRetire, camera, uploadBudget);
-					if (n <= 0)
-						return;
-					// Make staged mesh data visible to vertex/index fetch in later passes.
-					VkMemoryBarrier barrier{};
-					barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-					barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-					barrier.dstAccessMask =
-						VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT;
-					vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
-										 VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 1, &barrier, 0, nullptr,
-										 0, nullptr);
+					if (chunkManager && uploadBudget > 0 && !paused)
+					{
+						PROFILE_SCOPE("MeshUpload");
+						const int n = chunkManager->uploadPendingMeshes(
+							vkContext->getAllocator(), stagingRing, cmd, resourceRetire, camera, uploadBudget);
+						if (n > 0)
+						{
+							// Make staged mesh data visible to vertex/index fetch in later passes.
+							VkMemoryBarrier barrier{};
+							barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+							barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+							barrier.dstAccessMask =
+								VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT;
+							vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+												 VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 1, &barrier, 0, nullptr,
+												 0, nullptr);
+						}
+					}
+					if (gameUi && gameUi->hasPendingBiomeMapUpload())
+					{
+						PROFILE_SCOPE("BiomeMapUpload");
+						gameUi->recordPendingBiomeMapUpload(cmd, stagingRing);
+					}
 				},
 				[&](VkCommandBuffer cmd) {
 					if (imgui)

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -1,6 +1,7 @@
 #include "Engine/GameUI.hpp"
 
 #include <Engine/Profiler.hpp>
+#include <Vulkan/StagingRing.hpp>
 #include <imgui/imgui.h>
 #include <imgui/imgui_impl_vulkan.h>
 #include <SDL3/SDL.h>
@@ -55,6 +56,7 @@ void GameUI::shutdown()
 		m_mapJob.future.wait();
 
 	m_mapJob.reset();
+	m_pendingUpload = {};
 
 	if (m_vk && m_vk->getDevice() != VK_NULL_HANDLE)
 	{
@@ -74,6 +76,7 @@ void GameUI::shutdown()
 	}
 	m_mapHasTexture = false;
 	m_mapImageSize = 0;
+	m_mapImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 	m_vk = nullptr;
 	m_imm = nullptr;
 }
@@ -87,6 +90,7 @@ void GameUI::invalidateBiomeMap()
 	// but is marked inactive so the UI will not display stale world terrain.
 	// It will be updated in-place when the next valid map completes.
 	m_mapHasTexture = false;
+	m_pendingUpload = {};
 }
 
 void GameUI::onImGuiVulkanBackendRecreate()
@@ -1146,7 +1150,7 @@ void GameUI::drawOverlayHints(GameUIFrame &frame)
 
 void GameUI::ensureBiomeTexture(int size)
 {
-	if (!m_vk || !m_imm)
+	if (!m_vk)
 		return;
 	if (canReuseBiomeTexture(m_mapImage.image != VK_NULL_HANDLE,
 							 m_mapDesc != VK_NULL_HANDLE,
@@ -1156,7 +1160,9 @@ void GameUI::ensureBiomeTexture(int size)
 		return;
 	}
 
-	m_vk->waitIdle();
+	if (m_mapImage.image != VK_NULL_HANDLE)
+		m_vk->waitIdle();
+
 	if (m_mapDesc != VK_NULL_HANDLE)
 	{
 		ImGui_ImplVulkan_RemoveTexture(m_mapDesc);
@@ -1183,29 +1189,53 @@ void GameUI::ensureBiomeTexture(int size)
 	m_mapDesc = ImGui_ImplVulkan_AddTexture(m_mapSampler, m_mapImage.view,
 											VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 	m_mapImageSize = size;
+	m_mapImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 }
 
-void GameUI::uploadBiomeTexture(const std::vector<unsigned char> &rgb, int size)
+void GameUI::recordPendingBiomeMapUpload(VkCommandBuffer cmd, StagingRing &stagingRing)
 {
-	if (!m_vk || !m_imm || rgb.size() < static_cast<size_t>(size * size * 3))
+	if (m_pendingUpload.rgba.empty() || m_mapImage.image == VK_NULL_HANDLE)
 		return;
 
-	ensureBiomeTexture(size);
-	if (m_mapImage.image == VK_NULL_HANDLE || m_mapDesc == VK_NULL_HANDLE)
-		return;
-
-	// Expand RGB → RGBA for R8G8B8A8.
-	std::vector<unsigned char> rgba(static_cast<size_t>(size * size * 4));
-	for (int i = 0; i < size * size; ++i)
+	const VkDeviceSize dataSize = m_pendingUpload.rgba.size() * sizeof(uint8_t);
+	VkDeviceSize stagingOffset = 0;
+	void *stagingPtr = nullptr;
+	if (!stagingRing.alloc(dataSize, stagingOffset, stagingPtr))
 	{
-		rgba[i * 4 + 0] = rgb[i * 3 + 0];
-		rgba[i * 4 + 1] = rgb[i * 3 + 1];
-		rgba[i * 4 + 2] = rgb[i * 3 + 2];
-		rgba[i * 4 + 3] = 255;
+		// Slice was full this frame; defer upload to next frame.
+		return;
 	}
 
-	uploadImage2D(m_vk->getAllocator(), *m_imm, m_mapImage, rgba.data(),
-				  rgba.size() * sizeof(unsigned char));
+	std::memcpy(stagingPtr, m_pendingUpload.rgba.data(), dataSize);
+
+	cmdTransitionImageLayout(cmd, m_mapImage.image, m_mapImageLayout,
+							 VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_ASPECT_COLOR_BIT,
+							 m_mapImage.mipLevels, m_mapImage.arrayLayers);
+
+	VkBufferImageCopy region{};
+	region.bufferOffset = stagingOffset;
+	region.bufferRowLength = 0;
+	region.bufferImageHeight = 0;
+	region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	region.imageSubresource.mipLevel = 0;
+	region.imageSubresource.baseArrayLayer = 0;
+	region.imageSubresource.layerCount = 1;
+	region.imageOffset = {0, 0, 0};
+	region.imageExtent = {m_pendingUpload.width, m_pendingUpload.height, 1};
+
+	vkCmdCopyBufferToImage(cmd, stagingRing.buffer(), m_mapImage.image,
+						   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+	cmdTransitionImageLayout(cmd, m_mapImage.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+							 VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_ASPECT_COLOR_BIT,
+							 m_mapImage.mipLevels, m_mapImage.arrayLayers);
+
+	m_mapImageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+	m_mapHasTexture = true;
+	m_pendingUpload.rgba.clear();
+	m_pendingUpload.width = 0;
+	m_pendingUpload.height = 0;
+	m_pendingUpload.generation = 0;
 }
 
 void GameUI::tickBiomeMap(GameUIFrame &frame)
@@ -1241,10 +1271,15 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 
 		if (isBiomeMapResultAcceptable(res, frame.worldGenerationId, frame.seed, m_mapRequestId))
 		{
-			paintBiomeMapPlayerDot(res.rgb, res.size, playerXZ, res.zoom, res.gridX, res.gridZ);
+			paintBiomeMapPlayerDot(res.rgba, res.size, playerXZ, res.zoom, res.gridX, res.gridZ);
 			m_mapCenter = res.center;
-			uploadBiomeTexture(res.rgb, res.size);
-			m_mapHasTexture = true;
+			ensureBiomeTexture(res.size);
+			m_pendingUpload = BiomeMapUpload{
+				.rgba = std::move(res.rgba),
+				.width = static_cast<uint32_t>(res.size),
+				.height = static_cast<uint32_t>(res.size),
+				.generation = res.requestId
+			};
 			m_mapLastPublishedAt = now;
 		}
 		else

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -1197,6 +1197,13 @@ void GameUI::recordPendingBiomeMapUpload(VkCommandBuffer cmd, StagingRing &stagi
 	if (m_pendingUpload.rgba.empty() || m_mapImage.image == VK_NULL_HANDLE)
 		return;
 
+	// Drop deferred uploads that have been superseded
+	if (m_pendingUpload.requestId != m_mapRequestId)
+	{
+		m_pendingUpload = {};
+		return;
+	}
+
 	const VkDeviceSize dataSize = m_pendingUpload.rgba.size() * sizeof(uint8_t);
 	VkDeviceSize stagingOffset = 0;
 	void *stagingPtr = nullptr;
@@ -1232,10 +1239,11 @@ void GameUI::recordPendingBiomeMapUpload(VkCommandBuffer cmd, StagingRing &stagi
 
 	m_mapImageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 	m_mapHasTexture = true;
+	m_mapLastPublishedAt = SDL_GetTicks() / 1000.0;
 	m_pendingUpload.rgba.clear();
 	m_pendingUpload.width = 0;
 	m_pendingUpload.height = 0;
-	m_pendingUpload.generation = 0;
+	m_pendingUpload.requestId = 0;
 }
 
 void GameUI::tickBiomeMap(GameUIFrame &frame)
@@ -1278,9 +1286,8 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 				.rgba = std::move(res.rgba),
 				.width = static_cast<uint32_t>(res.size),
 				.height = static_cast<uint32_t>(res.size),
-				.generation = res.requestId
+				.requestId = res.requestId
 			};
-			m_mapLastPublishedAt = now;
 		}
 		else
 		{
@@ -1290,7 +1297,7 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 		}
 	}
 
-	const bool running = m_mapJob.isRunning();
+	const bool running = m_mapJob.isRunning() || hasPendingBiomeMapUpload();
 
 	// Periodic refresh triggered ONLY when no job is currently running
 	const bool timeElapsed = (now - m_mapLastPublishedAt) >= 1.0;

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -22,6 +22,8 @@
 
 #include <Engine/GameUIBiomeMap.hpp>
 
+class StagingRing;
+
 /// Frame snapshot for ImGui panels (pointers owned by Engine).
 struct GameUIFrame
 {
@@ -115,6 +117,10 @@ public:
 	uint64_t currentWorldGenId() const { return m_currentWorldGenId; }
 	uint64_t currentMapRequestId() const { return m_mapRequestId; }
 
+	bool hasPendingBiomeMapUpload() const { return !m_pendingUpload.rgba.empty(); }
+	const BiomeMapUpload &pendingBiomeMapUpload() const { return m_pendingUpload; }
+	void recordPendingBiomeMapUpload(VkCommandBuffer cmd, StagingRing &stagingRing);
+
 private:
 	struct BiomeMapJob
 	{
@@ -171,7 +177,6 @@ private:
 
 	void tickBiomeMap(GameUIFrame &frame);
 	void ensureBiomeTexture(int size);
-	void uploadBiomeTexture(const std::vector<unsigned char> &rgb, int size);
 
 	bool m_showHud{true};
 	bool m_showGraphics{false};
@@ -194,10 +199,12 @@ private:
 	uint64_t m_mapRequestId{0};
 
 	BiomeMapJob m_mapJob{};
+	BiomeMapUpload m_pendingUpload{};
 
 	VkContext *m_vk{nullptr};
 	ImmediateCommands *m_imm{nullptr};
 	AllocatedImage m_mapImage{};
+	VkImageLayout m_mapImageLayout{VK_IMAGE_LAYOUT_UNDEFINED};
 	VkSampler m_mapSampler{VK_NULL_HANDLE};
 	VkDescriptorSet m_mapDesc{VK_NULL_HANDLE};
 	int m_mapImageSize{0};

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -172,6 +172,7 @@ private:
 		if (m_mapJob.cancel)
 			m_mapJob.cancel->store(true, std::memory_order_relaxed);
 
+		m_pendingUpload = {};
 		m_mapNeedsUpdate = true;
 	}
 

--- a/src/Engine/GameUIBiomeMap.cpp
+++ b/src/Engine/GameUIBiomeMap.cpp
@@ -3,7 +3,7 @@
 
 #include <cmath>
 
-void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgb,
+void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
 						   int size,
 						   glm::vec2 playerXZ,
 						   float zoom,
@@ -16,12 +16,13 @@ void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgb,
 	auto paint = [&](int px, int py, unsigned char r, unsigned char g, unsigned char b) {
 		if (px < 0 || py < 0 || px >= size || py >= size)
 			return;
-		const int idx = (py * size + px) * 3;
-		if (static_cast<size_t>(idx + 2) < rgb.size())
+		const int idx = (py * size + px) * 4;
+		if (static_cast<size_t>(idx + 3) < rgba.size())
 		{
-			rgb[idx + 0] = r;
-			rgb[idx + 1] = g;
-			rgb[idx + 2] = b;
+			rgba[idx + 0] = r;
+			rgba[idx + 1] = g;
+			rgba[idx + 2] = b;
+			rgba[idx + 3] = 255;
 		}
 	};
 	for (int dy = -4; dy <= 4; ++dy)
@@ -63,12 +64,12 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 	std::vector<BiomeType> biomes;
 	gen.getBiomeRegion(req.center.x, req.center.y, step, req.size, req.size, biomes);
 
-	// Checkpoint 3: before RGB allocation
+	// Checkpoint 3: before RGBA allocation
 	if (cancelled())
 		return {};
 
 	const size_t totalPixels = static_cast<size_t>(req.size * req.size);
-	std::vector<unsigned char> rgb(totalPixels * 3);
+	std::vector<unsigned char> rgba(totalPixels * 4);
 
 	// Checkpoint 4: conversion loop with periodic check every 1024 iterations
 	constexpr size_t kCheckInterval = 1024;
@@ -79,9 +80,10 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 
 		const int b = static_cast<int>(biomes[i]);
 		const int bi = (b >= 0 && b < BIOME_COUNT) ? b : 0;
-		rgb[i * 3 + 0] = kBiomeColors[bi][0];
-		rgb[i * 3 + 1] = kBiomeColors[bi][1];
-		rgb[i * 3 + 2] = kBiomeColors[bi][2];
+		rgba[i * 4 + 0] = kBiomeColors[bi][0];
+		rgba[i * 4 + 1] = kBiomeColors[bi][1];
+		rgba[i * 4 + 2] = kBiomeColors[bi][2];
+		rgba[i * 4 + 3] = 255;
 	}
 
 	// Checkpoint 5: before publication
@@ -97,7 +99,7 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 	res.gridX = gridX;
 	res.gridZ = gridZ;
 	res.size = req.size;
-	res.rgb = std::move(rgb);
+	res.rgba = std::move(rgba);
 	res.valid = true;
 	return res;
 }

--- a/src/Engine/GameUIBiomeMap.hpp
+++ b/src/Engine/GameUIBiomeMap.hpp
@@ -78,7 +78,7 @@ struct BiomeMapUpload
 	std::vector<uint8_t> rgba;
 	uint32_t width{0};
 	uint32_t height{0};
-	uint64_t generation{0};
+	uint64_t requestId{0};
 };
 
 /// Validate that a biome map upload request contains well-formed pixel data.
@@ -86,6 +86,7 @@ inline bool isBiomeMapUploadValid(const BiomeMapUpload &upload)
 {
 	return upload.width > 0 &&
 		   upload.height > 0 &&
+		   upload.requestId > 0 &&
 		   upload.rgba.size() == static_cast<size_t>(upload.width) * static_cast<size_t>(upload.height) * 4;
 }
 

--- a/src/Engine/GameUIBiomeMap.hpp
+++ b/src/Engine/GameUIBiomeMap.hpp
@@ -68,9 +68,26 @@ struct BiomeMapResult
 	int gridX{0};
 	int gridZ{0};
 	int size{0};
-	std::vector<unsigned char> rgb;
+	std::vector<unsigned char> rgba;
 	bool valid{false};
 };
+
+/// Pending GPU upload request for streamed biome map data.
+struct BiomeMapUpload
+{
+	std::vector<uint8_t> rgba;
+	uint32_t width{0};
+	uint32_t height{0};
+	uint64_t generation{0};
+};
+
+/// Validate that a biome map upload request contains well-formed pixel data.
+inline bool isBiomeMapUploadValid(const BiomeMapUpload &upload)
+{
+	return upload.width > 0 &&
+		   upload.height > 0 &&
+		   upload.rgba.size() == static_cast<size_t>(upload.width) * static_cast<size_t>(upload.height) * 4;
+}
 
 /// Check if a biome map result matches active world generation, seed, request ID,
 /// and internal invariant checks before GPU publication.
@@ -85,7 +102,7 @@ inline bool isBiomeMapResultAcceptable(const BiomeMapResult &result,
 		   result.requestId == currentRequestId &&
 		   result.size > 0 &&
 		   result.zoom > 0.0f &&
-		   result.rgb.size() == static_cast<size_t>(result.size) * static_cast<size_t>(result.size) * 3;
+		   result.rgba.size() == static_cast<size_t>(result.size) * static_cast<size_t>(result.size) * 4;
 }
 
 /// Check whether the existing GPU backing resources can be reused without destruction/recreation.
@@ -108,16 +125,17 @@ inline bool shouldSupersedeBiomeMap(glm::vec2 player,
 	return glm::length(player - lastPlayer) > 8.0f;
 }
 
-/// Paint the player indicator dot (black outline with white center) into the RGB buffer.
-void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgb,
+/// Paint the player indicator dot (black outline with white center) into the RGBA buffer.
+void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
 						   int size,
 						   glm::vec2 playerXZ,
 						   float zoom,
 						   int gridX,
 						   int gridZ);
 
-/// Sample biomes and convert them to an RGB pixel buffer using thread-local generator.
+/// Sample biomes and convert them to an RGBA pixel buffer using thread-local generator.
 /// Fully self-contained: owns its buffers and does not retain raw pointers to Engine state.
 /// Best-effort cancellation prevents obsolete work from being published and skips work
 /// when cancellation is observed before/after biome sampling.
 BiomeMapResult generateBiomeMap(const BiomeMapRequest &req);
+

--- a/src/Vulkan/VkImage.cpp
+++ b/src/Vulkan/VkImage.cpp
@@ -191,6 +191,14 @@ void cmdTransitionImageLayout(VkCommandBuffer cmd,
 		srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
 		dstStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 	}
+	else if (oldLayout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL &&
+			 newLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
+	{
+		barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+		srcStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+		dstStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+	}
 	else if (oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && newLayout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
 	{
 		barrier.srcAccessMask = 0;

--- a/tests/test_biome_map.cpp
+++ b/tests/test_biome_map.cpp
@@ -328,7 +328,7 @@ static void test_biome_map_upload_validation()
 		.rgba = std::vector<uint8_t>(256 * 256 * 4, 128),
 		.width = 256,
 		.height = 256,
-		.generation = 1
+		.requestId = 1
 	};
 	CHECK(isBiomeMapUploadValid(validUpload), "Well-formed 256x256 RGBA upload must be valid");
 
@@ -336,7 +336,7 @@ static void test_biome_map_upload_validation()
 		.rgba = std::vector<uint8_t>(256 * 256 * 3, 128),
 		.width = 256,
 		.height = 256,
-		.generation = 1
+		.requestId = 1
 	};
 	CHECK(!isBiomeMapUploadValid(sizeMismatch), "RGB sized upload must be rejected");
 
@@ -344,9 +344,29 @@ static void test_biome_map_upload_validation()
 		.rgba = std::vector<uint8_t>(16 * 16 * 4, 128),
 		.width = 0,
 		.height = 16,
-		.generation = 1
+		.requestId = 1
 	};
 	CHECK(!isBiomeMapUploadValid(zeroDim), "Zero dimension upload must be rejected");
+}
+
+static void test_deferred_upload_superseded_rejection()
+{
+	uint64_t currentRequestId = 10;
+
+	BiomeMapUpload upload{
+		.rgba = std::vector<uint8_t>(16 * 16 * 4, 255),
+		.width = 16,
+		.height = 16,
+		.requestId = currentRequestId
+	};
+	CHECK(isBiomeMapUploadValid(upload), "Upload matching currentRequestId must be valid");
+
+	// Player movement / zoom / view supersession occurs:
+	++currentRequestId;
+
+	// Stale deferred upload whose requestId no longer matches active request ID must be recognized as superseded
+	CHECK(upload.requestId != currentRequestId,
+		  "Deferred upload requestId must mismatch incremented active request ID");
 }
 
 static void test_player_movement_supersession()
@@ -563,6 +583,7 @@ int main()
 	test_rapid_request_cancellation_sequence();
 	test_player_dot_painting();
 	test_biome_map_upload_validation();
+	test_deferred_upload_superseded_rejection();
 	test_player_movement_supersession();
 	test_biome_texture_reuse_rules();
 	test_slow_job_exceeding_refresh_interval();

--- a/tests/test_biome_map.cpp
+++ b/tests/test_biome_map.cpp
@@ -49,19 +49,20 @@ static void test_biome_map_result_validity()
 	CHECK(res.worldGenerationId == genId, "Result generation ID should match requested");
 	CHECK(res.seed == seed, "Result seed should match requested");
 	CHECK(res.size == size, "Result size should match requested");
-	CHECK(res.rgb.size() == static_cast<size_t>(size * size * 3), "Result RGB size mismatch");
+	CHECK(res.rgba.size() == static_cast<size_t>(size * size * 4), "Result RGBA size mismatch");
 
-	// Verify that pixel colors correspond to known biomes
+	// Verify that pixel colors correspond to known biomes and alpha is 255
 	bool hasNonZeroPixel = false;
-	for (size_t i = 0; i < res.rgb.size(); ++i)
+	bool allAlphaOpaque = true;
+	for (size_t i = 0; i < res.rgba.size(); i += 4)
 	{
-		if (res.rgb[i] != 0)
-		{
+		if (res.rgba[i + 0] != 0 || res.rgba[i + 1] != 0 || res.rgba[i + 2] != 0)
 			hasNonZeroPixel = true;
-			break;
-		}
+		if (res.rgba[i + 3] != 255)
+			allAlphaOpaque = false;
 	}
-	CHECK(hasNonZeroPixel, "RGB map should contain non-zero pixel data");
+	CHECK(hasNonZeroPixel, "RGBA map should contain non-zero pixel data");
+	CHECK(allAlphaOpaque, "RGBA map should have fully opaque alpha (255)");
 }
 
 static void test_deterministic_stale_generation_rejection()
@@ -174,9 +175,9 @@ static void test_deterministic_superseded_request_rejection()
 		  "Negative zoom result must be rejected");
 
 	badResult = currentResult;
-	badResult.rgb.pop_back();
+	badResult.rgba.pop_back();
 	CHECK(!isBiomeMapResultAcceptable(badResult, generation, seed, currentRequestId),
-		  "Truncated RGB buffer result must be rejected");
+		  "Truncated RGBA buffer result must be rejected");
 }
 
 static void test_cancellation_pre_cancelled()
@@ -194,7 +195,7 @@ static void test_cancellation_pre_cancelled()
 	};
 	BiomeMapResult res = generateBiomeMap(req);
 	CHECK(!res.valid, "Pre-cancelled task should return invalid result");
-	CHECK(res.rgb.empty(), "Cancelled task should not allocate RGB buffer");
+	CHECK(res.rgba.empty(), "Cancelled task should not allocate RGBA buffer");
 	CHECK(!isBiomeMapResultAcceptable(res, 1, 42, 1), "Cancelled task result must not be acceptable");
 }
 
@@ -233,7 +234,7 @@ static void test_cancellation_mid_flight()
 
 	BiomeMapResult res = fut.get();
 	CHECK(!res.valid, "Mid-flight cancelled task must return invalid result");
-	CHECK(res.rgb.empty(), "Cancelled task must have empty rgb buffer");
+	CHECK(res.rgba.empty(), "Cancelled task must have empty rgba buffer");
 	CHECK(!isBiomeMapResultAcceptable(res, 1, 42, 2), "Cancelled result must be rejected");
 }
 
@@ -296,7 +297,7 @@ static void test_rapid_request_cancellation_sequence()
 static void test_player_dot_painting()
 {
 	const int size = 32;
-	std::vector<unsigned char> rgb(size * size * 3, 0);
+	std::vector<unsigned char> rgba(size * size * 4, 0);
 
 	const glm::vec2 center{0.f, 0.f};
 	const float zoom = 1.0f;
@@ -304,17 +305,48 @@ static void test_player_dot_painting()
 	const int gridX = static_cast<int>(std::round((center.x + noiseOffset) * zoom - size * 0.5f));
 	const int gridZ = static_cast<int>(std::round((center.y + noiseOffset) * zoom - size * 0.5f));
 
-	paintBiomeMapPlayerDot(rgb, size, center, zoom, gridX, gridZ);
+	paintBiomeMapPlayerDot(rgba, size, center, zoom, gridX, gridZ);
 
-	// Center pixel of the dot should be white (255, 255, 255)
+	// Center pixel of the dot should be white (255, 255, 255, 255)
 	const int dotX = static_cast<int>(std::round((center.x + noiseOffset) * zoom)) - gridX;
 	const int dotY = static_cast<int>(std::round((center.y + noiseOffset) * zoom)) - gridZ;
-	const int centerIdx = (dotY * size + dotX) * 3;
-	CHECK(rgb[centerIdx + 0] == 255 && rgb[centerIdx + 1] == 255 && rgb[centerIdx + 2] == 255,
-		  "Center of player dot should be white");
+	const int centerIdx = (dotY * size + dotX) * 4;
+	CHECK(rgba[centerIdx + 0] == 255 && rgba[centerIdx + 1] == 255 &&
+		  rgba[centerIdx + 2] == 255 && rgba[centerIdx + 3] == 255,
+		  "Center of player dot should be opaque white");
 
 	// Check that painting doesn't crash on out-of-bounds positions
-	paintBiomeMapPlayerDot(rgb, size, {-100000.f, -100000.f}, zoom, gridX, gridZ);
+	paintBiomeMapPlayerDot(rgba, size, {-100000.f, -100000.f}, zoom, gridX, gridZ);
+}
+
+static void test_biome_map_upload_validation()
+{
+	BiomeMapUpload emptyUpload{};
+	CHECK(!isBiomeMapUploadValid(emptyUpload), "Empty upload must be invalid");
+
+	BiomeMapUpload validUpload{
+		.rgba = std::vector<uint8_t>(256 * 256 * 4, 128),
+		.width = 256,
+		.height = 256,
+		.generation = 1
+	};
+	CHECK(isBiomeMapUploadValid(validUpload), "Well-formed 256x256 RGBA upload must be valid");
+
+	BiomeMapUpload sizeMismatch{
+		.rgba = std::vector<uint8_t>(256 * 256 * 3, 128),
+		.width = 256,
+		.height = 256,
+		.generation = 1
+	};
+	CHECK(!isBiomeMapUploadValid(sizeMismatch), "RGB sized upload must be rejected");
+
+	BiomeMapUpload zeroDim{
+		.rgba = std::vector<uint8_t>(16 * 16 * 4, 128),
+		.width = 0,
+		.height = 16,
+		.generation = 1
+	};
+	CHECK(!isBiomeMapUploadValid(zeroDim), "Zero dimension upload must be rejected");
 }
 
 static void test_player_movement_supersession()
@@ -530,6 +562,7 @@ int main()
 	test_cancellation_mid_flight();
 	test_rapid_request_cancellation_sequence();
 	test_player_dot_painting();
+	test_biome_map_upload_validation();
 	test_player_movement_supersession();
 	test_biome_texture_reuse_rules();
 	test_slow_job_exceeding_refresh_interval();


### PR DESCRIPTION
- Eliminate synchronous submitAndWait, queue wait, and vkDeviceWaitIdle during steady-state biome-map refreshes by treating the biome map as streamed GPU data.
- Stream texture uploads through the existing frame-aware StagingRing; record buffer-to-image copy into the frame command buffer during preRecord prior to ImGui rendering.
- Avoid vkDeviceWaitIdle on initial texture creation when no prior backing image existed.
- Track Vulkan image layout across repeated uploads (SHADER_READ_ONLY_OPTIMAL -> TRANSFER_DST_OPTIMAL -> SHADER_READ_ONLY_OPTIMAL) and add the explicit layout transition branch to cmdTransitionImageLayout.
- Add BiomeMapUpload struct to decouple GameUI from low-level Vulkan synchronization and staging ring lifecycles.
- Generate RGBA directly in worker tasks (with alpha = 255) to eliminate redundant heap allocations and RGB-to-RGBA format conversions on the main UI thread.
- Move player dot painting to RGBA 4-channel pixel operations.
- Account biome map upload under Record -> BiomeMapUpload profile scope, eliminating periodic ~1 Hz UI/ImGui frame time spikes.
- Update tests/test_biome_map.cpp for RGBA buffers, full opacity validation, 4-channel player dot painting, and BiomeMapUpload validation.

close #75