### PR TITLE
fix(terrain): unify biome queries on a canonical BiomeRegionGrid (floor convention)

### DIFF
--- a/docs/terrain-generation.md
+++ b/docs/terrain-generation.md
@@ -178,21 +178,33 @@ Biome sampling is unified across the engine via a canonical erosion-aware pipeli
   `BiomeRegionGrid` (`src/Chunk/BiomeRegionGrid.hpp`) — the single source of truth mapping
   pixels ↔ world positions ↔ voxel columns for the generator and the GameUI biome map.
   Pixel `(0,0)` samples `worldAt(0,0)` (the minimum corner) and pixel `(width-1,height-1)`
-  samples `worldAt(width-1,height-1)`; for even dimensions the grid center falls between
-  the four central pixels. Columns discretize via the canonical `floor()` convention
+  samples `worldAt(width-1,height-1)`. The even/odd parity contract is explicit and
+  intentional: with `worldAt = center + (pixel - size*0.5) * step`, an even size puts the
+  center exactly on pixel `size/2` (width=4, center=0, step=1 → pixels sample
+  `-2, -1, 0, 1`), while an odd size straddles it between the two central pixels
+  (width=5 → `-2.5, -1.5, -0.5, 0.5, 1.5`; no pixel samples the center itself).
+  Columns discretize via the canonical `floor()` convention
   (`col = floor(sampleWorldCoord)`), ensuring adjacent pixels on the same column resolve
   identically. Erosion always runs at `step = 1.0f` — `grid.step` only selects which
-  canonical columns are sampled, never the erosion resolution. Returns `false` (with the
-  output cleared) when the grid is invalid or the optional cancellation callback fires;
-  partial results are never produced:
+  canonical columns are sampled, never the erosion resolution. The call runs sequentially
+  on the calling thread (no internal threads; the Engine schedules the whole call as one
+  `TaskPriority::Low` job) and is deterministic: tile order never influences the output.
+  Returns `false` (with the output cleared) when the grid is invalid or the optional
+  cancellation callback fires; partial results are never produced:
   - Small dense domains (≤ 516×516 haloed block bounding box): sampled in a single
-    vectorized pass at `step = 1.0f` with halo = 2. Total scratch memory is bounded at
-    roughly 10 MiB: 266K points × ~10 float fields × 4 bytes (not per buffer).
+    vectorized pass at `step = 1.0f` with halo = 2. Peak scratch is bounded at roughly
+    10 MiB: 266K points × 10 float fields × 4 bytes (not per buffer).
   - Larger domains / zoom-outs: memory-bounded tiled processing. The tile dimension is
     derived from `grid.step` (`floor((132 - 2*halo - 1) / step) + 1`, capped at 32) so
     every tile's haloed dense domain stays within the per-tile cap (~132² points ≈
     68 KB per float buffer), keeping all pixels — including `zoom = 0.1` — on the
     vectorized dense path. A direct per-column `evaluateBiomeColumn` fallback remains as
     a safety net only. An optional cancellation callback is polled before every tile.
+  - Scratch is a dedicated `BiomeRegionScratch` owned by the caller (pass `nullptr` to
+    use an internal thread-local fallback); the biome-map job owns one persistent scratch
+    and trims oversized capacity after builds that used the large dense path, so idle
+    pool workers never retain the ~10 MiB peak and per-thread retention stays near the
+    small tiled bound. `BiomeRegionStats` reports `denseTiles`, `fallbackPixels`,
+    `peakDensePoints`, and `peakScratchBytes` to keep the bound verifiable.
 - **UI consistency**: HUD biome and World / Biome map use the same canonical generated-column biome definition as loaded terrain at every zoom level. `BiomeMapResult` carries the exact `BiomeRegionGrid` it was sampled with, and the player marker is placed via `grid.pixelForWorld()`; markers outside the grid are simply not drawn.
 

--- a/docs/terrain-generation.md
+++ b/docs/terrain-generation.md
@@ -13,16 +13,21 @@ Phases 0–5. High-level engine ownership remains documented in
   fluids identically.
 - Features with horizontal reach are evaluated from the deterministic
   `MAX_TREE_RADIUS` candidate halo.
+- Biome queries (single-point `getBiomeAt` and block-resolution `getBiomeRegion`
+  with step=1.0) use the canonical erosion-aware pipeline with a halo of at least
+  2 cells, guaranteeing identical biome selection to generated chunk columns.
 - GPU upload and destruction are not part of terrain generation and remain on
   the main thread.
 
 ## Pipeline
 
-1. Batch the 2D terrain and climate graphs over a 28×28 extended window.
+1. Batch the 2D terrain and climate graphs over an extended window (halo >= 2;
+   chunks use 28×28 with halo=6 to cover the vegetation candidate ring).
 2. Calculate continuous heights and apply one deterministic thermal-erosion
-   pass.
+   pass at block resolution.
 3. Select biomes from terrain band, temperature, humidity, weirdness, erosion,
-   relief, and river values.
+   relief, and river values. (Point and block-resolution region queries share
+   this exact erosion-aware pipeline.)
 4. Produce the 16×16 core height/color data and bounded 3D noise ranges.
 5. Fill voxel columns, carve caves, and assign deterministic aquifer fluids.
 6. Place depth- and biome-aware ore veins.
@@ -147,4 +152,18 @@ be misleading as full collidable cubes.
 
 The regular `test_terrain` run additionally checks multi-thread and generation
 order determinism, chunk-border continuity, aquatic features, cave fluids,
-ore ranges, feature bounds, bedrock, and block identifiers.
+ore ranges, feature bounds, bedrock, block identifiers, and cross-API
+biome consistency.
+
+## Biome Query Invariants
+
+Biome sampling is unified across the engine via a canonical erosion-aware pipeline:
+1. Sample the 2D terrain and climate noise graphs over the requested region padded with an erosion halo (minimum 2 cells).
+2. Calculate continuous heights via `calculateHeightFloat`.
+3. Apply deterministic thermal erosion (`applyErosion`) at block resolution (`step = 1.0`).
+4. Select biomes using `determineBiome` with post-erosion height and clamped parameters.
+
+- **Point queries (`getBiomeAt(worldX, worldZ)`)**: Samples a 5×5 cell window (halo = 2) centered on the world column, running thermal erosion on the neighborhood. This guarantees bit-for-bit equivalence with chunk generation without heap allocations.
+- **Region queries (`getBiomeRegion(...)`)**: Batch-samples uniform grids with halo = 2 padding. At block resolution (`step = 1.0`), output matches `generateChunk` and `getBiomeAt` across chunk borders.
+- **UI consistency**: The HUD biome label and the World / Biome map cannot disagree with loaded chunks for matching coordinates.
+

--- a/docs/terrain-generation.md
+++ b/docs/terrain-generation.md
@@ -201,10 +201,11 @@ Biome sampling is unified across the engine via a canonical erosion-aware pipeli
     vectorized dense path. A direct per-column `evaluateBiomeColumn` fallback remains as
     a safety net only. An optional cancellation callback is polled before every tile.
   - Scratch is a dedicated `BiomeRegionScratch` owned by the caller (pass `nullptr` to
-    use an internal thread-local fallback); the biome-map job owns one persistent scratch
-    and trims oversized capacity after builds that used the large dense path, so idle
-    pool workers never retain the ~10 MiB peak and per-thread retention stays near the
-    small tiled bound. `BiomeRegionStats` reports `denseTiles`, `fallbackPixels`,
+    use an internal thread-local fallback); `getBiomeRegion()` trims oversized dense
+    capacity on **every** exit — successful or cancelled/failed attempts alike — so only
+    the small tiled bound is ever retained across attempts, while tiled-sized capacity
+    survives for cheap reuse. The biome-map job owns one persistent scratch under this
+    policy. `BiomeRegionStats` reports `denseTiles`, `fallbackPixels`,
     `peakDensePoints`, and `peakScratchBytes` to keep the bound verifiable.
 - **UI consistency**: HUD biome and World / Biome map use the same canonical generated-column biome definition as loaded terrain at every zoom level. `BiomeMapResult` carries the exact `BiomeRegionGrid` it was sampled with, and the player marker is placed via `grid.pixelForWorld()`; markers outside the grid are simply not drawn.
 

--- a/docs/terrain-generation.md
+++ b/docs/terrain-generation.md
@@ -164,10 +164,35 @@ Biome sampling is unified across the engine via a canonical erosion-aware pipeli
 3. Apply deterministic thermal erosion (`applyCanonicalErosion`) at block resolution (`step = 1.0`).
 4. Select biomes using `determineBiome` with post-erosion height and clamped parameters.
 
+- **Coordinate conventions (canonical)**: A continuous world position maps to
+  a voxel column with `floor()` — everywhere: HUD, `getBiomeAt()`,
+  `getBiomeRegion()`, the biome map, and the player marker
+  (`worldToVoxelColumn()` in `src/Chunk/BiomeRegionGrid.hpp`). Map *rendering*
+  additionally uses a separate, display-only rounding: the player marker is
+  drawn at the nearest display pixel (`round()`, via
+  `BiomeRegionGrid::pixelForWorld`). The two roundings have different roles
+  and must not be interchanged: never derive a canonical biome column from a
+  display pixel other than through `BiomeRegionGrid::columnAt()`.
 - **Point queries (`getBiomeAt(worldX, worldZ)`)**: Evaluates a 5×5 cell window (halo = 2) centered on the world column via `evaluateBiomeColumn`, running thermal erosion on the neighborhood. This guarantees bit-for-bit equivalence with chunk generation without heap allocations.
-- **Region queries (`getBiomeRegion(centerX, centerZ, step, width, height, ...)`)**: Returns canonical biome samples for every output coordinate, independently of display sampling step:
-  - For `step == 1.0` (and small dense domains): Evaluates the dense block bounding box at `step = 1.0` with halo = 2 in a single vectorized pass.
-  - For `step < 1.0` (zoom-in): Evaluates the compact dense block bounding box at `step = 1.0`. For sub-block pixels, coordinates discretize via round-to-nearest (`col = round(sampleWorldCoord)`), ensuring adjacent pixels on the same column resolve identically.
-  - For `step > 1.0` (zoom-out): Uses a memory-bounded adaptive tiled approach (tiles of up to 32×32 output pixels) or direct canonical column evaluation, guaranteeing strictly bounded scratch memory (< 1 MB) without memory explosions at wide zoom-outs.
-- **UI consistency**: HUD biome and World / Biome map use the same canonical generated-column biome definition as loaded terrain at every zoom level.
+- **Region queries (`getBiomeRegion(grid, ...)`)**: The sampling domain is described by a
+  `BiomeRegionGrid` (`src/Chunk/BiomeRegionGrid.hpp`) — the single source of truth mapping
+  pixels ↔ world positions ↔ voxel columns for the generator and the GameUI biome map.
+  Pixel `(0,0)` samples `worldAt(0,0)` (the minimum corner) and pixel `(width-1,height-1)`
+  samples `worldAt(width-1,height-1)`; for even dimensions the grid center falls between
+  the four central pixels. Columns discretize via the canonical `floor()` convention
+  (`col = floor(sampleWorldCoord)`), ensuring adjacent pixels on the same column resolve
+  identically. Erosion always runs at `step = 1.0f` — `grid.step` only selects which
+  canonical columns are sampled, never the erosion resolution. Returns `false` (with the
+  output cleared) when the grid is invalid or the optional cancellation callback fires;
+  partial results are never produced:
+  - Small dense domains (≤ 516×516 haloed block bounding box): sampled in a single
+    vectorized pass at `step = 1.0f` with halo = 2. Total scratch memory is bounded at
+    roughly 10 MiB: 266K points × ~10 float fields × 4 bytes (not per buffer).
+  - Larger domains / zoom-outs: memory-bounded tiled processing. The tile dimension is
+    derived from `grid.step` (`floor((132 - 2*halo - 1) / step) + 1`, capped at 32) so
+    every tile's haloed dense domain stays within the per-tile cap (~132² points ≈
+    68 KB per float buffer), keeping all pixels — including `zoom = 0.1` — on the
+    vectorized dense path. A direct per-column `evaluateBiomeColumn` fallback remains as
+    a safety net only. An optional cancellation callback is polled before every tile.
+- **UI consistency**: HUD biome and World / Biome map use the same canonical generated-column biome definition as loaded terrain at every zoom level. `BiomeMapResult` carries the exact `BiomeRegionGrid` it was sampled with, and the player marker is placed via `grid.pixelForWorld()`; markers outside the grid are simply not drawn.
 

--- a/docs/terrain-generation.md
+++ b/docs/terrain-generation.md
@@ -13,9 +13,10 @@ Phases 0–5. High-level engine ownership remains documented in
   fluids identically.
 - Features with horizontal reach are evaluated from the deterministic
   `MAX_TREE_RADIUS` candidate halo.
-- Biome queries (single-point `getBiomeAt` and block-resolution `getBiomeRegion`
-  with step=1.0) use the canonical erosion-aware pipeline with a halo of at least
-  2 cells, guaranteeing identical biome selection to generated chunk columns.
+- Biome queries (point query `getBiomeAt` and region query `getBiomeRegion`)
+  return canonical biome samples for every output coordinate independently of
+  display sampling step, using the canonical block-resolution erosion-aware
+  pipeline with halo >= 2.
 - GPU upload and destruction are not part of terrain generation and remain on
   the main thread.
 
@@ -26,8 +27,8 @@ Phases 0–5. High-level engine ownership remains documented in
 2. Calculate continuous heights and apply one deterministic thermal-erosion
    pass at block resolution.
 3. Select biomes from terrain band, temperature, humidity, weirdness, erosion,
-   relief, and river values. (Point and block-resolution region queries share
-   this exact erosion-aware pipeline.)
+   relief, and river values. (Point and region queries share this exact
+   canonical pipeline.)
 4. Produce the 16×16 core height/color data and bounded 3D noise ranges.
 5. Fill voxel columns, carve caves, and assign deterministic aquifer fluids.
 6. Place depth- and biome-aware ore veins.
@@ -158,12 +159,15 @@ biome consistency.
 ## Biome Query Invariants
 
 Biome sampling is unified across the engine via a canonical erosion-aware pipeline:
-1. Sample the 2D terrain and climate noise graphs over the requested region padded with an erosion halo (minimum 2 cells).
+1. Sample the 2D terrain and climate noise graphs over the requested region padded with an erosion halo (minimum 2 cells) at block resolution (`erosionStep = 1.0f`).
 2. Calculate continuous heights via `calculateHeightFloat`.
-3. Apply deterministic thermal erosion (`applyErosion`) at block resolution (`step = 1.0`).
+3. Apply deterministic thermal erosion (`applyCanonicalErosion`) at block resolution (`step = 1.0`).
 4. Select biomes using `determineBiome` with post-erosion height and clamped parameters.
 
-- **Point queries (`getBiomeAt(worldX, worldZ)`)**: Samples a 5×5 cell window (halo = 2) centered on the world column, running thermal erosion on the neighborhood. This guarantees bit-for-bit equivalence with chunk generation without heap allocations.
-- **Region queries (`getBiomeRegion(...)`)**: Batch-samples uniform grids with halo = 2 padding. At block resolution (`step = 1.0`), output matches `generateChunk` and `getBiomeAt` across chunk borders.
-- **UI consistency**: The HUD biome label and the World / Biome map cannot disagree with loaded chunks for matching coordinates.
+- **Point queries (`getBiomeAt(worldX, worldZ)`)**: Evaluates a 5×5 cell window (halo = 2) centered on the world column via `evaluateBiomeColumn`, running thermal erosion on the neighborhood. This guarantees bit-for-bit equivalence with chunk generation without heap allocations.
+- **Region queries (`getBiomeRegion(centerX, centerZ, step, width, height, ...)`)**: Returns canonical biome samples for every output coordinate, independently of display sampling step:
+  - For `step == 1.0` (and small dense domains): Evaluates the dense block bounding box at `step = 1.0` with halo = 2 in a single vectorized pass.
+  - For `step < 1.0` (zoom-in): Evaluates the compact dense block bounding box at `step = 1.0`. For sub-block pixels, coordinates discretize via round-to-nearest (`col = round(sampleWorldCoord)`), ensuring adjacent pixels on the same column resolve identically.
+  - For `step > 1.0` (zoom-out): Uses a memory-bounded adaptive tiled approach (tiles of up to 32×32 output pixels) or direct canonical column evaluation, guaranteeing strictly bounded scratch memory (< 1 MB) without memory explosions at wide zoom-outs.
+- **UI consistency**: HUD biome and World / Biome map use the same canonical generated-column biome definition as loaded terrain at every zoom level.
 

--- a/src/Chunk/BiomeRegionGrid.hpp
+++ b/src/Chunk/BiomeRegionGrid.hpp
@@ -1,15 +1,30 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
 #include <glm/glm.hpp>
 
 /// Continuous world position -> voxel column (canonical convention).
 /// This is THE single convention shared by the HUD, getBiomeAt(),
 /// getBiomeRegion(), the biome map, and the player marker: a world
-/// coordinate belongs to the voxel column at its floor().
+/// coordinate belongs to the voxel column at its floor(). Non-finite or
+/// int-unrepresentable inputs clamp to the nearest representable column
+/// (INT_MIN direction for NaN) instead of invoking UB; such positions are
+/// far outside any reachable world.
 inline int worldToVoxelColumn(float world)
 {
-	return static_cast<int>(std::floor(world));
+	if (!std::isfinite(world))
+		return std::numeric_limits<int>::min();
+	// Floor in double, then range-check: float cannot represent the int
+	// endpoints exactly, and static_cast<int>(floor(huge)) would be UB.
+	const double w = std::floor(static_cast<double>(world));
+	constexpr double kIntMin = static_cast<double>(std::numeric_limits<int>::min());
+	constexpr double kIntMax = static_cast<double>(std::numeric_limits<int>::max());
+	if (w <= kIntMin)
+		return std::numeric_limits<int>::min();
+	if (w >= kIntMax)
+		return std::numeric_limits<int>::max();
+	return static_cast<int>(w);
 }
 
 inline glm::ivec2 worldToVoxelColumn(glm::vec2 world)
@@ -23,24 +38,32 @@ inline glm::ivec2 worldToVoxelColumn(glm::vec2 world)
 /// resolve to out-of-range indices; callers must bounds-check.
 inline int worldToNearestMapPixel(float world, float center, float step, int size)
 {
-	const float fx = (world - center) / step + static_cast<float>(size) * 0.5f;
+	const double fx = (static_cast<double>(world) - static_cast<double>(center)) /
+						  static_cast<double>(step) +
+					  static_cast<double>(size) * 0.5;
 	if (!std::isfinite(fx))
-		return -2147483648;
-	if (fx >= 2147483520.0f) // 2^31-128: safely inside int range before rounding
-		return 2147483647;
-	if (fx <= -2147483520.0f)
-		return -2147483648;
-	return static_cast<int>(std::round(fx));
+		return std::numeric_limits<int>::min();
+	const double rounded = std::round(fx);
+	constexpr double kIntMin = static_cast<double>(std::numeric_limits<int>::min());
+	constexpr double kIntMax = static_cast<double>(std::numeric_limits<int>::max());
+	if (rounded <= kIntMin)
+		return std::numeric_limits<int>::min();
+	if (rounded >= kIntMax)
+		return std::numeric_limits<int>::max();
+	return static_cast<int>(rounded);
 }
 
 /// Canonical description of a biome-map sampling grid. It is the single
 /// source of truth mapping pixels <-> world positions <-> voxel columns for
 /// both TerrainGenerator::getBiomeRegion() and the GameUI biome map.
 ///
-/// Pixel (0,0) samples worldAt(0,0) (the minimum corner) and pixel
-/// (width-1,height-1) samples worldAt(width-1,height-1). For even
-/// dimensions the grid center falls between the four central pixels; for
-/// odd dimensions it lands exactly on the central pixel.
+/// With `worldAt(x) = center + (x - size * 0.5f) * step`, the parity
+/// contract is deliberately asymmetric and assumed as-is:
+/// - even size: pixel `size/2` samples exactly `center`. Example
+///   width=4, center=0, step=1 -> pixels sample -2, -1, 0, 1.
+/// - odd size: `center` falls between the two central pixels. Example
+///   width=5, center=0, step=1 -> pixels sample -2.5, -1.5, -0.5,
+///   0.5, 1.5, so no pixel samples the center itself.
 ///
 /// Lightweight and dependency-free (glm only): no FastNoise/Vulkan/ImGui.
 struct BiomeRegionGrid

--- a/src/Chunk/BiomeRegionGrid.hpp
+++ b/src/Chunk/BiomeRegionGrid.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <cmath>
+#include <glm/glm.hpp>
+
+/// Continuous world position -> voxel column (canonical convention).
+/// This is THE single convention shared by the HUD, getBiomeAt(),
+/// getBiomeRegion(), the biome map, and the player marker: a world
+/// coordinate belongs to the voxel column at its floor().
+inline int worldToVoxelColumn(float world)
+{
+	return static_cast<int>(std::floor(world));
+}
+
+inline glm::ivec2 worldToVoxelColumn(glm::vec2 world)
+{
+	return {worldToVoxelColumn(world.x), worldToVoxelColumn(world.y)};
+}
+
+/// World position -> nearest biome-map pixel index along one axis.
+/// Visualization-only rounding (round to nearest pixel); never use this to
+/// resolve a canonical voxel column. Values outside the grid (or NaN input)
+/// resolve to out-of-range indices; callers must bounds-check.
+inline int worldToNearestMapPixel(float world, float center, float step, int size)
+{
+	const float fx = (world - center) / step + static_cast<float>(size) * 0.5f;
+	if (!std::isfinite(fx))
+		return -2147483648;
+	if (fx >= 2147483520.0f) // 2^31-128: safely inside int range before rounding
+		return 2147483647;
+	if (fx <= -2147483520.0f)
+		return -2147483648;
+	return static_cast<int>(std::round(fx));
+}
+
+/// Canonical description of a biome-map sampling grid. It is the single
+/// source of truth mapping pixels <-> world positions <-> voxel columns for
+/// both TerrainGenerator::getBiomeRegion() and the GameUI biome map.
+///
+/// Pixel (0,0) samples worldAt(0,0) (the minimum corner) and pixel
+/// (width-1,height-1) samples worldAt(width-1,height-1). For even
+/// dimensions the grid center falls between the four central pixels; for
+/// odd dimensions it lands exactly on the central pixel.
+///
+/// Lightweight and dependency-free (glm only): no FastNoise/Vulkan/ImGui.
+struct BiomeRegionGrid
+{
+	glm::vec2 center{0.0f, 0.0f}; // world-space center of the grid
+	float step{1.0f};             // world units per pixel; must be > 0 and finite
+	int width{0};
+	int height{0};
+
+	/// World coordinate sampled by pixel (x, z).
+	glm::vec2 worldAt(int x, int z) const
+	{
+		return center + glm::vec2(
+							(static_cast<float>(x) - static_cast<float>(width) * 0.5f) * step,
+							(static_cast<float>(z) - static_cast<float>(height) * 0.5f) * step);
+	}
+
+	/// Voxel column a pixel resolves to (canonical floor convention).
+	glm::ivec2 columnAt(int x, int z) const
+	{
+		return worldToVoxelColumn(worldAt(x, z));
+	}
+
+	/// Nearest display pixel for a world position. May fall outside
+	/// [0,width)x[0,height) when the position lies outside the grid.
+	glm::ivec2 pixelForWorld(glm::vec2 world) const
+	{
+		return {worldToNearestMapPixel(world.x, center.x, step, width),
+				worldToNearestMapPixel(world.y, center.y, step, height)};
+	}
+
+	/// True when the grid is usable for sampling.
+	bool valid() const
+	{
+		return width > 0 && height > 0 &&
+			   std::isfinite(step) && step > 0.0f &&
+			   std::isfinite(center.x) && std::isfinite(center.y);
+	}
+};
+
+/// Single factory for biome-map grids so every producer (TerrainGenerator,
+/// GameUI, tests) builds the same description from the same inputs.
+inline BiomeRegionGrid makeBiomeRegionGrid(float centerX, float centerZ,
+										   float step, int width, int height)
+{
+	return BiomeRegionGrid{glm::vec2(centerX, centerZ), step, width, height};
+}

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -592,6 +592,8 @@ struct GenBuffers
   std::vector<float> erosionBuf;
   std::vector<float> pvBuf;
   std::vector<float> ridgeBuf;
+  std::vector<float> heightBuf;
+  std::vector<float> erosionTempBuf;
 
   // Persistent generator to avoid expensive setup every chunk
   std::unique_ptr<TerrainGenerator> generator;
@@ -766,6 +768,77 @@ ChunkData TerrainGenerator::generateChunkProfiled(
   }
 }
 
+void TerrainGenerator::sampleTerrainColumnNoiseAndHeights(
+    const TerrainColumnBuffers &buffers,
+    int extStartX, int extStartZ,
+    int extWidth, int extHeight,
+    float step) const
+{
+  using Clock = std::chrono::steady_clock;
+  const auto noise2DStart =
+      m_activeProfile ? Clock::now() : Clock::time_point{};
+
+  m_continentalNoise->GenUniformGrid2D(buffers.continental, extStartX, extStartZ,
+                                       extWidth, extHeight, step, m_seed);
+  m_erosionNoise->GenUniformGrid2D(buffers.erosion, extStartX, extStartZ,
+                                   extWidth, extHeight, step, m_seed + 1000);
+  m_peaksValleysNoise->GenUniformGrid2D(buffers.peaksValleys, extStartX, extStartZ,
+                                        extWidth, extHeight, step, m_seed + 2000);
+  m_ridgeNoise->GenUniformGrid2D(buffers.ridge, extStartX, extStartZ,
+                                 extWidth, extHeight, step, m_seed + 3000);
+  m_temperatureNoise->GenUniformGrid2D(buffers.temperature, extStartX, extStartZ,
+                                       extWidth, extHeight, step, m_seed + 6000);
+  m_humidityNoise->GenUniformGrid2D(buffers.humidity, extStartX, extStartZ,
+                                    extWidth, extHeight, step, m_seed + 7000);
+  m_weirdnessNoise->GenUniformGrid2D(buffers.weirdness, extStartX, extStartZ,
+                                     extWidth, extHeight, step, m_seed + 8000);
+  m_riverNoise->GenUniformGrid2D(buffers.river, extStartX, extStartZ,
+                                 extWidth, extHeight, step, m_seed + 9000);
+
+  if (m_activeProfile)
+    m_activeProfile->noise2DMs +=
+        std::chrono::duration<double, std::milli>(Clock::now() - noise2DStart)
+            .count();
+
+  const int totalPoints = extWidth * extHeight;
+  for (int i = 0; i < totalPoints; ++i)
+  {
+    buffers.heightMap[i] = calculateHeightFloat(
+        buffers.continental[i], buffers.erosion[i],
+        buffers.peaksValleys[i], buffers.ridge[i],
+        buffers.river[i], buffers.weirdness[i]);
+  }
+
+  if (step == 1.0f)
+  {
+    const auto erosionStart =
+        m_activeProfile ? Clock::now() : Clock::time_point{};
+    applyErosion(buffers.heightMap, extWidth, extHeight, buffers.erosionTemp);
+    if (m_activeProfile)
+      m_activeProfile->erosionMs +=
+          std::chrono::duration<double, std::milli>(Clock::now() - erosionStart)
+              .count();
+  }
+}
+
+BiomeType TerrainGenerator::evaluateBiomeAt(
+    const TerrainColumnBuffers &buffers,
+    int extIndex) const
+{
+  const float continental = std::clamp(buffers.continental[extIndex], -1.0f, 1.0f);
+  const float temperature = std::clamp(buffers.temperature[extIndex], -1.0f, 1.0f);
+  const float humidity = std::clamp(buffers.humidity[extIndex], -1.0f, 1.0f);
+  const float weirdness = std::clamp(buffers.weirdness[extIndex], -1.0f, 1.0f);
+  const float riverVal = buffers.river[extIndex];
+  const float erosion = std::clamp(buffers.erosion[extIndex], -1.0f, 1.0f);
+  const float pv = std::clamp(buffers.peaksValleys[extIndex], -1.0f, 1.0f);
+
+  const int height = std::clamp(static_cast<int>(std::round(buffers.heightMap[extIndex])), 1, static_cast<int>(CHUNK_HEIGHT - HEIGHT_CEILING_MARGIN));
+
+  return determineBiome(temperature, humidity, weirdness,
+                        continental, erosion, pv, riverVal, height);
+}
+
 void TerrainGenerator::generateChunkBatch(ChunkData &chunkData, int chunkX,
                                           int chunkZ)
 {
@@ -802,37 +875,24 @@ void TerrainGenerator::generateChunkBatch(ChunkData &chunkData, int chunkX,
   float extendedWorldZf = worldZf - static_cast<float>(EXT_CORE_OFFSET);
   const int EXTENDED_SIZE = EXT_SIZE;
 
-  const auto noise2DStart =
-      m_activeProfile ? Clock::now() : Clock::time_point{};
-  m_continentalNoise->GenUniformGrid2D(continentalResults, extendedWorldXf,
-                                       extendedWorldZf, EXTENDED_SIZE, EXTENDED_SIZE, 1.0f,
-                                       m_seed);
+  TerrainColumnBuffers buffers{
+      .continental = continentalResults,
+      .erosion = erosionResults,
+      .peaksValleys = peaksValleysResults,
+      .ridge = ridgeResults,
+      .temperature = temperatureResults,
+      .humidity = humidityResults,
+      .weirdness = weirdnessResults,
+      .river = riverResults,
+      .heightMap = s_genBuffers.extendedHeightMap.data(),
+      .erosionTemp = s_genBuffers.erosionTempMap.data()};
 
-  m_erosionNoise->GenUniformGrid2D(erosionResults, extendedWorldXf, extendedWorldZf,
-                                   EXTENDED_SIZE, EXTENDED_SIZE, 1.0f, m_seed + 1000);
+  sampleTerrainColumnNoiseAndHeights(
+      buffers,
+      static_cast<int>(extendedWorldXf),
+      static_cast<int>(extendedWorldZf),
+      EXTENDED_SIZE, EXTENDED_SIZE, 1.0f);
 
-  m_peaksValleysNoise->GenUniformGrid2D(peaksValleysResults, extendedWorldXf,
-                                        extendedWorldZf, EXTENDED_SIZE, EXTENDED_SIZE, 1.0f,
-                                        m_seed + 2000);
-
-  m_ridgeNoise->GenUniformGrid2D(ridgeResults, extendedWorldXf, extendedWorldZf,
-                                 EXTENDED_SIZE, EXTENDED_SIZE, 1.0f, m_seed + 3000);
-
-  // Generate biome noise for extended area
-  m_temperatureNoise->GenUniformGrid2D(temperatureResults, extendedWorldXf, extendedWorldZf,
-                                       EXTENDED_SIZE, EXTENDED_SIZE, 1.0f, m_seed + 6000);
-
-  m_humidityNoise->GenUniformGrid2D(humidityResults, extendedWorldXf, extendedWorldZf,
-                                    EXTENDED_SIZE, EXTENDED_SIZE, 1.0f, m_seed + 7000);
-
-  m_weirdnessNoise->GenUniformGrid2D(weirdnessResults, extendedWorldXf, extendedWorldZf,
-                                     EXTENDED_SIZE, EXTENDED_SIZE, 1.0f, m_seed + 8000);
-  m_riverNoise->GenUniformGrid2D(riverResults, extendedWorldXf, extendedWorldZf,
-                                 EXTENDED_SIZE, EXTENDED_SIZE, 1.0f, m_seed + 9000);
-  if (m_activeProfile)
-    m_activeProfile->noise2DMs +=
-        std::chrono::duration<double, std::milli>(Clock::now() - noise2DStart)
-            .count();
   const auto aquiferStart =
       m_activeProfile ? Clock::now() : Clock::time_point{};
   m_aquiferNoise->GenUniformGrid2D(aquiferResults, extendedWorldXf,
@@ -843,23 +903,7 @@ void TerrainGenerator::generateChunkBatch(ChunkData &chunkData, int chunkX,
         std::chrono::duration<double, std::milli>(Clock::now() - aquiferStart)
             .count();
 
-  // Pre-calculate float heights for the extended map.
   float *extHeightMap = s_genBuffers.extendedHeightMap.data();
-  for (int i = 0; i < EXTENDED_SIZE * EXTENDED_SIZE; ++i)
-  {
-    extHeightMap[i] = calculateHeightFloat(
-        continentalResults[i], erosionResults[i],
-        peaksValleysResults[i], ridgeResults[i], riverResults[i], weirdnessResults[i]);
-  }
-
-  // Apply erosion smoothing step to the float heightmap
-  const auto erosionStart =
-      m_activeProfile ? Clock::now() : Clock::time_point{};
-  applyErosion(extHeightMap, EXTENDED_SIZE);
-  if (m_activeProfile)
-    m_activeProfile->erosionMs +=
-        std::chrono::duration<double, std::milli>(Clock::now() - erosionStart)
-            .count();
 
   // Pass 1a: biomes, heights and raw biome colors over the whole extended
   // window (must precede 3D noise so we can bound cave sampling to
@@ -874,18 +918,11 @@ void TerrainGenerator::generateChunkBatch(ChunkData &chunkData, int chunkX,
     {
       int extIndex = extZ * EXTENDED_SIZE + extX;
 
-      float continental = std::clamp(continentalResults[extIndex], -1.0f, 1.0f);
-      float temperature = std::clamp(temperatureResults[extIndex], -1.0f, 1.0f);
-      float humidity = std::clamp(humidityResults[extIndex], -1.0f, 1.0f);
       float weirdness = std::clamp(weirdnessResults[extIndex], -1.0f, 1.0f);
-      float riverVal = riverResults[extIndex];
       float erosion = std::clamp(erosionResults[extIndex], -1.0f, 1.0f);
-      float pv = std::clamp(peaksValleysResults[extIndex], -1.0f, 1.0f);
 
+      BiomeType biome = evaluateBiomeAt(buffers, extIndex);
       int height = std::clamp(static_cast<int>(std::round(extHeightMap[extIndex])), 1, static_cast<int>(CHUNK_HEIGHT - HEIGHT_CEILING_MARGIN));
-
-      BiomeType biome = determineBiome(temperature, humidity, weirdness,
-                                       continental, erosion, pv, riverVal, height);
 
       // Oasis patches use the strongest weirdness values as a shallow pond
       // core. The outer oasis ring remains dry and hosts palms/ground cover.
@@ -1549,26 +1586,53 @@ BiomeType TerrainGenerator::determineBiome(float temperature, float humidity,
 
 BiomeType TerrainGenerator::getBiomeAt(int worldX, int worldZ) const
 {
-  float x = static_cast<float>(worldX) + NOISE_OFFSET;
-  float z = static_cast<float>(worldZ) + NOISE_OFFSET;
+  constexpr int HALO = 2;
+  constexpr int EXT_W = 1 + 2 * HALO;
+  constexpr int EXT_H = 1 + 2 * HALO;
+  constexpr int EXT_COUNT = EXT_W * EXT_H;
 
-  float temp = m_temperatureNoise->GenSingle2D(x, z, m_seed + 6000);
-  float humid = m_humidityNoise->GenSingle2D(x, z, m_seed + 7000);
-  float weird = m_weirdnessNoise->GenSingle2D(x, z, m_seed + 8000);
-  float cont = m_continentalNoise->GenSingle2D(x, z, m_seed);
-  float erosion = m_erosionNoise->GenSingle2D(x, z, m_seed + 1000);
-  float pv = m_peaksValleysNoise->GenSingle2D(x, z, m_seed + 2000);
-  float ridge = m_ridgeNoise->GenSingle2D(x, z, m_seed + 3000);
-  float river = m_riverNoise->GenSingle2D(x, z, m_seed + 9000);
-  int height = calculateHeight(cont, erosion, pv, ridge, river, weird);
+  std::array<float, EXT_COUNT> cont;
+  std::array<float, EXT_COUNT> erosion;
+  std::array<float, EXT_COUNT> pv;
+  std::array<float, EXT_COUNT> ridge;
+  std::array<float, EXT_COUNT> temp;
+  std::array<float, EXT_COUNT> humid;
+  std::array<float, EXT_COUNT> weird;
+  std::array<float, EXT_COUNT> river;
+  std::array<float, EXT_COUNT> heightMap;
+  std::array<float, EXT_COUNT> erosionTemp;
 
-  return determineBiome(temp, humid, weird, cont, erosion, pv, river, height);
+  TerrainColumnBuffers buffers{
+      .continental = cont.data(),
+      .erosion = erosion.data(),
+      .peaksValleys = pv.data(),
+      .ridge = ridge.data(),
+      .temperature = temp.data(),
+      .humidity = humid.data(),
+      .weirdness = weird.data(),
+      .river = river.data(),
+      .heightMap = heightMap.data(),
+      .erosionTemp = erosionTemp.data()};
+
+  const int extStartX = worldX + static_cast<int>(NOISE_OFFSET) - HALO;
+  const int extStartZ = worldZ + static_cast<int>(NOISE_OFFSET) - HALO;
+
+  sampleTerrainColumnNoiseAndHeights(buffers, extStartX, extStartZ, EXT_W, EXT_H, 1.0f);
+
+  constexpr int centerIndex = HALO * EXT_W + HALO;
+  return evaluateBiomeAt(buffers, centerIndex);
 }
 
 void TerrainGenerator::getBiomeRegion(float centerX, float centerZ, float step,
                                       int width, int height,
                                       std::vector<BiomeType> &outBiomes) const
 {
+  if (width <= 0 || height <= 0)
+  {
+    outBiomes.clear();
+    return;
+  }
+
   const int count = width * height;
   outBiomes.resize(count);
 
@@ -1582,46 +1646,49 @@ void TerrainGenerator::getBiomeRegion(float centerX, float centerZ, float step,
   const int startX = static_cast<int>(std::round((centerX + NOISE_OFFSET) * invStep - width * 0.5f));
   const int startZ = static_cast<int>(std::round((centerZ + NOISE_OFFSET) * invStep - height * 0.5f));
 
-  if (s_genBuffers.tempBuf.size() < static_cast<size_t>(count))
+  constexpr int HALO = 2;
+  const int extWidth = width + 2 * HALO;
+  const int extHeight = height + 2 * HALO;
+  const int extCount = extWidth * extHeight;
+
+  if (s_genBuffers.tempBuf.size() < static_cast<size_t>(extCount))
   {
-    s_genBuffers.tempBuf.resize(count);
-    s_genBuffers.humidBuf.resize(count);
-    s_genBuffers.weirdBuf.resize(count);
-    s_genBuffers.riverBuf.resize(count);
-    s_genBuffers.contBuf.resize(count);
-    s_genBuffers.erosionBuf.resize(count);
-    s_genBuffers.pvBuf.resize(count);
-    s_genBuffers.ridgeBuf.resize(count);
+    s_genBuffers.tempBuf.resize(extCount);
+    s_genBuffers.humidBuf.resize(extCount);
+    s_genBuffers.weirdBuf.resize(extCount);
+    s_genBuffers.riverBuf.resize(extCount);
+    s_genBuffers.contBuf.resize(extCount);
+    s_genBuffers.erosionBuf.resize(extCount);
+    s_genBuffers.pvBuf.resize(extCount);
+    s_genBuffers.ridgeBuf.resize(extCount);
+    s_genBuffers.heightBuf.resize(extCount);
+    s_genBuffers.erosionTempBuf.resize(extCount);
   }
 
-  float* tempBuf = s_genBuffers.tempBuf.data();
-  float* humidBuf = s_genBuffers.humidBuf.data();
-  float* weirdBuf = s_genBuffers.weirdBuf.data();
-  float* riverBuf = s_genBuffers.riverBuf.data();
-  float* contBuf = s_genBuffers.contBuf.data();
-  float* erosionBuf = s_genBuffers.erosionBuf.data();
-  float* pvBuf = s_genBuffers.pvBuf.data();
-  float* ridgeBuf = s_genBuffers.ridgeBuf.data();
+  TerrainColumnBuffers buffers{
+      .continental = s_genBuffers.contBuf.data(),
+      .erosion = s_genBuffers.erosionBuf.data(),
+      .peaksValleys = s_genBuffers.pvBuf.data(),
+      .ridge = s_genBuffers.ridgeBuf.data(),
+      .temperature = s_genBuffers.tempBuf.data(),
+      .humidity = s_genBuffers.humidBuf.data(),
+      .weirdness = s_genBuffers.weirdBuf.data(),
+      .river = s_genBuffers.riverBuf.data(),
+      .heightMap = s_genBuffers.heightBuf.data(),
+      .erosionTemp = s_genBuffers.erosionTempBuf.data()};
 
-  // GenUniformGrid2D processes batches with SIMD — far faster than individual GenSingle2D calls.
-  m_temperatureNoise->GenUniformGrid2D(tempBuf, startX, startZ, width, height, step, m_seed + 6000);
-  m_humidityNoise->GenUniformGrid2D(humidBuf, startX, startZ, width, height, step, m_seed + 7000);
-  m_weirdnessNoise->GenUniformGrid2D(weirdBuf, startX, startZ, width, height, step, m_seed + 8000);
-  m_continentalNoise->GenUniformGrid2D(contBuf, startX, startZ, width, height, step, m_seed);
-  m_erosionNoise->GenUniformGrid2D(erosionBuf, startX, startZ, width, height, step, m_seed + 1000);
-  m_peaksValleysNoise->GenUniformGrid2D(pvBuf, startX, startZ, width, height, step, m_seed + 2000);
-  m_ridgeNoise->GenUniformGrid2D(ridgeBuf, startX, startZ, width, height, step, m_seed + 3000);
-  m_riverNoise->GenUniformGrid2D(riverBuf, startX, startZ, width, height, step, m_seed + 9000);
+  const int extStartX = startX - HALO;
+  const int extStartZ = startZ - HALO;
 
-  for (int i = 0; i < count; i++)
+  sampleTerrainColumnNoiseAndHeights(buffers, extStartX, extStartZ, extWidth, extHeight, step);
+
+  for (int z = 0; z < height; ++z)
   {
-    const float cont = std::clamp(contBuf[i], -1.0f, 1.0f);
-    const float erosion = std::clamp(erosionBuf[i], -1.0f, 1.0f);
-    const float pv = std::clamp(pvBuf[i], -1.0f, 1.0f);
-    const float ridge = std::clamp(ridgeBuf[i], -1.0f, 1.0f);
-    const float river = riverBuf[i];
-    const int h = calculateHeight(cont, erosion, pv, ridge, river, weirdBuf[i]);
-    outBiomes[i] = determineBiome(tempBuf[i], humidBuf[i], weirdBuf[i], cont, erosion, pv, river, h);
+    for (int x = 0; x < width; ++x)
+    {
+      const int extIndex = (z + HALO) * extWidth + (x + HALO);
+      outBiomes[z * width + x] = evaluateBiomeAt(buffers, extIndex);
+    }
   }
 }
 
@@ -1740,43 +1807,51 @@ int TerrainGenerator::calculateHeight(float continental, float erosion,
 
 void TerrainGenerator::applyErosion(float *heightMap, int size) const
 {
-  if (size < 2)
+  applyErosion(heightMap, size, size, nullptr);
+}
+
+void TerrainGenerator::applyErosion(float *heightMap, int width, int height,
+                                    float *tempBuffer) const
+{
+  if (width < 2 || height < 2)
     return;
 
   // 1. Single Thermal Erosion pass (smooths overly steep slopes deterministically)
-  // We only run 1 iteration on the 28x28 extended heightmap. Cells [2,25]
-  // are fully deterministic across chunk windows because all four neighbors
-  // [1,26] are processed and their give-decisions only read sampled values
-  // [0,27]. (The old 20x20 window left the +/-1 border columns
-  // underdetermined because outer-ring cells never gave material.)
+  // Cells with at least 2 cells of halo from the border are fully deterministic
+  // across sampling windows because all four neighbors are processed and their
+  // give-decisions only read sampled values within the window.
   const float talusAngle = 0.6f;  // Max allowed height diff between adjacent cells
   const float thermalRate = 0.5f; // Fraction of material to move
+  const int totalCount = width * height;
 
-  float *tempMap;
-  std::vector<float> fallbackMap;
-  if (size <= EXT_SIZE)
+  float *tempMap = tempBuffer;
+  if (!tempMap)
   {
-    tempMap = s_genBuffers.erosionTempMap.data();
-    std::copy(heightMap, heightMap + size * size, tempMap);
-  }
-  else
-  {
-    fallbackMap.assign(heightMap, heightMap + size * size);
-    tempMap = fallbackMap.data();
-  }
-
-  for (int z = 1; z < size - 1; ++z)
-  {
-    for (int x = 1; x < size - 1; ++x)
+    if (totalCount <= EXT_SIZE * EXT_SIZE)
     {
-      int idx = z * size + x;
+      tempMap = s_genBuffers.erosionTempMap.data();
+    }
+    else
+    {
+      if (s_genBuffers.erosionTempBuf.size() < static_cast<size_t>(totalCount))
+        s_genBuffers.erosionTempBuf.resize(totalCount);
+      tempMap = s_genBuffers.erosionTempBuf.data();
+    }
+  }
+  std::copy(heightMap, heightMap + totalCount, tempMap);
+
+  for (int z = 1; z < height - 1; ++z)
+  {
+    for (int x = 1; x < width - 1; ++x)
+    {
+      int idx = z * width + x;
       float h = tempMap[idx];
 
       float maxDiff = 0.0f;
       int maxDiffIdx = -1;
 
       // Check 4 neighbors
-      const int neighbors[4] = {idx - 1, idx + 1, idx - size, idx + size};
+      const int neighbors[4] = {idx - 1, idx + 1, idx - width, idx + width};
       for (int i = 0; i < 4; ++i)
       {
         float diff = h - tempMap[neighbors[i]];
@@ -1795,10 +1870,10 @@ void TerrainGenerator::applyErosion(float *heightMap, int size) const
       }
     }
   }
-
+}
   // Hydraulic Erosion pass removed because particle simulation causes
   // boundary mismatches across asynchronously generated chunks.
-}
+
 
 // =============================================
 // VEGETATION GENERATION

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -768,12 +768,23 @@ ChunkData TerrainGenerator::generateChunkProfiled(
   }
 }
 
-void TerrainGenerator::sampleTerrainColumnNoiseAndHeights(
+void TerrainGenerator::sampleTerrainColumnFields(
     const TerrainColumnBuffers &buffers,
     int extStartX, int extStartZ,
     int extWidth, int extHeight,
     float step) const
 {
+  assert(extWidth > 0);
+  assert(extHeight > 0);
+  assert(buffers.continental != nullptr);
+  assert(buffers.erosion != nullptr);
+  assert(buffers.peaksValleys != nullptr);
+  assert(buffers.ridge != nullptr);
+  assert(buffers.temperature != nullptr);
+  assert(buffers.humidity != nullptr);
+  assert(buffers.weirdness != nullptr);
+  assert(buffers.river != nullptr);
+
   using Clock = std::chrono::steady_clock;
   const auto noise2DStart =
       m_activeProfile ? Clock::now() : Clock::time_point{};
@@ -799,25 +810,29 @@ void TerrainGenerator::sampleTerrainColumnNoiseAndHeights(
     m_activeProfile->noise2DMs +=
         std::chrono::duration<double, std::milli>(Clock::now() - noise2DStart)
             .count();
+}
 
-  const int totalPoints = extWidth * extHeight;
-  for (int i = 0; i < totalPoints; ++i)
+void TerrainGenerator::calculateTerrainHeights(
+    const TerrainColumnBuffers &buffers,
+    int extWidth, int extHeight) const
+{
+  assert(extWidth > 0);
+  assert(extHeight > 0);
+  assert(buffers.heightMap != nullptr);
+  assert(buffers.continental != nullptr);
+  assert(buffers.erosion != nullptr);
+  assert(buffers.peaksValleys != nullptr);
+  assert(buffers.ridge != nullptr);
+  assert(buffers.river != nullptr);
+  assert(buffers.weirdness != nullptr);
+
+  const size_t totalPoints = static_cast<size_t>(extWidth) * static_cast<size_t>(extHeight);
+  for (size_t i = 0; i < totalPoints; ++i)
   {
     buffers.heightMap[i] = calculateHeightFloat(
         buffers.continental[i], buffers.erosion[i],
         buffers.peaksValleys[i], buffers.ridge[i],
         buffers.river[i], buffers.weirdness[i]);
-  }
-
-  if (step == 1.0f)
-  {
-    const auto erosionStart =
-        m_activeProfile ? Clock::now() : Clock::time_point{};
-    applyErosion(buffers.heightMap, extWidth, extHeight, buffers.erosionTemp);
-    if (m_activeProfile)
-      m_activeProfile->erosionMs +=
-          std::chrono::duration<double, std::milli>(Clock::now() - erosionStart)
-              .count();
   }
 }
 
@@ -825,6 +840,15 @@ BiomeType TerrainGenerator::evaluateBiomeAt(
     const TerrainColumnBuffers &buffers,
     int extIndex) const
 {
+  assert(buffers.continental != nullptr);
+  assert(buffers.temperature != nullptr);
+  assert(buffers.humidity != nullptr);
+  assert(buffers.weirdness != nullptr);
+  assert(buffers.river != nullptr);
+  assert(buffers.erosion != nullptr);
+  assert(buffers.peaksValleys != nullptr);
+  assert(buffers.heightMap != nullptr);
+
   const float continental = std::clamp(buffers.continental[extIndex], -1.0f, 1.0f);
   const float temperature = std::clamp(buffers.temperature[extIndex], -1.0f, 1.0f);
   const float humidity = std::clamp(buffers.humidity[extIndex], -1.0f, 1.0f);
@@ -887,11 +911,13 @@ void TerrainGenerator::generateChunkBatch(ChunkData &chunkData, int chunkX,
       .heightMap = s_genBuffers.extendedHeightMap.data(),
       .erosionTemp = s_genBuffers.erosionTempMap.data()};
 
-  sampleTerrainColumnNoiseAndHeights(
+  sampleTerrainColumnFields(
       buffers,
       static_cast<int>(extendedWorldXf),
       static_cast<int>(extendedWorldZf),
       EXTENDED_SIZE, EXTENDED_SIZE, 1.0f);
+  calculateTerrainHeights(buffers, EXTENDED_SIZE, EXTENDED_SIZE);
+  applyCanonicalErosion(buffers.heightMap, EXTENDED_SIZE, EXTENDED_SIZE, buffers.erosionTemp);
 
   const auto aquiferStart =
       m_activeProfile ? Clock::now() : Clock::time_point{};
@@ -1584,7 +1610,24 @@ BiomeType TerrainGenerator::determineBiome(float temperature, float humidity,
   return BIOME_MOUNTAINS;
 }
 
-BiomeType TerrainGenerator::getBiomeAt(int worldX, int worldZ) const
+glm::vec2 TerrainGenerator::computeBiomeRegionWorldCoordinate(float centerX, float centerZ, float step,
+                                                             int width, int height,
+                                                             int xi, int zi)
+{
+  float wx = centerX + (static_cast<float>(xi) - static_cast<float>(width) * 0.5f) * step;
+  float wz = centerZ + (static_cast<float>(zi) - static_cast<float>(height) * 0.5f) * step;
+  return glm::vec2(wx, wz);
+}
+
+glm::ivec2 TerrainGenerator::computeBiomeRegionDiscreteColumn(float centerX, float centerZ, float step,
+                                                             int width, int height,
+                                                             int xi, int zi)
+{
+  glm::vec2 w = computeBiomeRegionWorldCoordinate(centerX, centerZ, step, width, height, xi, zi);
+  return glm::ivec2(static_cast<int>(std::round(w.x)), static_cast<int>(std::round(w.y)));
+}
+
+BiomeType TerrainGenerator::evaluateBiomeColumn(int worldX, int worldZ) const
 {
   constexpr int HALO = 2;
   constexpr int EXT_W = 1 + 2 * HALO;
@@ -1617,10 +1660,17 @@ BiomeType TerrainGenerator::getBiomeAt(int worldX, int worldZ) const
   const int extStartX = worldX + static_cast<int>(NOISE_OFFSET) - HALO;
   const int extStartZ = worldZ + static_cast<int>(NOISE_OFFSET) - HALO;
 
-  sampleTerrainColumnNoiseAndHeights(buffers, extStartX, extStartZ, EXT_W, EXT_H, 1.0f);
+  sampleTerrainColumnFields(buffers, extStartX, extStartZ, EXT_W, EXT_H, 1.0f);
+  calculateTerrainHeights(buffers, EXT_W, EXT_H);
+  applyCanonicalErosion(buffers.heightMap, EXT_W, EXT_H, buffers.erosionTemp);
 
   constexpr int centerIndex = HALO * EXT_W + HALO;
   return evaluateBiomeAt(buffers, centerIndex);
+}
+
+BiomeType TerrainGenerator::getBiomeAt(int worldX, int worldZ) const
+{
+  return evaluateBiomeColumn(worldX, worldZ);
 }
 
 void TerrainGenerator::getBiomeRegion(float centerX, float centerZ, float step,
@@ -1636,58 +1686,167 @@ void TerrainGenerator::getBiomeRegion(float centerX, float centerZ, float step,
   const int count = width * height;
   outBiomes.resize(count);
 
-  // GenUniformGrid2D samples pixel (xi, yi) at noise coordinate (xStart + xi) * frequency.
-  // We want that to equal worldX_of_pixel + NOISE_OFFSET, where
-  //   worldX_of_pixel = centerX + (xi - width/2) * step
-  // => (xStart + xi) * step == centerX + (xi - width/2) * step + NOISE_OFFSET
-  // => xStart == (centerX + NOISE_OFFSET) / step - width/2
-  // xStart must be an int (FastNoise2 API), so we round to the nearest grid cell.
-  const float invStep = 1.0f / step;
-  const int startX = static_cast<int>(std::round((centerX + NOISE_OFFSET) * invStep - width * 0.5f));
-  const int startZ = static_cast<int>(std::round((centerZ + NOISE_OFFSET) * invStep - height * 0.5f));
+  glm::ivec2 minCol = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, 0, 0);
+  glm::ivec2 maxCol = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, width - 1, height - 1);
+  int minWorldX = std::min(minCol.x, maxCol.x);
+  int maxWorldX = std::max(minCol.x, maxCol.x);
+  int minWorldZ = std::min(minCol.y, maxCol.y);
+  int maxWorldZ = std::max(minCol.y, maxCol.y);
+
+  int spanX = maxWorldX - minWorldX + 1;
+  int spanZ = maxWorldZ - minWorldZ + 1;
 
   constexpr int HALO = 2;
-  const int extWidth = width + 2 * HALO;
-  const int extHeight = height + 2 * HALO;
-  const int extCount = extWidth * extHeight;
+  int denseWidth = spanX + 2 * HALO;
+  int denseHeight = spanZ + 2 * HALO;
+  size_t totalDensePoints = static_cast<size_t>(denseWidth) * static_cast<size_t>(denseHeight);
 
-  if (s_genBuffers.tempBuf.size() < static_cast<size_t>(extCount))
+  // If the total dense domain is within ~1 MB (~266K points), sample in a single pass at step = 1.0f
+  constexpr size_t MAX_DENSE_DOMAIN_POINTS = 516 * 516;
+
+  if (totalDensePoints <= MAX_DENSE_DOMAIN_POINTS)
   {
-    s_genBuffers.tempBuf.resize(extCount);
-    s_genBuffers.humidBuf.resize(extCount);
-    s_genBuffers.weirdBuf.resize(extCount);
-    s_genBuffers.riverBuf.resize(extCount);
-    s_genBuffers.contBuf.resize(extCount);
-    s_genBuffers.erosionBuf.resize(extCount);
-    s_genBuffers.pvBuf.resize(extCount);
-    s_genBuffers.ridgeBuf.resize(extCount);
-    s_genBuffers.heightBuf.resize(extCount);
-    s_genBuffers.erosionTempBuf.resize(extCount);
-  }
-
-  TerrainColumnBuffers buffers{
-      .continental = s_genBuffers.contBuf.data(),
-      .erosion = s_genBuffers.erosionBuf.data(),
-      .peaksValleys = s_genBuffers.pvBuf.data(),
-      .ridge = s_genBuffers.ridgeBuf.data(),
-      .temperature = s_genBuffers.tempBuf.data(),
-      .humidity = s_genBuffers.humidBuf.data(),
-      .weirdness = s_genBuffers.weirdBuf.data(),
-      .river = s_genBuffers.riverBuf.data(),
-      .heightMap = s_genBuffers.heightBuf.data(),
-      .erosionTemp = s_genBuffers.erosionTempBuf.data()};
-
-  const int extStartX = startX - HALO;
-  const int extStartZ = startZ - HALO;
-
-  sampleTerrainColumnNoiseAndHeights(buffers, extStartX, extStartZ, extWidth, extHeight, step);
-
-  for (int z = 0; z < height; ++z)
-  {
-    for (int x = 0; x < width; ++x)
+    if (s_genBuffers.tempBuf.size() < totalDensePoints)
     {
-      const int extIndex = (z + HALO) * extWidth + (x + HALO);
-      outBiomes[z * width + x] = evaluateBiomeAt(buffers, extIndex);
+      s_genBuffers.tempBuf.resize(totalDensePoints);
+      s_genBuffers.humidBuf.resize(totalDensePoints);
+      s_genBuffers.weirdBuf.resize(totalDensePoints);
+      s_genBuffers.riverBuf.resize(totalDensePoints);
+      s_genBuffers.contBuf.resize(totalDensePoints);
+      s_genBuffers.erosionBuf.resize(totalDensePoints);
+      s_genBuffers.pvBuf.resize(totalDensePoints);
+      s_genBuffers.ridgeBuf.resize(totalDensePoints);
+      s_genBuffers.heightBuf.resize(totalDensePoints);
+      s_genBuffers.erosionTempBuf.resize(totalDensePoints);
+    }
+
+    TerrainColumnBuffers buffers{
+        .continental = s_genBuffers.contBuf.data(),
+        .erosion = s_genBuffers.erosionBuf.data(),
+        .peaksValleys = s_genBuffers.pvBuf.data(),
+        .ridge = s_genBuffers.ridgeBuf.data(),
+        .temperature = s_genBuffers.tempBuf.data(),
+        .humidity = s_genBuffers.humidBuf.data(),
+        .weirdness = s_genBuffers.weirdBuf.data(),
+        .river = s_genBuffers.riverBuf.data(),
+        .heightMap = s_genBuffers.heightBuf.data(),
+        .erosionTemp = s_genBuffers.erosionTempBuf.data()};
+
+    const int denseStartX = minWorldX - HALO;
+    const int denseStartZ = minWorldZ - HALO;
+
+    sampleTerrainColumnFields(buffers,
+                              denseStartX + static_cast<int>(NOISE_OFFSET),
+                              denseStartZ + static_cast<int>(NOISE_OFFSET),
+                              denseWidth, denseHeight, 1.0f);
+    calculateTerrainHeights(buffers, denseWidth, denseHeight);
+    applyCanonicalErosion(buffers.heightMap, denseWidth, denseHeight, buffers.erosionTemp);
+
+    for (int zi = 0; zi < height; ++zi)
+    {
+      for (int xi = 0; xi < width; ++xi)
+      {
+        glm::ivec2 col = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, xi, zi);
+        int denseX = col.x - denseStartX;
+        int denseZ = col.y - denseStartZ;
+        outBiomes[zi * width + xi] = evaluateBiomeAt(buffers, denseZ * denseWidth + denseX);
+      }
+    }
+  }
+  else
+  {
+    // Bounded tiled path for large regions / zoom-outs (step >= 4 or large width/height):
+    // Process in tiles of up to 32x32 output pixels.
+    constexpr int TILE_DIM = 32;
+    constexpr size_t MAX_TILE_DENSE_POINTS = 132 * 132; // ~17K points (~68 KB per buffer)
+
+    const int tilesX = (width + TILE_DIM - 1) / TILE_DIM;
+    const int tilesZ = (height + TILE_DIM - 1) / TILE_DIM;
+
+    for (int tz = 0; tz < tilesZ; ++tz)
+    {
+      for (int tx = 0; tx < tilesX; ++tx)
+      {
+        int x0 = tx * TILE_DIM;
+        int z0 = tz * TILE_DIM;
+        int x1 = std::min(x0 + TILE_DIM - 1, width - 1);
+        int z1 = std::min(z0 + TILE_DIM - 1, height - 1);
+
+        glm::ivec2 tMinCol = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, x0, z0);
+        glm::ivec2 tMaxCol = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, x1, z1);
+        int tMinX = std::min(tMinCol.x, tMaxCol.x);
+        int tMaxX = std::max(tMinCol.x, tMaxCol.x);
+        int tMinZ = std::min(tMinCol.y, tMaxCol.y);
+        int tMaxZ = std::max(tMinCol.y, tMaxCol.y);
+
+        int tSpanX = tMaxX - tMinX + 1;
+        int tSpanZ = tMaxZ - tMinZ + 1;
+        int tDenseW = tSpanX + 2 * HALO;
+        int tDenseH = tSpanZ + 2 * HALO;
+        size_t tDensePoints = static_cast<size_t>(tDenseW) * static_cast<size_t>(tDenseH);
+
+        if (tDensePoints <= MAX_TILE_DENSE_POINTS)
+        {
+          if (s_genBuffers.tempBuf.size() < tDensePoints)
+          {
+            s_genBuffers.tempBuf.resize(tDensePoints);
+            s_genBuffers.humidBuf.resize(tDensePoints);
+            s_genBuffers.weirdBuf.resize(tDensePoints);
+            s_genBuffers.riverBuf.resize(tDensePoints);
+            s_genBuffers.contBuf.resize(tDensePoints);
+            s_genBuffers.erosionBuf.resize(tDensePoints);
+            s_genBuffers.pvBuf.resize(tDensePoints);
+            s_genBuffers.ridgeBuf.resize(tDensePoints);
+            s_genBuffers.heightBuf.resize(tDensePoints);
+            s_genBuffers.erosionTempBuf.resize(tDensePoints);
+          }
+
+          TerrainColumnBuffers buffers{
+              .continental = s_genBuffers.contBuf.data(),
+              .erosion = s_genBuffers.erosionBuf.data(),
+              .peaksValleys = s_genBuffers.pvBuf.data(),
+              .ridge = s_genBuffers.ridgeBuf.data(),
+              .temperature = s_genBuffers.tempBuf.data(),
+              .humidity = s_genBuffers.humidBuf.data(),
+              .weirdness = s_genBuffers.weirdBuf.data(),
+              .river = s_genBuffers.riverBuf.data(),
+              .heightMap = s_genBuffers.heightBuf.data(),
+              .erosionTemp = s_genBuffers.erosionTempBuf.data()};
+
+          const int tDenseStartX = tMinX - HALO;
+          const int tDenseStartZ = tMinZ - HALO;
+
+          sampleTerrainColumnFields(buffers,
+                                    tDenseStartX + static_cast<int>(NOISE_OFFSET),
+                                    tDenseStartZ + static_cast<int>(NOISE_OFFSET),
+                                    tDenseW, tDenseH, 1.0f);
+          calculateTerrainHeights(buffers, tDenseW, tDenseH);
+          applyCanonicalErosion(buffers.heightMap, tDenseW, tDenseH, buffers.erosionTemp);
+
+          for (int zi = z0; zi <= z1; ++zi)
+          {
+            for (int xi = x0; xi <= x1; ++xi)
+            {
+              glm::ivec2 col = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, xi, zi);
+              int denseX = col.x - tDenseStartX;
+              int denseZ = col.y - tDenseStartZ;
+              outBiomes[zi * width + xi] = evaluateBiomeAt(buffers, denseZ * tDenseW + denseX);
+            }
+          }
+        }
+        else
+        {
+          // Large step fallback: evaluate point canonical columns directly
+          for (int zi = z0; zi <= z1; ++zi)
+          {
+            for (int xi = x0; xi <= x1; ++xi)
+            {
+              glm::ivec2 col = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, xi, zi);
+              outBiomes[zi * width + xi] = evaluateBiomeColumn(col.x, col.y);
+            }
+          }
+        }
+      }
     }
   }
 }
@@ -1807,14 +1966,20 @@ int TerrainGenerator::calculateHeight(float continental, float erosion,
 
 void TerrainGenerator::applyErosion(float *heightMap, int size) const
 {
-  applyErosion(heightMap, size, size, nullptr);
+  applyCanonicalErosion(heightMap, size, size, nullptr);
 }
 
-void TerrainGenerator::applyErosion(float *heightMap, int width, int height,
-                                    float *tempBuffer) const
+void TerrainGenerator::applyCanonicalErosion(float *heightMap, int width, int height,
+                                            float *tempBuffer) const
 {
   if (width < 2 || height < 2)
     return;
+
+  assert(heightMap != nullptr);
+
+  using Clock = std::chrono::steady_clock;
+  const auto erosionStart =
+      m_activeProfile ? Clock::now() : Clock::time_point{};
 
   // 1. Single Thermal Erosion pass (smooths overly steep slopes deterministically)
   // Cells with at least 2 cells of halo from the border are fully deterministic
@@ -1870,6 +2035,10 @@ void TerrainGenerator::applyErosion(float *heightMap, int width, int height,
       }
     }
   }
+  if (m_activeProfile)
+    m_activeProfile->erosionMs +=
+        std::chrono::duration<double, std::milli>(Clock::now() - erosionStart)
+            .count();
 }
   // Hydraulic Erosion pass removed because particle simulation causes
   // boundary mismatches across asynchronously generated chunks.

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -595,9 +595,12 @@ static thread_local TerrainGenerator::BiomeRegionScratch s_biomeRegionScratch;
 
 void TerrainGenerator::BiomeRegionScratch::trimOversizedCapacity()
 {
-  // Keep tiled-path-sized buffers for cheap reuse; release the large
-  // single-pass dense capacity (~10 MiB at the bound) so idle threads do
-  // not retain the peak after a zoomed-in map build.
+  // Releases capacity above the tiled-path bound. getBiomeRegion() calls
+  // this on every exit through an unconditional guard — after successful
+  // AND cancelled/failed attempts — so oversized dense capacity is never
+  // retained across attempts while tiled-sized capacity survives for
+  // cheap reuse. Call it manually only when mutating a scratch outside
+  // getBiomeRegion().
   const size_t keep = kMaxTileDensePoints;
   for (std::vector<float> *field : {&temperature, &humidity, &weirdness, &river,
                                     &continental, &erosion, &peaksValleys,
@@ -1687,6 +1690,17 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
   // thread-local so region capacity never lands in the shared chunk
   // generation buffers.
   BiomeRegionScratch &bufs = scratch ? *scratch : s_biomeRegionScratch;
+
+  // Unconditional cleanup on EVERY exit — success, cancellation, early
+  // failure, or an exception propagating out — so no path can retain the
+  // ~10 MiB dense peak (this makes cancelled biome-map builds as
+  // memory-safe as successful ones). Tiled-sized capacity survives for
+  // cheap reuse.
+  struct ScratchTrimGuard
+  {
+    BiomeRegionScratch &target;
+    ~ScratchTrimGuard() { target.trimOversizedCapacity(); }
+  } trimGuard{bufs};
 
   BiomeRegionStats localStats;
   BiomeRegionStats &stats = outStats ? *outStats : localStats;

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -2,12 +2,9 @@
 #include <Chunk/StreamHelpers.hpp>
 #include <Renderer/MinecraftTextures.hpp>
 #include <algorithm>
-#include <atomic>
 #include <chrono>
 #include <cmath>
-#include <exception>
 #include <mutex>
-#include <thread>
 
 // =============================================
 // STATIC MEMBER INITIALIZATION
@@ -585,24 +582,31 @@ struct GenBuffers
   // Reusable buffer for erosion calculation
   std::array<float, EXT_SIZE * EXT_SIZE> erosionTempMap;
 
-  // Reusable buffers for biome region generation
-  // Using 512*512 max size to accommodate the UI map which defaults to 256
-  std::vector<float> tempBuf;
-  std::vector<float> humidBuf;
-  std::vector<float> weirdBuf;
-  std::vector<float> riverBuf;
-  std::vector<float> contBuf;
-  std::vector<float> erosionBuf;
-  std::vector<float> pvBuf;
-  std::vector<float> ridgeBuf;
-  std::vector<float> heightBuf;
-  std::vector<float> erosionTempBuf;
-
   // Persistent generator to avoid expensive setup every chunk
   std::unique_ptr<TerrainGenerator> generator;
 };
 
 static thread_local GenBuffers s_genBuffers;
+
+// Dedicated scratch for biome region queries that runs on threads which do
+// not provide their own scratch. Kept separate from GenBuffers so chunk
+// generation workers never retain region-query capacity.
+static thread_local TerrainGenerator::BiomeRegionScratch s_biomeRegionScratch;
+
+void TerrainGenerator::BiomeRegionScratch::trimOversizedCapacity()
+{
+  // Keep tiled-path-sized buffers for cheap reuse; release the large
+  // single-pass dense capacity (~10 MiB at the bound) so idle threads do
+  // not retain the peak after a zoomed-in map build.
+  const size_t keep = kMaxTileDensePoints;
+  for (std::vector<float> *field : {&temperature, &humidity, &weirdness, &river,
+                                    &continental, &erosion, &peaksValleys,
+                                    &ridge, &height, &erosionTemp})
+  {
+    if (field->capacity() > keep)
+      std::vector<float>().swap(*field);
+  }
+}
 
 namespace
 {
@@ -1666,11 +1670,12 @@ bool TerrainGenerator::getBiomeRegion(float centerX, float centerZ, float step,
                                       BiomeRegionStats *outStats) const
 {
   return getBiomeRegion(makeBiomeRegionGrid(centerX, centerZ, step, width, height),
-                        outBiomes, shouldCancel, outStats);
+                        outBiomes, nullptr, shouldCancel, outStats);
 }
 
 bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
                                       std::vector<BiomeType> &outBiomes,
+                                      BiomeRegionScratch *scratch,
                                       const BiomeCancelCheck &shouldCancel,
                                       BiomeRegionStats *outStats) const
 {
@@ -1678,12 +1683,57 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
   if (!grid.valid())
     return false;
 
+  // Scratch owned by the caller when provided; otherwise a dedicated
+  // thread-local so region capacity never lands in the shared chunk
+  // generation buffers.
+  BiomeRegionScratch &bufs = scratch ? *scratch : s_biomeRegionScratch;
+
   BiomeRegionStats localStats;
   BiomeRegionStats &stats = outStats ? *outStats : localStats;
   stats = {};
 
   const auto checkCancelled = [&shouldCancel]() {
     return static_cast<bool>(shouldCancel) && shouldCancel();
+  };
+
+  // Canonical voxel columns are clamped to a sane domain: extreme grid
+  // parameters (e.g. enormous step or center) would otherwise overflow the
+  // int math downstream (span differences, the + NOISE_OFFSET noise-domain
+  // translation). One billion blocks is far beyond any reachable world.
+  constexpr int64_t kColumnLimit = 1000000000;
+  const auto canonicalColumn = [&grid, kColumnLimit](int xi, int zi) {
+    const glm::ivec2 col = grid.columnAt(xi, zi);
+    return glm::ivec2(
+        static_cast<int>(std::clamp<int64_t>(col.x, -kColumnLimit, kColumnLimit)),
+        static_cast<int>(std::clamp<int64_t>(col.y, -kColumnLimit, kColumnLimit)));
+  };
+
+  // Track the largest dense domain sampled in one shot for the stats.
+  const auto updatePeak = [&stats](int64_t points) {
+    if (static_cast<int64_t>(stats.peakDensePoints) < points)
+    {
+      stats.peakDensePoints = static_cast<size_t>(points);
+      stats.peakScratchBytes =
+          stats.peakDensePoints * kBiomeRegionScratchFields * sizeof(float);
+    }
+  };
+
+  // Grow all scratch fields to hold `points` floats.
+  const auto ensureScratch = [&](int64_t points) {
+    const size_t n = static_cast<size_t>(points);
+    if (bufs.temperature.size() < n)
+    {
+      bufs.temperature.resize(n);
+      bufs.humidity.resize(n);
+      bufs.weirdness.resize(n);
+      bufs.river.resize(n);
+      bufs.continental.resize(n);
+      bufs.erosion.resize(n);
+      bufs.peaksValleys.resize(n);
+      bufs.ridge.resize(n);
+      bufs.height.resize(n);
+      bufs.erosionTemp.resize(n);
+    }
   };
 
   // Fill output pixels [x0..x1]x[z0..z1] from an already-sampled dense
@@ -1695,7 +1745,7 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
     {
       for (int xi = x0; xi <= x1; ++xi)
       {
-        const glm::ivec2 col = grid.columnAt(xi, zi);
+        const glm::ivec2 col = canonicalColumn(xi, zi);
         const int denseX = col.x - denseStartX;
         const int denseZ = col.y - denseStartZ;
         outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(grid.width) +
@@ -1705,74 +1755,62 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
     }
   };
 
-  const glm::ivec2 minCol = grid.columnAt(0, 0);
-  const glm::ivec2 maxCol = grid.columnAt(grid.width - 1, grid.height - 1);
-  const int minWorldX = std::min(minCol.x, maxCol.x);
-  const int maxWorldX = std::max(minCol.x, maxCol.x);
-  const int minWorldZ = std::min(minCol.y, maxCol.y);
-  const int maxWorldZ = std::max(minCol.y, maxCol.y);
+  const glm::ivec2 minCol = canonicalColumn(0, 0);
+  const glm::ivec2 maxCol = canonicalColumn(grid.width - 1, grid.height - 1);
+  const int64_t minWorldX = std::min<int64_t>(minCol.x, maxCol.x);
+  const int64_t maxWorldX = std::max<int64_t>(minCol.x, maxCol.x);
+  const int64_t minWorldZ = std::min<int64_t>(minCol.y, maxCol.y);
+  const int64_t maxWorldZ = std::max<int64_t>(minCol.y, maxCol.y);
 
-  const int spanX = maxWorldX - minWorldX + 1;
-  const int spanZ = maxWorldZ - minWorldZ + 1;
+  // Spans in int64_t: extreme grid parameters must not overflow.
+  const int64_t spanX = maxWorldX - minWorldX + 1;
+  const int64_t spanZ = maxWorldZ - minWorldZ + 1;
 
   constexpr int HALO = 2;
-  const int denseWidth = spanX + 2 * HALO;
-  const int denseHeight = spanZ + 2 * HALO;
-  const size_t totalDensePoints = static_cast<size_t>(denseWidth) * static_cast<size_t>(denseHeight);
-
-  // Bound the dense-domain point count to keep total scratch memory around
-  // ~10 MiB: each point costs one float in each of the ~10 scratch fields,
-  // so 266K points x 10 buffers x 4 bytes, not per-buffer.
-  constexpr size_t MAX_DENSE_DOMAIN_POINTS = 516 * 516;
+  const int64_t denseWidth = spanX + 2 * HALO;
+  const int64_t denseHeight = spanZ + 2 * HALO;
+  const int64_t totalDensePoints = denseWidth * denseHeight;
 
   const size_t outputCount = static_cast<size_t>(grid.width) * static_cast<size_t>(grid.height);
 
-  if (totalDensePoints <= MAX_DENSE_DOMAIN_POINTS)
+  if (totalDensePoints <= static_cast<int64_t>(kMaxDenseDomainPoints))
   {
     if (checkCancelled())
       return false;
 
     outBiomes.resize(outputCount);
-
-    if (s_genBuffers.tempBuf.size() < totalDensePoints)
-    {
-      s_genBuffers.tempBuf.resize(totalDensePoints);
-      s_genBuffers.humidBuf.resize(totalDensePoints);
-      s_genBuffers.weirdBuf.resize(totalDensePoints);
-      s_genBuffers.riverBuf.resize(totalDensePoints);
-      s_genBuffers.contBuf.resize(totalDensePoints);
-      s_genBuffers.erosionBuf.resize(totalDensePoints);
-      s_genBuffers.pvBuf.resize(totalDensePoints);
-      s_genBuffers.ridgeBuf.resize(totalDensePoints);
-      s_genBuffers.heightBuf.resize(totalDensePoints);
-      s_genBuffers.erosionTempBuf.resize(totalDensePoints);
-    }
+    ensureScratch(totalDensePoints);
 
     TerrainColumnBuffers buffers{
-        .continental = s_genBuffers.contBuf.data(),
-        .erosion = s_genBuffers.erosionBuf.data(),
-        .peaksValleys = s_genBuffers.pvBuf.data(),
-        .ridge = s_genBuffers.ridgeBuf.data(),
-        .temperature = s_genBuffers.tempBuf.data(),
-        .humidity = s_genBuffers.humidBuf.data(),
-        .weirdness = s_genBuffers.weirdBuf.data(),
-        .river = s_genBuffers.riverBuf.data(),
-        .heightMap = s_genBuffers.heightBuf.data(),
-        .erosionTemp = s_genBuffers.erosionTempBuf.data()};
+        .continental = bufs.continental.data(),
+        .erosion = bufs.erosion.data(),
+        .peaksValleys = bufs.peaksValleys.data(),
+        .ridge = bufs.ridge.data(),
+        .temperature = bufs.temperature.data(),
+        .humidity = bufs.humidity.data(),
+        .weirdness = bufs.weirdness.data(),
+        .river = bufs.river.data(),
+        .heightMap = bufs.height.data(),
+        .erosionTemp = bufs.erosionTemp.data()};
 
-    const int denseStartX = minWorldX - HALO;
-    const int denseStartZ = minWorldZ - HALO;
+    const int denseStartX = static_cast<int>(minWorldX) - HALO;
+    const int denseStartZ = static_cast<int>(minWorldZ) - HALO;
 
     sampleTerrainColumnFields(buffers,
                               denseStartX + static_cast<int>(NOISE_OFFSET),
                               denseStartZ + static_cast<int>(NOISE_OFFSET),
-                              denseWidth, denseHeight, 1.0f);
-    calculateTerrainHeights(buffers, denseWidth, denseHeight);
-    applyCanonicalErosion(buffers.heightMap, denseWidth, denseHeight, buffers.erosionTemp);
+                              static_cast<int>(denseWidth),
+                              static_cast<int>(denseHeight), 1.0f);
+    calculateTerrainHeights(buffers, static_cast<int>(denseWidth),
+                            static_cast<int>(denseHeight));
+    applyCanonicalErosion(buffers.heightMap, static_cast<int>(denseWidth),
+                          static_cast<int>(denseHeight), buffers.erosionTemp);
 
-    fillOutputFromDense(buffers, denseStartX, denseStartZ, denseWidth,
+    fillOutputFromDense(buffers, denseStartX, denseStartZ,
+                        static_cast<int>(denseWidth),
                         0, grid.width - 1, 0, grid.height - 1);
     ++stats.denseTiles;
+    updatePeak(totalDensePoints);
 
     // Late cancellation: never return a fully-sampled but rejected result.
     if (checkCancelled())
@@ -1785,194 +1823,103 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
 
   // Bounded tiled path for large regions / zoom-outs. The tile dimension is
   // derived from grid.step so each tile's haloed dense domain always fits in
-  // MAX_TILE_DENSE_POINTS even at the smallest zoom (largest step), keeping
+  // kMaxTileDensePoints even at the smallest zoom (largest step), keeping
   // every pixel on the vectorized dense path. The point-query fallback below
-  // is a safety net, not the normal path for any zoom. Tiles are independent
-  // (disjoint output pixels, thread_local scratch) and execute in parallel.
-  constexpr size_t MAX_TILE_DENSE_POINTS = 132 * 132; // ~17K points (~68 KB per float buffer)
+  // is a safety net, not the normal path for any zoom.
   constexpr int kMaxTileDim = 32;
-  const float maxTileSpan = std::sqrt(static_cast<float>(MAX_TILE_DENSE_POINTS));
+  const float maxTileSpan = std::sqrt(static_cast<float>(kMaxTileDensePoints));
   const float tileDimF =
       std::floor((maxTileSpan - 1.0f - static_cast<float>(2 * HALO)) / grid.step) + 1.0f;
   const int tileDim = std::clamp(static_cast<int>(tileDimF), 1, kMaxTileDim);
 
   const int tilesX = (grid.width + tileDim - 1) / tileDim;
   const int tilesZ = (grid.height + tileDim - 1) / tileDim;
-  const int totalTiles = tilesX * tilesZ;
 
   outBiomes.resize(outputCount);
 
-  // Process one tile on the calling thread's generator/scratch buffers.
-  // Thread-safe by construction: tiles write only their own output pixels
-  // and all scratch state lives in thread_local storage.
-  const auto processTile = [&](const TerrainGenerator &tileGen, int tx, int tz,
-                               uint64_t &denseAdd, uint64_t &fallbackAdd) {
-    denseAdd = 0;
-    fallbackAdd = 0;
-
-    const int x0 = tx * tileDim;
-    const int z0 = tz * tileDim;
-    const int x1 = std::min(x0 + tileDim - 1, grid.width - 1);
-    const int z1 = std::min(z0 + tileDim - 1, grid.height - 1);
-
-    const glm::ivec2 tMinCol = grid.columnAt(x0, z0);
-    const glm::ivec2 tMaxCol = grid.columnAt(x1, z1);
-    const int tMinX = std::min(tMinCol.x, tMaxCol.x);
-    const int tMaxX = std::max(tMinCol.x, tMaxCol.x);
-    const int tMinZ = std::min(tMinCol.y, tMaxCol.y);
-    const int tMaxZ = std::max(tMinCol.y, tMaxCol.y);
-
-    const int tDenseW = (tMaxX - tMinX + 1) + 2 * HALO;
-    const int tDenseH = (tMaxZ - tMinZ + 1) + 2 * HALO;
-    const size_t tDensePoints = static_cast<size_t>(tDenseW) * static_cast<size_t>(tDenseH);
-
-    if (tDensePoints <= MAX_TILE_DENSE_POINTS) // guaranteed by tileDim; kept as a guard
-    {
-      if (s_genBuffers.tempBuf.size() < tDensePoints)
-      {
-        s_genBuffers.tempBuf.resize(tDensePoints);
-        s_genBuffers.humidBuf.resize(tDensePoints);
-        s_genBuffers.weirdBuf.resize(tDensePoints);
-        s_genBuffers.riverBuf.resize(tDensePoints);
-        s_genBuffers.contBuf.resize(tDensePoints);
-        s_genBuffers.erosionBuf.resize(tDensePoints);
-        s_genBuffers.pvBuf.resize(tDensePoints);
-        s_genBuffers.ridgeBuf.resize(tDensePoints);
-        s_genBuffers.heightBuf.resize(tDensePoints);
-        s_genBuffers.erosionTempBuf.resize(tDensePoints);
-      }
-
-      TerrainColumnBuffers buffers{
-          .continental = s_genBuffers.contBuf.data(),
-          .erosion = s_genBuffers.erosionBuf.data(),
-          .peaksValleys = s_genBuffers.pvBuf.data(),
-          .ridge = s_genBuffers.ridgeBuf.data(),
-          .temperature = s_genBuffers.tempBuf.data(),
-          .humidity = s_genBuffers.humidBuf.data(),
-          .weirdness = s_genBuffers.weirdBuf.data(),
-          .river = s_genBuffers.riverBuf.data(),
-          .heightMap = s_genBuffers.heightBuf.data(),
-          .erosionTemp = s_genBuffers.erosionTempBuf.data()};
-
-      const int tDenseStartX = tMinX - HALO;
-      const int tDenseStartZ = tMinZ - HALO;
-
-      tileGen.sampleTerrainColumnFields(buffers,
-                                        tDenseStartX + static_cast<int>(NOISE_OFFSET),
-                                        tDenseStartZ + static_cast<int>(NOISE_OFFSET),
-                                        tDenseW, tDenseH, 1.0f);
-      tileGen.calculateTerrainHeights(buffers, tDenseW, tDenseH);
-      tileGen.applyCanonicalErosion(buffers.heightMap, tDenseW, tDenseH, buffers.erosionTemp);
-
-      fillOutputFromDense(buffers, tDenseStartX, tDenseStartZ, tDenseW, x0, x1, z0, z1);
-      ++denseAdd;
-    }
-    else
-    {
-      // Safety net only: evaluate point canonical columns directly.
-      for (int zi = z0; zi <= z1; ++zi)
-      {
-        for (int xi = x0; xi <= x1; ++xi)
-        {
-          const glm::ivec2 col = grid.columnAt(xi, zi);
-          outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(grid.width) +
-                    static_cast<size_t>(xi)] = tileGen.evaluateBiomeColumn(col.x, col.y);
-        }
-      }
-      fallbackAdd += static_cast<uint64_t>(x1 - x0 + 1) *
-                     static_cast<uint64_t>(z1 - z0 + 1);
-    }
-  };
-
-  unsigned hardwareThreads = std::thread::hardware_concurrency();
-  if (hardwareThreads == 0)
-    hardwareThreads = 1;
-  const unsigned workerCount = std::min(std::min(hardwareThreads, 16u),
-                                        static_cast<unsigned>(totalTiles));
-
-  if (workerCount <= 1)
+  // Tiles are processed sequentially in fixed order: the result depends only
+  // on the grid and the seed, never on scheduling. TerrainGenerator does not
+  // spawn threads and does not decide CPU policy; the caller chooses when and
+  // on which worker the whole call runs (the Engine runs the biome map as a
+  // single TaskPriority::Low job).
+  for (int tz = 0; tz < tilesZ; ++tz)
   {
-    uint64_t denseAdd = 0;
-    uint64_t fallbackAdd = 0;
-    for (int tz = 0; tz < tilesZ; ++tz)
+    for (int tx = 0; tx < tilesX; ++tx)
     {
-      for (int tx = 0; tx < tilesX; ++tx)
+      // Cancellation checkpoint: polled before every tile so a long
+      // zoomed-out map build can be abandoned promptly.
+      if (checkCancelled())
       {
-        // Cancellation checkpoint: polled before every tile so a long
-        // zoomed-out map build can be abandoned promptly.
-        if (checkCancelled())
+        outBiomes.clear();
+        return false;
+      }
+
+      const int x0 = tx * tileDim;
+      const int z0 = tz * tileDim;
+      const int x1 = std::min(x0 + tileDim - 1, grid.width - 1);
+      const int z1 = std::min(z0 + tileDim - 1, grid.height - 1);
+
+      const glm::ivec2 tMinCol = canonicalColumn(x0, z0);
+      const glm::ivec2 tMaxCol = canonicalColumn(x1, z1);
+      const int64_t tMinX = std::min<int64_t>(tMinCol.x, tMaxCol.x);
+      const int64_t tMaxX = std::max<int64_t>(tMinCol.x, tMaxCol.x);
+      const int64_t tMinZ = std::min<int64_t>(tMinCol.y, tMaxCol.y);
+      const int64_t tMaxZ = std::max<int64_t>(tMinCol.y, tMaxCol.y);
+
+      const int64_t tDenseW = (tMaxX - tMinX + 1) + 2 * HALO;
+      const int64_t tDenseH = (tMaxZ - tMinZ + 1) + 2 * HALO;
+      const int64_t tDensePoints = tDenseW * tDenseH;
+
+      if (tDensePoints <= static_cast<int64_t>(kMaxTileDensePoints)) // guaranteed by tileDim; kept as a guard
+      {
+        ensureScratch(tDensePoints);
+
+        TerrainColumnBuffers buffers{
+            .continental = bufs.continental.data(),
+            .erosion = bufs.erosion.data(),
+            .peaksValleys = bufs.peaksValleys.data(),
+            .ridge = bufs.ridge.data(),
+            .temperature = bufs.temperature.data(),
+            .humidity = bufs.humidity.data(),
+            .weirdness = bufs.weirdness.data(),
+            .river = bufs.river.data(),
+            .heightMap = bufs.height.data(),
+            .erosionTemp = bufs.erosionTemp.data()};
+
+        const int tDenseStartX = static_cast<int>(tMinX) - HALO;
+        const int tDenseStartZ = static_cast<int>(tMinZ) - HALO;
+
+        sampleTerrainColumnFields(buffers,
+                                  tDenseStartX + static_cast<int>(NOISE_OFFSET),
+                                  tDenseStartZ + static_cast<int>(NOISE_OFFSET),
+                                  static_cast<int>(tDenseW),
+                                  static_cast<int>(tDenseH), 1.0f);
+        calculateTerrainHeights(buffers, static_cast<int>(tDenseW),
+                                static_cast<int>(tDenseH));
+        applyCanonicalErosion(buffers.heightMap, static_cast<int>(tDenseW),
+                              static_cast<int>(tDenseH), buffers.erosionTemp);
+
+        fillOutputFromDense(buffers, tDenseStartX, tDenseStartZ,
+                            static_cast<int>(tDenseW), x0, x1, z0, z1);
+        ++stats.denseTiles;
+        updatePeak(tDensePoints);
+      }
+      else
+      {
+        // Safety net only: evaluate point canonical columns directly.
+        for (int zi = z0; zi <= z1; ++zi)
         {
-          outBiomes.clear();
-          return false;
+          for (int xi = x0; xi <= x1; ++xi)
+          {
+            const glm::ivec2 col = canonicalColumn(xi, zi);
+            outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(grid.width) +
+                      static_cast<size_t>(xi)] = evaluateBiomeColumn(col.x, col.y);
+          }
         }
-        processTile(*this, tx, tz, denseAdd, fallbackAdd);
-        stats.denseTiles += denseAdd;
-        stats.fallbackPixels += fallbackAdd;
+        stats.fallbackPixels += static_cast<uint64_t>(x1 - x0 + 1) *
+                                static_cast<uint64_t>(z1 - z0 + 1);
       }
     }
-    return true;
-  }
-
-  // Parallel workers pull tiles from a shared index. Tile results are
-  // deterministic regardless of scheduling.
-  std::atomic<int> nextTile{0};
-  std::atomic<bool> cancelObserved{false};
-  std::atomic<uint64_t> denseAccum{0};
-  std::atomic<uint64_t> fallbackAccum{0};
-  std::mutex errorMutex;
-  std::exception_ptr errorPtr;
-
-  const auto workerMain = [&]() {
-    try
-    {
-      // Per-thread generator + scratch buffers (thread_local storage).
-      TerrainGenerator &workerGen = TerrainGenerator::getThreadLocal(m_seed);
-      uint64_t denseAdd = 0;
-      uint64_t fallbackAdd = 0;
-      for (;;)
-      {
-        if (cancelObserved.load(std::memory_order_relaxed))
-          return;
-        const int tile = nextTile.fetch_add(1, std::memory_order_relaxed);
-        if (tile >= totalTiles)
-          return;
-        if (checkCancelled())
-        {
-          cancelObserved.store(true, std::memory_order_relaxed);
-          return;
-        }
-        processTile(workerGen, tile % tilesX, tile / tilesX, denseAdd, fallbackAdd);
-        denseAccum.fetch_add(denseAdd, std::memory_order_relaxed);
-        fallbackAccum.fetch_add(fallbackAdd, std::memory_order_relaxed);
-      }
-    }
-    catch (...)
-    {
-      const std::lock_guard<std::mutex> lock(errorMutex);
-      if (!errorPtr)
-        errorPtr = std::current_exception();
-      cancelObserved.store(true, std::memory_order_relaxed);
-    }
-  };
-
-  std::vector<std::thread> workers;
-  workers.reserve(workerCount - 1);
-  for (unsigned w = 1; w < workerCount; ++w)
-    workers.emplace_back(workerMain);
-  workerMain();
-  for (std::thread &worker : workers)
-    worker.join();
-
-  if (errorPtr)
-    std::rethrow_exception(errorPtr);
-
-  stats.denseTiles = denseAccum.load();
-  stats.fallbackPixels = fallbackAccum.load();
-
-  if (cancelObserved.load(std::memory_order_relaxed))
-  {
-    outBiomes.clear();
-    return false;
   }
 
   return true;
@@ -2125,9 +2072,12 @@ void TerrainGenerator::applyCanonicalErosion(float *heightMap, int width, int he
     }
     else
     {
-      if (s_genBuffers.erosionTempBuf.size() < static_cast<size_t>(totalCount))
-        s_genBuffers.erosionTempBuf.resize(totalCount);
-      tempMap = s_genBuffers.erosionTempBuf.data();
+      // Rare fallback for large-domain erosion without a caller-provided
+      // temp buffer; kept thread-local and separate from GenBuffers.
+      static thread_local std::vector<float> fallbackTemp;
+      if (fallbackTemp.size() < static_cast<size_t>(totalCount))
+        fallbackTemp.resize(static_cast<size_t>(totalCount));
+      tempMap = fallbackTemp.data();
     }
   }
   std::copy(heightMap, heightMap + totalCount, tempMap);

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -2,9 +2,12 @@
 #include <Chunk/StreamHelpers.hpp>
 #include <Renderer/MinecraftTextures.hpp>
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cmath>
+#include <exception>
 #include <mutex>
+#include <thread>
 
 // =============================================
 // STATIC MEMBER INITIALIZATION
@@ -1610,23 +1613,6 @@ BiomeType TerrainGenerator::determineBiome(float temperature, float humidity,
   return BIOME_MOUNTAINS;
 }
 
-glm::vec2 TerrainGenerator::computeBiomeRegionWorldCoordinate(float centerX, float centerZ, float step,
-                                                             int width, int height,
-                                                             int xi, int zi)
-{
-  float wx = centerX + (static_cast<float>(xi) - static_cast<float>(width) * 0.5f) * step;
-  float wz = centerZ + (static_cast<float>(zi) - static_cast<float>(height) * 0.5f) * step;
-  return glm::vec2(wx, wz);
-}
-
-glm::ivec2 TerrainGenerator::computeBiomeRegionDiscreteColumn(float centerX, float centerZ, float step,
-                                                             int width, int height,
-                                                             int xi, int zi)
-{
-  glm::vec2 w = computeBiomeRegionWorldCoordinate(centerX, centerZ, step, width, height, xi, zi);
-  return glm::ivec2(static_cast<int>(std::round(w.x)), static_cast<int>(std::round(w.y)));
-}
-
 BiomeType TerrainGenerator::evaluateBiomeColumn(int worldX, int worldZ) const
 {
   constexpr int HALO = 2;
@@ -1673,39 +1659,81 @@ BiomeType TerrainGenerator::getBiomeAt(int worldX, int worldZ) const
   return evaluateBiomeColumn(worldX, worldZ);
 }
 
-void TerrainGenerator::getBiomeRegion(float centerX, float centerZ, float step,
+bool TerrainGenerator::getBiomeRegion(float centerX, float centerZ, float step,
                                       int width, int height,
-                                      std::vector<BiomeType> &outBiomes) const
+                                      std::vector<BiomeType> &outBiomes,
+                                      const BiomeCancelCheck &shouldCancel,
+                                      BiomeRegionStats *outStats) const
 {
-  if (width <= 0 || height <= 0)
-  {
-    outBiomes.clear();
-    return;
-  }
+  return getBiomeRegion(makeBiomeRegionGrid(centerX, centerZ, step, width, height),
+                        outBiomes, shouldCancel, outStats);
+}
 
-  const int count = width * height;
-  outBiomes.resize(count);
+bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
+                                      std::vector<BiomeType> &outBiomes,
+                                      const BiomeCancelCheck &shouldCancel,
+                                      BiomeRegionStats *outStats) const
+{
+  outBiomes.clear();
+  if (!grid.valid())
+    return false;
 
-  glm::ivec2 minCol = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, 0, 0);
-  glm::ivec2 maxCol = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, width - 1, height - 1);
-  int minWorldX = std::min(minCol.x, maxCol.x);
-  int maxWorldX = std::max(minCol.x, maxCol.x);
-  int minWorldZ = std::min(minCol.y, maxCol.y);
-  int maxWorldZ = std::max(minCol.y, maxCol.y);
+  BiomeRegionStats localStats;
+  BiomeRegionStats &stats = outStats ? *outStats : localStats;
+  stats = {};
 
-  int spanX = maxWorldX - minWorldX + 1;
-  int spanZ = maxWorldZ - minWorldZ + 1;
+  const auto checkCancelled = [&shouldCancel]() {
+    return static_cast<bool>(shouldCancel) && shouldCancel();
+  };
+
+  // Fill output pixels [x0..x1]x[z0..z1] from an already-sampled dense
+  // block window at canonical step = 1.0f.
+  const auto fillOutputFromDense = [&](const TerrainColumnBuffers &buffers,
+                                       int denseStartX, int denseStartZ, int denseW,
+                                       int x0, int x1, int z0, int z1) {
+    for (int zi = z0; zi <= z1; ++zi)
+    {
+      for (int xi = x0; xi <= x1; ++xi)
+      {
+        const glm::ivec2 col = grid.columnAt(xi, zi);
+        const int denseX = col.x - denseStartX;
+        const int denseZ = col.y - denseStartZ;
+        outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(grid.width) +
+                  static_cast<size_t>(xi)] =
+            evaluateBiomeAt(buffers, denseZ * denseW + denseX);
+      }
+    }
+  };
+
+  const glm::ivec2 minCol = grid.columnAt(0, 0);
+  const glm::ivec2 maxCol = grid.columnAt(grid.width - 1, grid.height - 1);
+  const int minWorldX = std::min(minCol.x, maxCol.x);
+  const int maxWorldX = std::max(minCol.x, maxCol.x);
+  const int minWorldZ = std::min(minCol.y, maxCol.y);
+  const int maxWorldZ = std::max(minCol.y, maxCol.y);
+
+  const int spanX = maxWorldX - minWorldX + 1;
+  const int spanZ = maxWorldZ - minWorldZ + 1;
 
   constexpr int HALO = 2;
-  int denseWidth = spanX + 2 * HALO;
-  int denseHeight = spanZ + 2 * HALO;
-  size_t totalDensePoints = static_cast<size_t>(denseWidth) * static_cast<size_t>(denseHeight);
+  const int denseWidth = spanX + 2 * HALO;
+  const int denseHeight = spanZ + 2 * HALO;
+  const size_t totalDensePoints = static_cast<size_t>(denseWidth) * static_cast<size_t>(denseHeight);
 
-  // If the total dense domain is within ~1 MB (~266K points), sample in a single pass at step = 1.0f
+  // Bound the dense-domain point count to keep total scratch memory around
+  // ~10 MiB: each point costs one float in each of the ~10 scratch fields,
+  // so 266K points x 10 buffers x 4 bytes, not per-buffer.
   constexpr size_t MAX_DENSE_DOMAIN_POINTS = 516 * 516;
+
+  const size_t outputCount = static_cast<size_t>(grid.width) * static_cast<size_t>(grid.height);
 
   if (totalDensePoints <= MAX_DENSE_DOMAIN_POINTS)
   {
+    if (checkCancelled())
+      return false;
+
+    outBiomes.resize(outputCount);
+
     if (s_genBuffers.tempBuf.size() < totalDensePoints)
     {
       s_genBuffers.tempBuf.resize(totalDensePoints);
@@ -1742,113 +1770,212 @@ void TerrainGenerator::getBiomeRegion(float centerX, float centerZ, float step,
     calculateTerrainHeights(buffers, denseWidth, denseHeight);
     applyCanonicalErosion(buffers.heightMap, denseWidth, denseHeight, buffers.erosionTemp);
 
-    for (int zi = 0; zi < height; ++zi)
+    fillOutputFromDense(buffers, denseStartX, denseStartZ, denseWidth,
+                        0, grid.width - 1, 0, grid.height - 1);
+    ++stats.denseTiles;
+
+    // Late cancellation: never return a fully-sampled but rejected result.
+    if (checkCancelled())
     {
-      for (int xi = 0; xi < width; ++xi)
-      {
-        glm::ivec2 col = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, xi, zi);
-        int denseX = col.x - denseStartX;
-        int denseZ = col.y - denseStartZ;
-        outBiomes[zi * width + xi] = evaluateBiomeAt(buffers, denseZ * denseWidth + denseX);
-      }
+      outBiomes.clear();
+      return false;
     }
+    return true;
   }
-  else
+
+  // Bounded tiled path for large regions / zoom-outs. The tile dimension is
+  // derived from grid.step so each tile's haloed dense domain always fits in
+  // MAX_TILE_DENSE_POINTS even at the smallest zoom (largest step), keeping
+  // every pixel on the vectorized dense path. The point-query fallback below
+  // is a safety net, not the normal path for any zoom. Tiles are independent
+  // (disjoint output pixels, thread_local scratch) and execute in parallel.
+  constexpr size_t MAX_TILE_DENSE_POINTS = 132 * 132; // ~17K points (~68 KB per float buffer)
+  constexpr int kMaxTileDim = 32;
+  const float maxTileSpan = std::sqrt(static_cast<float>(MAX_TILE_DENSE_POINTS));
+  const float tileDimF =
+      std::floor((maxTileSpan - 1.0f - static_cast<float>(2 * HALO)) / grid.step) + 1.0f;
+  const int tileDim = std::clamp(static_cast<int>(tileDimF), 1, kMaxTileDim);
+
+  const int tilesX = (grid.width + tileDim - 1) / tileDim;
+  const int tilesZ = (grid.height + tileDim - 1) / tileDim;
+  const int totalTiles = tilesX * tilesZ;
+
+  outBiomes.resize(outputCount);
+
+  // Process one tile on the calling thread's generator/scratch buffers.
+  // Thread-safe by construction: tiles write only their own output pixels
+  // and all scratch state lives in thread_local storage.
+  const auto processTile = [&](const TerrainGenerator &tileGen, int tx, int tz,
+                               uint64_t &denseAdd, uint64_t &fallbackAdd) {
+    denseAdd = 0;
+    fallbackAdd = 0;
+
+    const int x0 = tx * tileDim;
+    const int z0 = tz * tileDim;
+    const int x1 = std::min(x0 + tileDim - 1, grid.width - 1);
+    const int z1 = std::min(z0 + tileDim - 1, grid.height - 1);
+
+    const glm::ivec2 tMinCol = grid.columnAt(x0, z0);
+    const glm::ivec2 tMaxCol = grid.columnAt(x1, z1);
+    const int tMinX = std::min(tMinCol.x, tMaxCol.x);
+    const int tMaxX = std::max(tMinCol.x, tMaxCol.x);
+    const int tMinZ = std::min(tMinCol.y, tMaxCol.y);
+    const int tMaxZ = std::max(tMinCol.y, tMaxCol.y);
+
+    const int tDenseW = (tMaxX - tMinX + 1) + 2 * HALO;
+    const int tDenseH = (tMaxZ - tMinZ + 1) + 2 * HALO;
+    const size_t tDensePoints = static_cast<size_t>(tDenseW) * static_cast<size_t>(tDenseH);
+
+    if (tDensePoints <= MAX_TILE_DENSE_POINTS) // guaranteed by tileDim; kept as a guard
+    {
+      if (s_genBuffers.tempBuf.size() < tDensePoints)
+      {
+        s_genBuffers.tempBuf.resize(tDensePoints);
+        s_genBuffers.humidBuf.resize(tDensePoints);
+        s_genBuffers.weirdBuf.resize(tDensePoints);
+        s_genBuffers.riverBuf.resize(tDensePoints);
+        s_genBuffers.contBuf.resize(tDensePoints);
+        s_genBuffers.erosionBuf.resize(tDensePoints);
+        s_genBuffers.pvBuf.resize(tDensePoints);
+        s_genBuffers.ridgeBuf.resize(tDensePoints);
+        s_genBuffers.heightBuf.resize(tDensePoints);
+        s_genBuffers.erosionTempBuf.resize(tDensePoints);
+      }
+
+      TerrainColumnBuffers buffers{
+          .continental = s_genBuffers.contBuf.data(),
+          .erosion = s_genBuffers.erosionBuf.data(),
+          .peaksValleys = s_genBuffers.pvBuf.data(),
+          .ridge = s_genBuffers.ridgeBuf.data(),
+          .temperature = s_genBuffers.tempBuf.data(),
+          .humidity = s_genBuffers.humidBuf.data(),
+          .weirdness = s_genBuffers.weirdBuf.data(),
+          .river = s_genBuffers.riverBuf.data(),
+          .heightMap = s_genBuffers.heightBuf.data(),
+          .erosionTemp = s_genBuffers.erosionTempBuf.data()};
+
+      const int tDenseStartX = tMinX - HALO;
+      const int tDenseStartZ = tMinZ - HALO;
+
+      tileGen.sampleTerrainColumnFields(buffers,
+                                        tDenseStartX + static_cast<int>(NOISE_OFFSET),
+                                        tDenseStartZ + static_cast<int>(NOISE_OFFSET),
+                                        tDenseW, tDenseH, 1.0f);
+      tileGen.calculateTerrainHeights(buffers, tDenseW, tDenseH);
+      tileGen.applyCanonicalErosion(buffers.heightMap, tDenseW, tDenseH, buffers.erosionTemp);
+
+      fillOutputFromDense(buffers, tDenseStartX, tDenseStartZ, tDenseW, x0, x1, z0, z1);
+      ++denseAdd;
+    }
+    else
+    {
+      // Safety net only: evaluate point canonical columns directly.
+      for (int zi = z0; zi <= z1; ++zi)
+      {
+        for (int xi = x0; xi <= x1; ++xi)
+        {
+          const glm::ivec2 col = grid.columnAt(xi, zi);
+          outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(grid.width) +
+                    static_cast<size_t>(xi)] = tileGen.evaluateBiomeColumn(col.x, col.y);
+        }
+      }
+      fallbackAdd += static_cast<uint64_t>(x1 - x0 + 1) *
+                     static_cast<uint64_t>(z1 - z0 + 1);
+    }
+  };
+
+  unsigned hardwareThreads = std::thread::hardware_concurrency();
+  if (hardwareThreads == 0)
+    hardwareThreads = 1;
+  const unsigned workerCount = std::min(std::min(hardwareThreads, 16u),
+                                        static_cast<unsigned>(totalTiles));
+
+  if (workerCount <= 1)
   {
-    // Bounded tiled path for large regions / zoom-outs (step >= 4 or large width/height):
-    // Process in tiles of up to 32x32 output pixels.
-    constexpr int TILE_DIM = 32;
-    constexpr size_t MAX_TILE_DENSE_POINTS = 132 * 132; // ~17K points (~68 KB per buffer)
-
-    const int tilesX = (width + TILE_DIM - 1) / TILE_DIM;
-    const int tilesZ = (height + TILE_DIM - 1) / TILE_DIM;
-
+    uint64_t denseAdd = 0;
+    uint64_t fallbackAdd = 0;
     for (int tz = 0; tz < tilesZ; ++tz)
     {
       for (int tx = 0; tx < tilesX; ++tx)
       {
-        int x0 = tx * TILE_DIM;
-        int z0 = tz * TILE_DIM;
-        int x1 = std::min(x0 + TILE_DIM - 1, width - 1);
-        int z1 = std::min(z0 + TILE_DIM - 1, height - 1);
-
-        glm::ivec2 tMinCol = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, x0, z0);
-        glm::ivec2 tMaxCol = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, x1, z1);
-        int tMinX = std::min(tMinCol.x, tMaxCol.x);
-        int tMaxX = std::max(tMinCol.x, tMaxCol.x);
-        int tMinZ = std::min(tMinCol.y, tMaxCol.y);
-        int tMaxZ = std::max(tMinCol.y, tMaxCol.y);
-
-        int tSpanX = tMaxX - tMinX + 1;
-        int tSpanZ = tMaxZ - tMinZ + 1;
-        int tDenseW = tSpanX + 2 * HALO;
-        int tDenseH = tSpanZ + 2 * HALO;
-        size_t tDensePoints = static_cast<size_t>(tDenseW) * static_cast<size_t>(tDenseH);
-
-        if (tDensePoints <= MAX_TILE_DENSE_POINTS)
+        // Cancellation checkpoint: polled before every tile so a long
+        // zoomed-out map build can be abandoned promptly.
+        if (checkCancelled())
         {
-          if (s_genBuffers.tempBuf.size() < tDensePoints)
-          {
-            s_genBuffers.tempBuf.resize(tDensePoints);
-            s_genBuffers.humidBuf.resize(tDensePoints);
-            s_genBuffers.weirdBuf.resize(tDensePoints);
-            s_genBuffers.riverBuf.resize(tDensePoints);
-            s_genBuffers.contBuf.resize(tDensePoints);
-            s_genBuffers.erosionBuf.resize(tDensePoints);
-            s_genBuffers.pvBuf.resize(tDensePoints);
-            s_genBuffers.ridgeBuf.resize(tDensePoints);
-            s_genBuffers.heightBuf.resize(tDensePoints);
-            s_genBuffers.erosionTempBuf.resize(tDensePoints);
-          }
-
-          TerrainColumnBuffers buffers{
-              .continental = s_genBuffers.contBuf.data(),
-              .erosion = s_genBuffers.erosionBuf.data(),
-              .peaksValleys = s_genBuffers.pvBuf.data(),
-              .ridge = s_genBuffers.ridgeBuf.data(),
-              .temperature = s_genBuffers.tempBuf.data(),
-              .humidity = s_genBuffers.humidBuf.data(),
-              .weirdness = s_genBuffers.weirdBuf.data(),
-              .river = s_genBuffers.riverBuf.data(),
-              .heightMap = s_genBuffers.heightBuf.data(),
-              .erosionTemp = s_genBuffers.erosionTempBuf.data()};
-
-          const int tDenseStartX = tMinX - HALO;
-          const int tDenseStartZ = tMinZ - HALO;
-
-          sampleTerrainColumnFields(buffers,
-                                    tDenseStartX + static_cast<int>(NOISE_OFFSET),
-                                    tDenseStartZ + static_cast<int>(NOISE_OFFSET),
-                                    tDenseW, tDenseH, 1.0f);
-          calculateTerrainHeights(buffers, tDenseW, tDenseH);
-          applyCanonicalErosion(buffers.heightMap, tDenseW, tDenseH, buffers.erosionTemp);
-
-          for (int zi = z0; zi <= z1; ++zi)
-          {
-            for (int xi = x0; xi <= x1; ++xi)
-            {
-              glm::ivec2 col = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, xi, zi);
-              int denseX = col.x - tDenseStartX;
-              int denseZ = col.y - tDenseStartZ;
-              outBiomes[zi * width + xi] = evaluateBiomeAt(buffers, denseZ * tDenseW + denseX);
-            }
-          }
+          outBiomes.clear();
+          return false;
         }
-        else
-        {
-          // Large step fallback: evaluate point canonical columns directly
-          for (int zi = z0; zi <= z1; ++zi)
-          {
-            for (int xi = x0; xi <= x1; ++xi)
-            {
-              glm::ivec2 col = computeBiomeRegionDiscreteColumn(centerX, centerZ, step, width, height, xi, zi);
-              outBiomes[zi * width + xi] = evaluateBiomeColumn(col.x, col.y);
-            }
-          }
-        }
+        processTile(*this, tx, tz, denseAdd, fallbackAdd);
+        stats.denseTiles += denseAdd;
+        stats.fallbackPixels += fallbackAdd;
       }
     }
+    return true;
   }
+
+  // Parallel workers pull tiles from a shared index. Tile results are
+  // deterministic regardless of scheduling.
+  std::atomic<int> nextTile{0};
+  std::atomic<bool> cancelObserved{false};
+  std::atomic<uint64_t> denseAccum{0};
+  std::atomic<uint64_t> fallbackAccum{0};
+  std::mutex errorMutex;
+  std::exception_ptr errorPtr;
+
+  const auto workerMain = [&]() {
+    try
+    {
+      // Per-thread generator + scratch buffers (thread_local storage).
+      TerrainGenerator &workerGen = TerrainGenerator::getThreadLocal(m_seed);
+      uint64_t denseAdd = 0;
+      uint64_t fallbackAdd = 0;
+      for (;;)
+      {
+        if (cancelObserved.load(std::memory_order_relaxed))
+          return;
+        const int tile = nextTile.fetch_add(1, std::memory_order_relaxed);
+        if (tile >= totalTiles)
+          return;
+        if (checkCancelled())
+        {
+          cancelObserved.store(true, std::memory_order_relaxed);
+          return;
+        }
+        processTile(workerGen, tile % tilesX, tile / tilesX, denseAdd, fallbackAdd);
+        denseAccum.fetch_add(denseAdd, std::memory_order_relaxed);
+        fallbackAccum.fetch_add(fallbackAdd, std::memory_order_relaxed);
+      }
+    }
+    catch (...)
+    {
+      const std::lock_guard<std::mutex> lock(errorMutex);
+      if (!errorPtr)
+        errorPtr = std::current_exception();
+      cancelObserved.store(true, std::memory_order_relaxed);
+    }
+  };
+
+  std::vector<std::thread> workers;
+  workers.reserve(workerCount - 1);
+  for (unsigned w = 1; w < workerCount; ++w)
+    workers.emplace_back(workerMain);
+  workerMain();
+  for (std::thread &worker : workers)
+    worker.join();
+
+  if (errorPtr)
+    std::rethrow_exception(errorPtr);
+
+  stats.denseTiles = denseAccum.load();
+  stats.fallbackPixels = fallbackAccum.load();
+
+  if (cancelObserved.load(std::memory_order_relaxed))
+  {
+    outBiomes.clear();
+    return false;
+  }
+
+  return true;
 }
 
 // =============================================

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -118,10 +118,12 @@ public:
     std::vector<float> height;
     std::vector<float> erosionTemp;
 
-    // Releases capacity above the tiled-path bound. Call this after a build
-    // used the single-pass dense path (its buffers can reach ~10 MiB) so
-    // idle workers do not retain the peak; tiled-path-sized capacity is
-    // kept for cheap reuse.
+    // Releases capacity above the tiled-path bound. getBiomeRegion() runs
+    // this automatically on every exit — after successful AND
+    // cancelled/failed attempts — so oversized dense capacity is never
+    // retained across attempts while tiled-sized capacity survives for
+    // cheap reuse. Call it manually only when mutating a scratch outside
+    // getBiomeRegion().
     void trimOversizedCapacity();
   };
 
@@ -151,10 +153,13 @@ public:
   // in a fixed order so the result is deterministic and the scheduler only
   // decides when the whole call runs, not what it produces. Returns false
   // (and clears outBiomes) when the grid is invalid or `shouldCancel`
-  // returned true; partial results are never returned. `outStats` is
-  // optional. `scratch` may be null, in which case a dedicated internal
-  // thread-local scratch is used; pass a caller-owned scratch to control
-  // memory retention (see BiomeRegionScratch).
+  // returned true; partial results are never returned. On every exit —
+  // success, cancellation, failure, or exception — the scratch is trimmed
+  // to the tiled-path bound, so oversized dense capacity is never retained
+  // across attempts. `outStats` is optional. `scratch` may be null, in
+  // which case a dedicated internal thread-local scratch is used; pass a
+  // caller-owned scratch to control memory retention (see
+  // BiomeRegionScratch).
   bool getBiomeRegion(const BiomeRegionGrid &grid,
                       std::vector<BiomeType> &outBiomes,
                       BiomeRegionScratch *scratch = nullptr,

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -95,17 +95,51 @@ public:
   BiomeType getBiomeAt(int worldX, int worldZ) const;
 
   // Optional early-exit hook polled between region tiles; return true to
-  // cancel. May be invoked concurrently from tile worker threads, so the
-  // callable must be thread-safe (e.g. read an atomic token). Kept as a
-  // lightweight std::function so TerrainGenerator stays decoupled from any
-  // specific threading primitive.
+  // cancel. Kept as a lightweight std::function so TerrainGenerator stays
+  // decoupled from any specific threading primitive. getBiomeRegion() runs
+  // its tiles sequentially on the calling thread, so no extra
+  // synchronization is required of the callable.
   using BiomeCancelCheck = std::function<bool()>;
+
+  // Scratch working set for one getBiomeRegion() call. Owned by the caller
+  // so heavy capacity is not retained indefinitely inside TerrainGenerator's
+  // shared thread-local chunk buffers. Reuse one scratch per producer job
+  // (e.g. the biome-map worker) to avoid re-allocating between refreshes.
+  struct BiomeRegionScratch
+  {
+    std::vector<float> temperature;
+    std::vector<float> humidity;
+    std::vector<float> weirdness;
+    std::vector<float> river;
+    std::vector<float> continental;
+    std::vector<float> erosion;
+    std::vector<float> peaksValleys;
+    std::vector<float> ridge;
+    std::vector<float> height;
+    std::vector<float> erosionTemp;
+
+    // Releases capacity above the tiled-path bound. Call this after a build
+    // used the single-pass dense path (its buffers can reach ~10 MiB) so
+    // idle workers do not retain the peak; tiled-path-sized capacity is
+    // kept for cheap reuse.
+    void trimOversizedCapacity();
+  };
+
+  // Domain point-count bounds. No region buffer may exceed these without an
+  // explicit fallback path; kMaxDenseDomainPoints bounds the single-pass
+  // scratch (~10 MiB across all 10 float fields), kMaxTileDensePoints the
+  // per-tile scratch (~68 KB per field).
+  static constexpr size_t kMaxDenseDomainPoints = 516 * 516;
+  static constexpr size_t kMaxTileDensePoints = 132 * 132;
+  static constexpr size_t kBiomeRegionScratchFields = 10;
 
   // Counters describing how a getBiomeRegion() call was executed.
   struct BiomeRegionStats
   {
     uint64_t denseTiles{0};      // tiles processed by the vectorized dense path
     uint64_t fallbackPixels{0};  // pixels evaluated by point-query fallback
+    size_t peakDensePoints{0};   // largest dense domain sampled in one shot
+    size_t peakScratchBytes{0};  // peakDensePoints * fields * sizeof(float)
   };
 
   // Batch biome sampling for map visualization. `grid` is the single source
@@ -113,11 +147,17 @@ public:
   // BiomeRegionGrid.hpp). Output is row-major, outBiomes[grid.width * z + x].
   // The canonical block-resolution pipeline (incl. erosion at step = 1.0f) is
   // independent of grid.step: the grid only selects which canonical columns
-  // are sampled. Returns false (and clears outBiomes) when the grid is
-  // invalid or `shouldCancel` returned true; partial results are never
-  // returned. `outStats` is optional.
+  // are sampled. Runs sequentially on the calling thread; tiles are sampled
+  // in a fixed order so the result is deterministic and the scheduler only
+  // decides when the whole call runs, not what it produces. Returns false
+  // (and clears outBiomes) when the grid is invalid or `shouldCancel`
+  // returned true; partial results are never returned. `outStats` is
+  // optional. `scratch` may be null, in which case a dedicated internal
+  // thread-local scratch is used; pass a caller-owned scratch to control
+  // memory retention (see BiomeRegionScratch).
   bool getBiomeRegion(const BiomeRegionGrid &grid,
                       std::vector<BiomeType> &outBiomes,
+                      BiomeRegionScratch *scratch = nullptr,
                       const BiomeCancelCheck &shouldCancel = {},
                       BiomeRegionStats *outStats = nullptr) const;
 

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -192,6 +192,32 @@ private:
                       float ridge, float riverVal, float weirdness) const;
   float calculateHeightFloat(float continental, float erosion, float peaksValleys, float ridge, float riverVal, float weirdness) const;
   void applyErosion(float *heightMap, int size) const;
+  void applyErosion(float *heightMap, int width, int height, float *tempBuffer = nullptr) const;
+
+  // Shared erosion-aware terrain sampling pipeline
+  struct TerrainColumnBuffers
+  {
+    float *continental{nullptr};
+    float *erosion{nullptr};
+    float *peaksValleys{nullptr};
+    float *ridge{nullptr};
+    float *temperature{nullptr};
+    float *humidity{nullptr};
+    float *weirdness{nullptr};
+    float *river{nullptr};
+    float *heightMap{nullptr};
+    float *erosionTemp{nullptr};
+  };
+
+  void sampleTerrainColumnNoiseAndHeights(
+      const TerrainColumnBuffers &buffers,
+      int extStartX, int extStartZ,
+      int extWidth, int extHeight,
+      float step) const;
+
+  BiomeType evaluateBiomeAt(
+      const TerrainColumnBuffers &buffers,
+      int extIndex) const;
 
   // Biome determination
   BiomeType determineBiome(float temperature, float humidity, float weirdness,

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -90,6 +90,17 @@ public:
   // Get biome at world position (for cross-chunk queries)
   BiomeType getBiomeAt(int worldX, int worldZ) const;
 
+  // Canonical column biome evaluation primitive
+  BiomeType evaluateBiomeColumn(int worldX, int worldZ) const;
+
+  // Helpers to map region pixels to world coordinates and discrete columns
+  static glm::vec2 computeBiomeRegionWorldCoordinate(float centerX, float centerZ, float step,
+                                                     int width, int height,
+                                                     int xi, int zi);
+  static glm::ivec2 computeBiomeRegionDiscreteColumn(float centerX, float centerZ, float step,
+                                                    int width, int height,
+                                                    int xi, int zi);
+
   // Batch biome sampling for map visualization (uses GenUniformGrid2D for SIMD efficiency).
   // centerX/Z are world-space coordinates, step is world units per pixel,
   // width/height are the output dimensions. outBiomes is filled in row-major order.
@@ -192,9 +203,9 @@ private:
                       float ridge, float riverVal, float weirdness) const;
   float calculateHeightFloat(float continental, float erosion, float peaksValleys, float ridge, float riverVal, float weirdness) const;
   void applyErosion(float *heightMap, int size) const;
-  void applyErosion(float *heightMap, int width, int height, float *tempBuffer = nullptr) const;
+  void applyCanonicalErosion(float *heightMap, int width, int height, float *tempBuffer = nullptr) const;
 
-  // Shared erosion-aware terrain sampling pipeline
+  // Shared canonical column pipeline stages
   struct TerrainColumnBuffers
   {
     float *continental{nullptr};
@@ -209,11 +220,15 @@ private:
     float *erosionTemp{nullptr};
   };
 
-  void sampleTerrainColumnNoiseAndHeights(
+  void sampleTerrainColumnFields(
       const TerrainColumnBuffers &buffers,
       int extStartX, int extStartZ,
       int extWidth, int extHeight,
-      float step) const;
+      float step = 1.0f) const;
+
+  void calculateTerrainHeights(
+      const TerrainColumnBuffers &buffers,
+      int extWidth, int extHeight) const;
 
   BiomeType evaluateBiomeAt(
       const TerrainColumnBuffers &buffers,

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -2,11 +2,14 @@
 
 #include <FastNoise/FastNoise.h>
 #include <array>
+#include <functional>
 #include <glm/glm.hpp>
 #include <unordered_map>
 #include <memory>
+#include <cstdint>
 
 #include <utils.hpp>
+#include <Chunk/BiomeRegionGrid.hpp>
 
 struct ChunkData
 {
@@ -87,25 +90,43 @@ public:
   // Getter for seed to enable thread-safe generation
   int getSeed() const { return m_seed; }
 
-  // Get biome at world position (for cross-chunk queries)
+  // Get biome at world position (for cross-chunk queries). Equivalent to
+  // the biome stored in the generated chunk containing (worldX, worldZ).
   BiomeType getBiomeAt(int worldX, int worldZ) const;
 
-  // Canonical column biome evaluation primitive
-  BiomeType evaluateBiomeColumn(int worldX, int worldZ) const;
+  // Optional early-exit hook polled between region tiles; return true to
+  // cancel. May be invoked concurrently from tile worker threads, so the
+  // callable must be thread-safe (e.g. read an atomic token). Kept as a
+  // lightweight std::function so TerrainGenerator stays decoupled from any
+  // specific threading primitive.
+  using BiomeCancelCheck = std::function<bool()>;
 
-  // Helpers to map region pixels to world coordinates and discrete columns
-  static glm::vec2 computeBiomeRegionWorldCoordinate(float centerX, float centerZ, float step,
-                                                     int width, int height,
-                                                     int xi, int zi);
-  static glm::ivec2 computeBiomeRegionDiscreteColumn(float centerX, float centerZ, float step,
-                                                    int width, int height,
-                                                    int xi, int zi);
+  // Counters describing how a getBiomeRegion() call was executed.
+  struct BiomeRegionStats
+  {
+    uint64_t denseTiles{0};      // tiles processed by the vectorized dense path
+    uint64_t fallbackPixels{0};  // pixels evaluated by point-query fallback
+  };
 
-  // Batch biome sampling for map visualization (uses GenUniformGrid2D for SIMD efficiency).
-  // centerX/Z are world-space coordinates, step is world units per pixel,
-  // width/height are the output dimensions. outBiomes is filled in row-major order.
-  void getBiomeRegion(float centerX, float centerZ, float step,
-                      int width, int height, std::vector<BiomeType> &outBiomes) const;
+  // Batch biome sampling for map visualization. `grid` is the single source
+  // of truth for the pixel <-> world <-> voxel-column mapping (see
+  // BiomeRegionGrid.hpp). Output is row-major, outBiomes[grid.width * z + x].
+  // The canonical block-resolution pipeline (incl. erosion at step = 1.0f) is
+  // independent of grid.step: the grid only selects which canonical columns
+  // are sampled. Returns false (and clears outBiomes) when the grid is
+  // invalid or `shouldCancel` returned true; partial results are never
+  // returned. `outStats` is optional.
+  bool getBiomeRegion(const BiomeRegionGrid &grid,
+                      std::vector<BiomeType> &outBiomes,
+                      const BiomeCancelCheck &shouldCancel = {},
+                      BiomeRegionStats *outStats = nullptr) const;
+
+  // Convenience overload building the grid from explicit parameters.
+  bool getBiomeRegion(float centerX, float centerZ, float step,
+                      int width, int height,
+                      std::vector<BiomeType> &outBiomes,
+                      const BiomeCancelCheck &shouldCancel = {},
+                      BiomeRegionStats *outStats = nullptr) const;
 
   // Get biome configuration
   static const BiomeConfig &getBiomeConfig(BiomeType biome);
@@ -233,6 +254,10 @@ private:
   BiomeType evaluateBiomeAt(
       const TerrainColumnBuffers &buffers,
       int extIndex) const;
+
+  // Canonical column biome evaluation primitive (5x5 halo window at
+  // step = 1.0f). Private: external callers must use getBiomeAt().
+  BiomeType evaluateBiomeColumn(int worldX, int worldZ) const;
 
   // Biome determination
   BiomeType determineBiome(float temperature, float humidity, float weirdness,

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -259,8 +259,9 @@ void GameUI::drawHud(GameUIFrame &frame)
 
 		if (frame.generator)
 		{
-			const BiomeType biome = frame.generator->getBiomeAt(
-				static_cast<int>(std::floor(p.x)), static_cast<int>(std::floor(p.z)));
+			// Single canonical world -> voxel-column convention (floor).
+			const glm::ivec2 column = worldToVoxelColumn(glm::vec2(p.x, p.z));
+			const BiomeType biome = frame.generator->getBiomeAt(column.x, column.y);
 			if (biome >= 0 && biome < BIOME_COUNT)
 				ImGui::Text("Biome: %s", biomeTypeString[biome]);
 		}

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -1279,7 +1279,7 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 
 		if (isBiomeMapResultAcceptable(res, frame.worldGenerationId, frame.seed, m_mapRequestId))
 		{
-			paintBiomeMapPlayerDot(res.rgba, res.size, playerXZ, res.zoom, res.gridX, res.gridZ);
+			paintBiomeMapPlayerDot(res.rgba, res.grid, playerXZ);
 			m_mapCenter = res.center;
 			ensureBiomeTexture(res.size);
 			m_pendingUpload = BiomeMapUpload{

--- a/src/Engine/GameUIBiomeMap.cpp
+++ b/src/Engine/GameUIBiomeMap.cpp
@@ -66,16 +66,15 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 
 	TerrainGenerator &gen = TerrainGenerator::getThreadLocal(req.seed);
 	std::vector<BiomeType> biomes;
-	// Scratch owned by this job (not by TerrainGenerator internals): reused
-	// across refreshes landing on the same worker, and trimmed after builds
-	// that hit the large single-pass dense path so idle pool workers never
-	// retain the ~10 MiB peak.
+	// Scratch owned by this job (not by TerrainGenerator internals):
+	// tiled-sized capacity is reused across refreshes, while oversized
+	// dense capacity is released after every attempt — successful or
+	// cancelled — by getBiomeRegion's exit guard.
 	static thread_local TerrainGenerator::BiomeRegionScratch scratch;
 	// Cancellation is checked before, during (between tiles), and after the
 	// region sampling; an interrupted build publishes nothing.
 	if (!gen.getBiomeRegion(grid, biomes, &scratch, [&] { return cancelled(); }))
 		return {};
-	scratch.trimOversizedCapacity();
 
 	// Checkpoint 3: before RGBA allocation
 	if (cancelled())

--- a/src/Engine/GameUIBiomeMap.cpp
+++ b/src/Engine/GameUIBiomeMap.cpp
@@ -11,6 +11,11 @@ void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
 	// voxel column of the player is worldToVoxelColumn(playerXZ); the marker
 	// does not redefine it.
 	const glm::ivec2 dot = grid.pixelForWorld(playerXZ);
+	// Contract: a marker whose center falls outside the grid draws nothing —
+	// no half-clipped ring on the border, and no arithmetic on extreme
+	// pixel indices below.
+	if (dot.x < 0 || dot.y < 0 || dot.x >= grid.width || dot.y >= grid.height)
+		return;
 	const int size = grid.width;
 	auto paint = [&](int px, int py, unsigned char r, unsigned char g, unsigned char b) {
 		if (px < 0 || py < 0 || px >= size || py >= grid.height)
@@ -61,10 +66,16 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 
 	TerrainGenerator &gen = TerrainGenerator::getThreadLocal(req.seed);
 	std::vector<BiomeType> biomes;
-	// Propagate cancellation into the region sampling so a long zoomed-out
-	// build is abandoned between tiles instead of running to completion.
-	if (!gen.getBiomeRegion(grid, biomes, [&] { return cancelled(); }))
+	// Scratch owned by this job (not by TerrainGenerator internals): reused
+	// across refreshes landing on the same worker, and trimmed after builds
+	// that hit the large single-pass dense path so idle pool workers never
+	// retain the ~10 MiB peak.
+	static thread_local TerrainGenerator::BiomeRegionScratch scratch;
+	// Cancellation is checked before, during (between tiles), and after the
+	// region sampling; an interrupted build publishes nothing.
+	if (!gen.getBiomeRegion(grid, biomes, &scratch, [&] { return cancelled(); }))
 		return {};
+	scratch.trimOversizedCapacity();
 
 	// Checkpoint 3: before RGBA allocation
 	if (cancelled())

--- a/src/Engine/GameUIBiomeMap.cpp
+++ b/src/Engine/GameUIBiomeMap.cpp
@@ -4,17 +4,16 @@
 #include <cmath>
 
 void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
-						   int size,
-						   glm::vec2 playerXZ,
-						   float zoom,
-						   int gridX,
-						   int gridZ)
+							const BiomeRegionGrid &grid,
+							glm::vec2 playerXZ)
 {
-	const float noiseOffset = TerrainGenerator::NOISE_OFFSET;
-	const int dotX = static_cast<int>(std::round((playerXZ.x + noiseOffset) * zoom)) - gridX;
-	const int dotY = static_cast<int>(std::round((playerXZ.y + noiseOffset) * zoom)) - gridZ;
+	// Visualization rounding only: nearest display pixel. The canonical
+	// voxel column of the player is worldToVoxelColumn(playerXZ); the marker
+	// does not redefine it.
+	const glm::ivec2 dot = grid.pixelForWorld(playerXZ);
+	const int size = grid.width;
 	auto paint = [&](int px, int py, unsigned char r, unsigned char g, unsigned char b) {
-		if (px < 0 || py < 0 || px >= size || py >= size)
+		if (px < 0 || py < 0 || px >= size || py >= grid.height)
 			return;
 		const int idx = (py * size + px) * 4;
 		if (static_cast<size_t>(idx + 3) < rgba.size())
@@ -28,11 +27,11 @@ void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
 	for (int dy = -4; dy <= 4; ++dy)
 		for (int dx = -4; dx <= 4; ++dx)
 			if (dx * dx + dy * dy <= 16)
-				paint(dotX + dx, dotY + dy, 0, 0, 0);
+				paint(dot.x + dx, dot.y + dy, 0, 0, 0);
 	for (int dy = -2; dy <= 2; ++dy)
 		for (int dx = -2; dx <= 2; ++dx)
 			if (dx * dx + dy * dy <= 4)
-				paint(dotX + dx, dotY + dy, 255, 255, 255);
+				paint(dot.x + dx, dot.y + dy, 255, 255, 255);
 }
 
 BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
@@ -48,10 +47,10 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 	if (req.size <= 0 || req.zoom <= 0.0f)
 		return {};
 
-	const float step = 1.0f / req.zoom;
-	const float noiseOffset = TerrainGenerator::NOISE_OFFSET;
-	const int gridX = static_cast<int>(std::round((req.center.x + noiseOffset) * req.zoom - req.size * 0.5f));
-	const int gridZ = static_cast<int>(std::round((req.center.y + noiseOffset) * req.zoom - req.size * 0.5f));
+	// Single canonical grid for the whole pipeline: sampling, result
+	// description, and player-marker placement all share it.
+	const BiomeRegionGrid grid =
+		makeBiomeRegionGrid(req.center.x, req.center.y, 1.0f / req.zoom, req.size, req.size);
 
 	if (req.onCheckpoint)
 		req.onCheckpoint();
@@ -62,7 +61,10 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 
 	TerrainGenerator &gen = TerrainGenerator::getThreadLocal(req.seed);
 	std::vector<BiomeType> biomes;
-	gen.getBiomeRegion(req.center.x, req.center.y, step, req.size, req.size, biomes);
+	// Propagate cancellation into the region sampling so a long zoomed-out
+	// build is abandoned between tiles instead of running to completion.
+	if (!gen.getBiomeRegion(grid, biomes, [&] { return cancelled(); }))
+		return {};
 
 	// Checkpoint 3: before RGBA allocation
 	if (cancelled())
@@ -96,8 +98,7 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 	res.seed = req.seed;
 	res.center = req.center;
 	res.zoom = req.zoom;
-	res.gridX = gridX;
-	res.gridZ = gridZ;
+	res.grid = grid;
 	res.size = req.size;
 	res.rgba = std::move(rgba);
 	res.valid = true;

--- a/src/Engine/GameUIBiomeMap.hpp
+++ b/src/Engine/GameUIBiomeMap.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <Chunk/BiomeRegionGrid.hpp>
 #include <utils.hpp>
 
 #include <atomic>
+#include <cmath>
 #include <cstdint>
 #include <functional>
 #include <future>
@@ -65,8 +67,10 @@ struct BiomeMapResult
 	int seed{0};
 	glm::vec2 center{0.f, 0.f};
 	float zoom{1.f};
-	int gridX{0};
-	int gridZ{0};
+	/// Canonical grid describing pixel <-> world <-> voxel-column mapping
+	/// for this map (step == 1/zoom, center == request center). The player
+	/// marker is placed through it instead of reconstructing the mapping.
+	BiomeRegionGrid grid;
 	int size{0};
 	std::vector<unsigned char> rgba;
 	bool valid{false};
@@ -93,9 +97,9 @@ inline bool isBiomeMapUploadValid(const BiomeMapUpload &upload)
 /// Check if a biome map result matches active world generation, seed, request ID,
 /// and internal invariant checks before GPU publication.
 inline bool isBiomeMapResultAcceptable(const BiomeMapResult &result,
-									  uint64_t currentWorldGenId,
-									  int currentSeed,
-									  uint64_t currentRequestId)
+										  uint64_t currentWorldGenId,
+										  int currentSeed,
+										  uint64_t currentRequestId)
 {
 	return result.valid &&
 		   result.worldGenerationId == currentWorldGenId &&
@@ -103,6 +107,9 @@ inline bool isBiomeMapResultAcceptable(const BiomeMapResult &result,
 		   result.requestId == currentRequestId &&
 		   result.size > 0 &&
 		   result.zoom > 0.0f &&
+		   result.grid.valid() &&
+		   result.grid.width == result.size &&
+		   result.grid.height == result.size &&
 		   result.rgba.size() == static_cast<size_t>(result.size) * static_cast<size_t>(result.size) * 4;
 }
 
@@ -126,13 +133,12 @@ inline bool shouldSupersedeBiomeMap(glm::vec2 player,
 	return glm::length(player - lastPlayer) > 8.0f;
 }
 
-/// Paint the player indicator dot (black outline with white center) into the RGBA buffer.
+/// Paint the player indicator dot (black outline with white center) into the
+/// RGBA buffer. The dot pixel is grid.pixelForWorld(playerXZ) (nearest display
+/// pixel); when it falls outside the grid nothing is painted.
 void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
-						   int size,
-						   glm::vec2 playerXZ,
-						   float zoom,
-						   int gridX,
-						   int gridZ);
+							const BiomeRegionGrid &grid,
+							glm::vec2 playerXZ);
 
 /// Sample biomes and convert them to an RGBA pixel buffer using thread-local generator.
 /// Fully self-contained: owns its buffers and does not retain raw pointers to Engine state.

--- a/src/Engine/GameUIBiomeMap.hpp
+++ b/src/Engine/GameUIBiomeMap.hpp
@@ -142,7 +142,8 @@ void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
 
 /// Sample biomes and convert them to an RGBA pixel buffer using thread-local generator.
 /// Fully self-contained: owns its buffers and does not retain raw pointers to Engine state.
-/// Best-effort cancellation prevents obsolete work from being published and skips work
-/// when cancellation is observed before/after biome sampling.
+/// Cancellation is checked before sampling, during region sampling (between
+/// tiles), and after sampling — an interrupted build returns an invalid
+/// result and never publishes partial pixel data.
 BiomeMapResult generateBiomeMap(const BiomeMapRequest &req);
 

--- a/tests/test_biome_map.cpp
+++ b/tests/test_biome_map.cpp
@@ -51,6 +51,19 @@ static void test_biome_map_result_validity()
 	CHECK(res.size == size, "Result size should match requested");
 	CHECK(res.rgba.size() == static_cast<size_t>(size * size * 4), "Result RGBA size mismatch");
 
+	// The result must carry the canonical grid it was sampled with.
+	CHECK(res.grid.center == center, "Result grid center should match request center");
+	CHECK(std::fabs(res.grid.step - 1.0f / zoom) < 1e-6f, "Result grid step should be 1/zoom");
+	CHECK(res.grid.width == size && res.grid.height == size, "Result grid dimensions should match size");
+	for (int z = 0; z < size; z += 7)
+	{
+		for (int x = 0; x < size; x += 7)
+		{
+			const glm::ivec2 pixel = res.grid.pixelForWorld(res.grid.worldAt(x, z));
+			CHECK(pixel == glm::ivec2(x, z), "Result grid pixel/world round-trip");
+		}
+	}
+
 	// Verify that pixel colors correspond to known biomes and alpha is 255
 	bool hasNonZeroPixel = false;
 	bool allAlphaOpaque = true;
@@ -297,26 +310,74 @@ static void test_rapid_request_cancellation_sequence()
 static void test_player_dot_painting()
 {
 	const int size = 32;
-	std::vector<unsigned char> rgba(size * size * 4, 0);
-
 	const glm::vec2 center{0.f, 0.f};
 	const float zoom = 1.0f;
-	const float noiseOffset = TerrainGenerator::NOISE_OFFSET;
-	const int gridX = static_cast<int>(std::round((center.x + noiseOffset) * zoom - size * 0.5f));
-	const int gridZ = static_cast<int>(std::round((center.y + noiseOffset) * zoom - size * 0.5f));
+	const BiomeRegionGrid grid = makeBiomeRegionGrid(center.x, center.y, 1.0f / zoom, size, size);
 
-	paintBiomeMapPlayerDot(rgba, size, center, zoom, gridX, gridZ);
+	// Player at the grid center: the dot must land on the nearest display
+	// pixel of the player position per the canonical grid.
+	{
+		std::vector<unsigned char> rgba(size * size * 4, 0);
+		paintBiomeMapPlayerDot(rgba, grid, center);
 
-	// Center pixel of the dot should be white (255, 255, 255, 255)
-	const int dotX = static_cast<int>(std::round((center.x + noiseOffset) * zoom)) - gridX;
-	const int dotY = static_cast<int>(std::round((center.y + noiseOffset) * zoom)) - gridZ;
-	const int centerIdx = (dotY * size + dotX) * 4;
-	CHECK(rgba[centerIdx + 0] == 255 && rgba[centerIdx + 1] == 255 &&
-		  rgba[centerIdx + 2] == 255 && rgba[centerIdx + 3] == 255,
-		  "Center of player dot should be opaque white");
+		const glm::ivec2 dot = grid.pixelForWorld(center);
+		const size_t centerIdx = (static_cast<size_t>(dot.y) * size + dot.x) * 4;
+		CHECK(rgba[centerIdx + 0] == 255 && rgba[centerIdx + 1] == 255 &&
+				  rgba[centerIdx + 2] == 255 && rgba[centerIdx + 3] == 255,
+			  "Center of player dot should be opaque white");
 
-	// Check that painting doesn't crash on out-of-bounds positions
-	paintBiomeMapPlayerDot(rgba, size, {-100000.f, -100000.f}, zoom, gridX, gridZ);
+		// The black outline ring must surround the white core.
+		const size_t ringIdx = (static_cast<size_t>(dot.y - 4) * size + dot.x) * 4;
+		CHECK(rgba[ringIdx + 0] == 0 && rgba[ringIdx + 1] == 0 &&
+				  rgba[ringIdx + 2] == 0 && rgba[ringIdx + 3] == 255,
+			  "Player dot outline should be opaque black");
+	}
+
+	// Fractional player position: pixel comes from the grid, not from a
+	// locally reconstructed mapping.
+	{
+		std::vector<unsigned char> rgba(size * size * 4, 0);
+		const glm::vec2 player{-0.5f, 12.25f};
+		paintBiomeMapPlayerDot(rgba, grid, player);
+		const glm::ivec2 dot = grid.pixelForWorld(player);
+		CHECK(dot.x >= 0 && dot.y >= 0 && dot.x < size && dot.y < size,
+			  "fractional player maps inside the grid");
+		const size_t centerIdx = (static_cast<size_t>(dot.y) * size + dot.x) * 4;
+		CHECK(rgba[centerIdx + 0] == 255 && rgba[centerIdx + 1] == 255 &&
+				  rgba[centerIdx + 2] == 255 && rgba[centerIdx + 3] == 255,
+			  "Fractional player dot center should be opaque white");
+	}
+
+	// Player far outside the grid: nothing may be painted at all.
+	{
+		std::vector<unsigned char> rgba(size * size * 4, 0);
+		const std::vector<unsigned char> before = rgba;
+		paintBiomeMapPlayerDot(rgba, grid, {-100000.f, -100000.f});
+		CHECK(rgba == before, "Out-of-grid player must not paint any pixel");
+	}
+
+	// Just beyond the border (one ring would overlap the map): the ring may
+	// clip but the marker core must stay outside.
+	{
+		std::vector<unsigned char> rgba(size * size * 4, 0);
+		const glm::vec2 player = grid.worldAt(-1, -1); // one pixel outside
+		paintBiomeMapPlayerDot(rgba, grid, player);
+		const glm::ivec2 dot = grid.pixelForWorld(player);
+		CHECK(dot == glm::ivec2(-1, -1), "player one pixel outside maps to pixel -1");
+		for (int y = 0; y < size; ++y)
+			for (int x = 0; x < size; ++x)
+			{
+				const size_t idx = (static_cast<size_t>(y) * size + x) * 4;
+				if (rgba[idx + 3] == 255)
+				{
+					// Only outline pixels within 4 px of the border may paint.
+					const int dx = x - dot.x;
+					const int dy = y - dot.y;
+					CHECK(dx * dx + dy * dy <= 16,
+						  "only the clipped outline may paint near the border");
+				}
+			}
+	}
 }
 
 static void test_biome_map_upload_validation()

--- a/tests/test_biome_map.cpp
+++ b/tests/test_biome_map.cpp
@@ -356,27 +356,16 @@ static void test_player_dot_painting()
 		CHECK(rgba == before, "Out-of-grid player must not paint any pixel");
 	}
 
-	// Just beyond the border (one ring would overlap the map): the ring may
-	// clip but the marker core must stay outside.
+	// Just beyond the border: a marker whose center is outside the grid
+	// paints nothing — no half-clipped ring on the edge.
 	{
 		std::vector<unsigned char> rgba(size * size * 4, 0);
 		const glm::vec2 player = grid.worldAt(-1, -1); // one pixel outside
+		CHECK(grid.pixelForWorld(player) == glm::ivec2(-1, -1),
+			  "player one pixel outside maps to pixel -1");
+		const std::vector<unsigned char> before = rgba;
 		paintBiomeMapPlayerDot(rgba, grid, player);
-		const glm::ivec2 dot = grid.pixelForWorld(player);
-		CHECK(dot == glm::ivec2(-1, -1), "player one pixel outside maps to pixel -1");
-		for (int y = 0; y < size; ++y)
-			for (int x = 0; x < size; ++x)
-			{
-				const size_t idx = (static_cast<size_t>(y) * size + x) * 4;
-				if (rgba[idx + 3] == 255)
-				{
-					// Only outline pixels within 4 px of the border may paint.
-					const int dx = x - dot.x;
-					const int dy = y - dot.y;
-					CHECK(dx * dx + dy * dy <= 16,
-						  "only the clipped outline may paint near the border");
-				}
-			}
+		CHECK(rgba == before, "Out-of-grid marker center must not paint any pixel");
 	}
 }
 

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -1715,35 +1715,40 @@ static void testBiomeRegionCancellationAndStats()
 		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 10.0f, 256, 256);
 		TerrainGenerator::BiomeRegionStats stats;
 		std::vector<BiomeType> biomes;
-		const bool completed = gen.getBiomeRegion(grid, biomes, {}, &stats);
+		const bool completed = gen.getBiomeRegion(grid, biomes, nullptr, {}, &stats);
 		CHECK(completed, "zoom 0.1 map sampling must complete");
 		CHECK(biomes.size() == static_cast<size_t>(256) * 256,
 			  "zoom 0.1 map output size valid");
 		CHECK(stats.denseTiles > 0, "zoom 0.1 must use dense tiles");
 		CHECK(stats.fallbackPixels == 0,
 			  "zoom 0.1 must not use the point-query fallback");
+		// Peak scratch must stay within the documented bounds: 10 float
+		// fields per dense point.
+		CHECK(stats.peakDensePoints <= TerrainGenerator::kMaxTileDensePoints,
+			  "tiled path must stay within the per-tile scratch bound");
+		CHECK(stats.peakScratchBytes ==
+				  stats.peakDensePoints * TerrainGenerator::kBiomeRegionScratchFields * sizeof(float),
+			  "peak scratch bytes must track peak dense points");
 	}
 
-	// Deterministic multi-tile cancellation: the callback cancels after the
-	// third tile; the call must report interruption and publish nothing.
-	// The callback may be polled concurrently from tile workers, so the
-	// counter is atomic.
+	// Deterministic sequential multi-tile cancellation: the callback cancels
+	// exactly on the fourth poll (before tile 4), so exactly three tiles run.
 	{
 		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 10.0f, 256, 256);
-		std::atomic<int> polls{0};
+		int polls = 0;
 		std::vector<BiomeType> biomes;
-		const bool completed = gen.getBiomeRegion(grid, biomes,
-												  [&polls] { return polls.fetch_add(1) >= 3; });
+		const bool completed = gen.getBiomeRegion(grid, biomes, nullptr,
+												  [&polls] { return ++polls == 4; });
 		CHECK(!completed, "cancelled region sampling must report interruption");
 		CHECK(biomes.empty(), "cancelled region sampling must not publish partial results");
-		CHECK(polls.load() < 256, "cancellation must fire before all tiles complete");
+		CHECK(polls == 4, "cancellation must fire exactly at the fourth tile checkpoint");
 	}
 
 	// A never-cancelling callback must complete identically to no callback.
 	{
 		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 10.0f, 64, 64);
 		std::vector<BiomeType> biomes;
-		CHECK(gen.getBiomeRegion(grid, biomes, [] { return false; }),
+		CHECK(gen.getBiomeRegion(grid, biomes, nullptr, [] { return false; }),
 			  "never-cancelling callback must complete");
 		CHECK(biomes.size() == static_cast<size_t>(64) * 64, "output size intact");
 	}
@@ -1753,9 +1758,23 @@ static void testBiomeRegionCancellationAndStats()
 	{
 		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 64, 64);
 		std::vector<BiomeType> biomes;
-		CHECK(!gen.getBiomeRegion(grid, biomes, [] { return true; }),
+		CHECK(!gen.getBiomeRegion(grid, biomes, nullptr, [] { return true; }),
 			  "single-pass cancellation must report interruption");
 		CHECK(biomes.empty(), "single-pass cancellation must publish nothing");
+	}
+
+	// Single-pass cancellation observed only AFTER sampling (poll 1 before,
+	// poll 2 after the dense pass): the result must still be discarded —
+	// never a fully-sampled but cancelled publication.
+	{
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 64, 64);
+		int polls = 0;
+		std::vector<BiomeType> biomes;
+		const bool completed = gen.getBiomeRegion(grid, biomes, nullptr,
+												  [&polls] { return ++polls >= 2; });
+		CHECK(!completed, "post-sampling cancellation must report interruption");
+		CHECK(biomes.empty(), "post-sampling cancellation must publish nothing");
+		CHECK(polls == 2, "post-sampling cancellation must poll before and after the pass");
 	}
 
 	// Invalid grids are rejected without sampling.
@@ -1773,7 +1792,158 @@ static void testBiomeRegionCancellationAndStats()
 	}
 
 	std::cout << "biome region cancellation: multi-tile and single-pass early exit, "
-			  << "invalid-grid rejection, and dense-path stats validated\n";
+			  << "post-sampling rejection, invalid-grid rejection, and dense-path stats validated\n";
+}
+
+static void testBiomeRegionDeterminism()
+{
+	// Same seed + same grid must produce identical biome buffers across
+	// repeated calls and across independent generator instances — for both
+	// the single-pass dense path and the tiled path.
+	struct Case
+	{
+		float step;
+		int size;
+	};
+	constexpr Case kCases[] = {
+		{1.0f, 96},  // span 99x99 -> single dense pass
+		{10.0f, 256}, // span 2555x2555 -> tiled path
+	};
+
+	TerrainGenerator genA(4242);
+	TerrainGenerator genB(4242); // independent instance, same seed
+
+	for (const Case &tc : kCases)
+	{
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(123.47f, -87.23f, tc.step, tc.size, tc.size);
+		std::vector<BiomeType> first, second, fromOtherGen;
+		CHECK(genA.getBiomeRegion(grid, first), "determinism sampling (call 1) must complete");
+		CHECK(genA.getBiomeRegion(grid, second), "determinism sampling (call 2) must complete");
+		CHECK(genB.getBiomeRegion(grid, fromOtherGen), "determinism sampling (other generator) must complete");
+		CHECK(first == second, "repeated calls with the same grid must be identical");
+		CHECK(first == fromOtherGen, "independent generators with the same seed must agree");
+	}
+
+	std::cout << "biome region determinism: repeated calls and independent generators agree\n";
+}
+
+static void testBiomeRegionDenseTiledEquivalence()
+{
+	// A region whose whole dense domain exceeds the single-pass cap must be
+	// bit-for-bit identical to the same columns assembled from small dense
+	// sub-queries. This protects the halo handling at tile boundaries.
+	TerrainGenerator gen(1337);
+
+	constexpr int kSize = 260;
+	constexpr float kStep = 2.0f; // span 519+halo > 516^2 cap -> tiled path
+	const BiomeRegionGrid grid = makeBiomeRegionGrid(500.0f, -500.0f, kStep, kSize, kSize);
+
+	std::vector<BiomeType> tiled;
+	CHECK(gen.getBiomeRegion(grid, tiled), "tiled sampling must complete");
+
+	constexpr int kBlock = 4; // independent partitioning, not the tile size
+	std::vector<BiomeType> reference(static_cast<size_t>(kSize) * kSize);
+	static_assert(kSize % kBlock == 0, "full blocks keep the pixel mapping exact");
+	for (int bz = 0; bz < kSize; bz += kBlock)
+	{
+		for (int bx = 0; bx < kSize; bx += kBlock)
+		{
+			// Anchor the sub-grid center on an actual pixel of the original
+			// grid: with this grid contract an even-size grid samples its
+			// center at pixel size/2, so the reconstructed pixels coincide
+			// exactly with the original ones (a half-pixel midpoint would
+			// shift every column by step/2).
+			const glm::vec2 blockCenter = grid.worldAt(bx + kBlock / 2,
+													   bz + kBlock / 2);
+			const BiomeRegionGrid blockGrid = makeBiomeRegionGrid(
+				blockCenter.x, blockCenter.y, kStep, kBlock, kBlock);
+			std::vector<BiomeType> block;
+			CHECK(gen.getBiomeRegion(blockGrid, block), "block sampling must complete");
+			for (int z = 0; z < kBlock; ++z)
+				for (int x = 0; x < kBlock; ++x)
+					reference[static_cast<size_t>(bz + z) * kSize + (bx + x)] =
+						block[static_cast<size_t>(z) * kBlock + x];
+		}
+	}
+
+	{
+		size_t mismatches = 0;
+		for (int z = 0; z < kSize && mismatches < 5; ++z)
+			for (int x = 0; x < kSize && mismatches < 5; ++x)
+			{
+				const BiomeType a = tiled[static_cast<size_t>(z) * kSize + x];
+				const BiomeType b = reference[static_cast<size_t>(z) * kSize + x];
+				if (a != b)
+				{
+					++mismatches;
+					const glm::ivec2 col = grid.columnAt(x, z);
+					std::cerr << "MISMATCH pixel=(" << x << "," << z << ") world=("
+							  << grid.worldAt(x, z).x << "," << grid.worldAt(x, z).y
+							  << ") col=(" << col.x << "," << col.y << ") tiled="
+							  << biomeTypeString[a] << " dense=" << biomeTypeString[b]
+							  << " getBiomeAt=" << biomeTypeString[gen.getBiomeAt(col.x, col.y)]
+							  << '\n';
+				}
+			}
+		CHECK(mismatches == 0, "tiled output must be bit-for-bit identical to dense sub-queries");
+	}
+	std::cout << "biome region equivalence: " << kSize << "x" << kSize
+			  << " tiled output matches dense sub-queries bit-for-bit\n";
+}
+
+static void testBiomeRegionGridParity()
+{
+	// Even size: pixel size/2 samples the center exactly.
+	const BiomeRegionGrid even = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 4, 4);
+	CHECK(even.worldAt(2, 2) == glm::vec2(0.0f, 0.0f),
+		  "even size: pixel size/2 = center");
+	CHECK(even.worldAt(0, 0) == glm::vec2(-2.0f, -2.0f) &&
+			  even.worldAt(3, 3) == glm::vec2(1.0f, 1.0f),
+		  "even size: pixels sample -2, -1, 0, 1");
+
+	// Odd size: the center falls between the two central pixels.
+	const BiomeRegionGrid odd = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 5, 5);
+	CHECK(odd.worldAt(2, 2) == glm::vec2(-0.5f, -0.5f) &&
+			  odd.worldAt(3, 3) == glm::vec2(0.5f, 0.5f),
+		  "odd size: center straddled by pixels 2 and 3");
+	bool centerSampled = false;
+	for (int z = 0; z < 5; ++z)
+		for (int x = 0; x < 5; ++x)
+			centerSampled |= (odd.worldAt(x, z) == glm::vec2(0.0f, 0.0f));
+	CHECK(!centerSampled, "odd size: no pixel samples the center exactly");
+
+	std::cout << "BiomeRegionGrid parity: even center-on-pixel / odd center-between-pixels validated\n";
+}
+
+static void testBiomeRegionExtremeGridGuard()
+{
+	// Extreme grid parameters (absurd step) must not overflow the span math
+	// or the noise-domain translation: the call completes deterministically
+	// with clamped canonical columns.
+	TerrainGenerator gen(1337);
+	constexpr float kHugeStep = 1e20f;
+	const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, kHugeStep, 8, 8);
+
+	std::vector<BiomeType> first, second;
+	CHECK(gen.getBiomeRegion(grid, first), "extreme-step grid must complete");
+	CHECK(gen.getBiomeRegion(grid, second), "extreme-step grid must repeat");
+	CHECK(first == second, "extreme-step grid must be deterministic");
+	CHECK(first.size() == static_cast<size_t>(8) * 8, "extreme-step output size valid");
+
+	// Columns clamp toward the limit: pixels left of the center floor to a
+	// huge negative world (clamped to -limit), the center pixel itself maps
+	// to world 0 (column 0), and pixels right of it clamp to +limit.
+	for (int z = 0; z < 8; ++z)
+	{
+		for (int x = 1; x < 4; ++x)
+			CHECK(first[static_cast<size_t>(z) * 8 + x] == first[static_cast<size_t>(z) * 8],
+				  "negative-clamped half resolves consistently");
+		for (int x = 6; x < 8; ++x)
+			CHECK(first[static_cast<size_t>(z) * 8 + x] == first[static_cast<size_t>(z) * 8 + 5],
+				  "positive-clamped half resolves consistently");
+	}
+
+	std::cout << "biome region extreme grid: absurd step handled without overflow\n";
 }
 
 static void testBiomeMapGridMatchesPointQueries()
@@ -1791,7 +1961,7 @@ static void testBiomeMapGridMatchesPointQueries()
 		int size;
 	};
 	constexpr GridCase kGrids[] = {
-		{0.0f, 0.0f, 1.0f, 33},        // odd size: center lands on a pixel
+		{0.0f, 0.0f, 1.0f, 33},        // odd size: center falls between two pixels
 		{0.0f, 0.0f, 0.5f, 32},        // step 2
 		{123.47f, -87.23f, 2.0f, 32},  // step 0.5, fractional center
 		{123.47f, -87.23f, 8.0f, 24},  // step 0.125, fractional center
@@ -2020,14 +2190,17 @@ static void testBiomeRegionMultiStepAndZoomConsistency()
 			const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, step, kMapDim, kMapDim);
 			TerrainGenerator::BiomeRegionStats stats;
 			const auto tStart = Clock::now();
-			const bool ok = gen.getBiomeRegion(grid, fullMap, {}, &stats);
+			const bool ok = gen.getBiomeRegion(grid, fullMap, nullptr, {}, &stats);
 			const double ms = std::chrono::duration<double, std::milli>(Clock::now() - tStart).count();
 			CHECK(ok && fullMap.size() == static_cast<size_t>(kMapDim) * kMapDim,
 				  "256x256 map output size valid");
 			std::cout << "  [UI Map Perf] zoom=" << zoom << " (step=" << step << "): "
 					  << ms << " ms (" << (kMapDim * kMapDim / (ms * 1000.0)) << " Mpixels/sec)"
 					  << " denseTiles=" << stats.denseTiles
-					  << " fallbackPixels=" << stats.fallbackPixels << '\n';
+					  << " fallbackPixels=" << stats.fallbackPixels
+					  << " peakScratchBytes=" << stats.peakScratchBytes
+					  << " avgMsPerTile=" << (stats.denseTiles ? ms / static_cast<double>(stats.denseTiles) : ms)
+					  << '\n';
 			// Deterministic (not wall-clock) regression gate: every UI map
 			// zoom must stay on the vectorized dense tile path.
 			CHECK(stats.fallbackPixels == 0,
@@ -2064,7 +2237,11 @@ int main(int argc, char **argv)
 	testBiomeQueryConsistency();
 	testWorldToVoxelColumnConvention();
 	testBiomeRegionGridMapping();
+	testBiomeRegionGridParity();
 	testBiomeRegionCancellationAndStats();
+	testBiomeRegionDeterminism();
+	testBiomeRegionDenseTiledEquivalence();
+	testBiomeRegionExtremeGridGuard();
 	testBiomeMapGridMatchesPointQueries();
 	testBiomeRegionMultiStepAndZoomConsistency();
 	testPhase3BiomePresence();

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -1412,6 +1412,174 @@ static int runWorldStats(int argc, char **argv)
 	return 0;
 }
 
+static void testBiomeQueryConsistency()
+{
+	constexpr int kTestSeeds[] = {1337, 42, 9001};
+	const std::vector<std::pair<int, int>> kStaticCoords = {
+		{0, 0},
+		{CHUNK_SIZE, 0},
+		{0, CHUNK_SIZE},
+		{CHUNK_SIZE, CHUNK_SIZE},
+		{-CHUNK_SIZE, 0},
+		{0, -CHUNK_SIZE},
+		{-CHUNK_SIZE, -CHUNK_SIZE},
+		{-160, -80},
+		{-320, 4000},
+		{128, -256}
+	};
+
+	bool sawRiver = false;
+	bool sawMountain = false;
+	bool sawCoastOrOcean = false;
+	bool sawRareOrDesert = false;
+	int totalColumnsChecked = 0;
+
+	for (int seed : kTestSeeds)
+	{
+		TerrainGenerator gen(seed);
+		std::vector<std::pair<int, int>> chunkCoords = kStaticCoords;
+
+		// Scan a grid to locate coordinates specifically hitting mountain, river, coast, and rare biomes
+		bool foundMountainCoord = false;
+		bool foundRiverCoord = false;
+		bool foundCoastCoord = false;
+		bool foundRareCoord = false;
+
+		for (int cz = -20; cz <= 20 && (!foundMountainCoord || !foundRiverCoord || !foundCoastCoord || !foundRareCoord); cz += 3)
+		{
+			for (int cx = -20; cx <= 20 && (!foundMountainCoord || !foundRiverCoord || !foundCoastCoord || !foundRareCoord); cx += 3)
+			{
+				const int wx = cx * CHUNK_SIZE;
+				const int wz = cz * CHUNK_SIZE;
+				const BiomeType b = gen.getBiomeAt(wx, wz);
+				if (!foundMountainCoord && isMountainBiomeForTest(b))
+				{
+					chunkCoords.push_back({wx, wz});
+					foundMountainCoord = true;
+				}
+				if (!foundRiverCoord && (b == BIOME_RIVER || b == BIOME_FROZEN_RIVER))
+				{
+					chunkCoords.push_back({wx, wz});
+					foundRiverCoord = true;
+				}
+				if (!foundCoastCoord && (b == BIOME_BEACH || b == BIOME_OCEAN || b == BIOME_FROZEN_OCEAN))
+				{
+					chunkCoords.push_back({wx, wz});
+					foundCoastCoord = true;
+				}
+				if (!foundRareCoord && (b == BIOME_BADLANDS || b == BIOME_OASIS || b == BIOME_MUSHROOM_FIELDS || b == BIOME_ICE_SPIKES))
+				{
+					chunkCoords.push_back({wx, wz});
+					foundRareCoord = true;
+				}
+			}
+		}
+
+		for (const auto &[chunkX, chunkZ] : chunkCoords)
+		{
+			ChunkData chunk = gen.generateChunk(chunkX, chunkZ);
+
+			// 1. Point query consistency: getBiomeAt vs chunkData.biomes
+			for (int lz = 0; lz < CHUNK_SIZE; ++lz)
+			{
+				for (int lx = 0; lx < CHUNK_SIZE; ++lx)
+				{
+					const int col = lz * CHUNK_SIZE + lx;
+					const int wx = chunkX + lx;
+					const int wz = chunkZ + lz;
+
+					const BiomeType chunkBiome = chunk.biomes[col];
+					const BiomeType pointBiome = gen.getBiomeAt(wx, wz);
+					CHECK(chunkBiome == pointBiome,
+						  "getBiomeAt must match chunk biomes exactly (seed=" << seed
+						  << " wx=" << wx << " wz=" << wz
+						  << " expected=" << biomeTypeString[chunkBiome]
+						  << " got=" << biomeTypeString[pointBiome] << ")");
+
+					if (chunkBiome == BIOME_RIVER || chunkBiome == BIOME_FROZEN_RIVER)
+						sawRiver = true;
+					if (isMountainBiomeForTest(chunkBiome))
+						sawMountain = true;
+					if (chunkBiome == BIOME_BEACH || chunkBiome == BIOME_OCEAN || chunkBiome == BIOME_FROZEN_OCEAN)
+						sawCoastOrOcean = true;
+					if (chunkBiome == BIOME_BADLANDS || chunkBiome == BIOME_OASIS || chunkBiome == BIOME_MUSHROOM_FIELDS || chunkBiome == BIOME_ICE_SPIKES)
+						sawRareOrDesert = true;
+
+					++totalColumnsChecked;
+				}
+			}
+
+			// 2. Region query consistency for single chunk: getBiomeRegion vs chunkData.biomes
+			const float centerX = static_cast<float>(chunkX) + CHUNK_SIZE * 0.5f;
+			const float centerZ = static_cast<float>(chunkZ) + CHUNK_SIZE * 0.5f;
+			std::vector<BiomeType> region;
+			gen.getBiomeRegion(centerX, centerZ, 1.0f, CHUNK_SIZE, CHUNK_SIZE, region);
+			CHECK(region.size() == static_cast<size_t>(CHUNK_SIZE * CHUNK_SIZE),
+				  "region size should match chunk columns");
+
+			for (int lz = 0; lz < CHUNK_SIZE; ++lz)
+			{
+				for (int lx = 0; lx < CHUNK_SIZE; ++lx)
+				{
+					const int col = lz * CHUNK_SIZE + lx;
+					CHECK(region[col] == chunk.biomes[col],
+						  "getBiomeRegion must match chunk biomes exactly (seed=" << seed
+						  << " chunk=(" << chunkX << "," << chunkZ << ")"
+						  << " lx=" << lx << " lz=" << lz
+						  << " expected=" << biomeTypeString[chunk.biomes[col]]
+						  << " got=" << biomeTypeString[region[col]] << ")");
+				}
+			}
+		}
+
+		// 3. Multi-chunk contiguous region query covering 3x3 chunks across chunk boundaries and negatives
+		constexpr int kGridChunks = 3;
+		constexpr int kRegionDim = kGridChunks * CHUNK_SIZE; // 48x48 blocks
+		const int originChunkX = -CHUNK_SIZE;
+		const int originChunkZ = -CHUNK_SIZE;
+		const float regionCenterX = static_cast<float>(originChunkX) + kRegionDim * 0.5f;
+		const float regionCenterZ = static_cast<float>(originChunkZ) + kRegionDim * 0.5f;
+
+		std::vector<BiomeType> largeRegion;
+		gen.getBiomeRegion(regionCenterX, regionCenterZ, 1.0f, kRegionDim, kRegionDim, largeRegion);
+		CHECK(largeRegion.size() == static_cast<size_t>(kRegionDim * kRegionDim),
+			  "largeRegion size must match 48x48");
+
+		for (int cz = 0; cz < kGridChunks; ++cz)
+		{
+			for (int cx = 0; cx < kGridChunks; ++cx)
+			{
+				const int chunkX = originChunkX + cx * CHUNK_SIZE;
+				const int chunkZ = originChunkZ + cz * CHUNK_SIZE;
+				ChunkData chunk = gen.generateChunk(chunkX, chunkZ);
+
+				for (int lz = 0; lz < CHUNK_SIZE; ++lz)
+				{
+					for (int lx = 0; lx < CHUNK_SIZE; ++lx)
+					{
+						const int chunkCol = lz * CHUNK_SIZE + lx;
+						const int regX = cx * CHUNK_SIZE + lx;
+						const int regZ = cz * CHUNK_SIZE + lz;
+						const int regCol = regZ * kRegionDim + regX;
+
+						CHECK(largeRegion[regCol] == chunk.biomes[chunkCol],
+							  "multi-chunk getBiomeRegion must match chunkData.biomes across boundaries");
+						CHECK(largeRegion[regCol] == gen.getBiomeAt(chunkX + lx, chunkZ + lz),
+							  "multi-chunk getBiomeRegion must match getBiomeAt across boundaries");
+					}
+				}
+			}
+		}
+	}
+
+	CHECK(sawRiver, "test coverage includes river biomes");
+	CHECK(sawMountain, "test coverage includes mountain biomes");
+	CHECK(sawCoastOrOcean, "test coverage includes coast or ocean biomes");
+	CHECK(sawRareOrDesert, "test coverage includes rare or badlands biomes");
+	std::cout << "biome query consistency: " << totalColumnsChecked
+			  << " columns verified identical across generateChunk, getBiomeAt, and getBiomeRegion\n";
+}
+
 // ---------------------------------------------------------------------------
 
 int main(int argc, char **argv)
@@ -1433,6 +1601,7 @@ int main(int argc, char **argv)
 	testBorderTrunks();
 	testFlatRiverChannels();
 	testBiomeRegistry();
+	testBiomeQueryConsistency();
 	testPhase3BiomePresence();
 	testPhase3FeatureBlocks();
 	testOasisPonds();

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -5,6 +5,7 @@
 #include <Renderer/MinecraftTextures.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <array>
 #include <chrono>
 #include <cmath>
@@ -13,6 +14,7 @@
 #include <cstring>
 #include <future>
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -1580,6 +1582,293 @@ static void testBiomeQueryConsistency()
 			  << " columns verified identical across generateChunk, getBiomeAt, and getBiomeRegion\n";
 }
 
+// ---------------------------------------------------------------------------
+// Canonical world<->voxel-column and world<->map-pixel mapping
+// (BiomeRegionGrid). Expected values are hardcoded, never derived from the
+// helpers under test.
+// ---------------------------------------------------------------------------
+
+static void testWorldToVoxelColumnConvention()
+{
+	// Canonical convention: continuous world position -> voxel column is
+	// floor(). These cases cover exactly where floor() and round() diverge.
+	constexpr float kCases[] = {
+		123.60f, 123.00f, -0.20f, -1.00f, -15.10f,
+		-0.01f, -0.49f, -0.50f, -0.99f,
+		-15.99f, -16.00f, -16.01f,
+		0.0f, 0.99f, 15.99f,
+	};
+	constexpr int kExpected[] = {
+		123, 123, -1, -1, -16,
+		-1, -1, -1, -1,
+		-16, -16, -17,
+		0, 0, 15,
+	};
+	static_assert(std::size(kCases) == std::size(kExpected));
+
+	for (size_t i = 0; i < std::size(kCases); ++i)
+	{
+		CHECK(worldToVoxelColumn(kCases[i]) == kExpected[i],
+			  "worldToVoxelColumn X must floor (" << kCases[i] << " -> "
+			  << kExpected[i] << ")");
+		// Z applies the identical convention; verify it separately.
+		CHECK(worldToVoxelColumn(glm::vec2(kCases[i], kCases[i])).y == kExpected[i],
+			  "worldToVoxelColumn Z must floor (" << kCases[i] << " -> "
+			  << kExpected[i] << ")");
+	}
+
+	// Explicit negative-transition cross cases.
+	CHECK(worldToVoxelColumn(glm::vec2(-0.2f, -0.8f)) == glm::ivec2(-1, -1),
+		  "world -0.2/-0.8 -> column -1/-1");
+	CHECK(worldToVoxelColumn(glm::vec2(0.8f, -0.2f)) == glm::ivec2(0, -1),
+		  "world 0.8/-0.2 -> column 0/-1");
+
+	std::cout << "worldToVoxelColumn: floor convention validated on "
+			  << std::size(kCases) << " hardcoded cases per axis\n";
+}
+
+static void testBiomeRegionGridMapping()
+{
+	// --- worldAt: center (0,0), 4x4, step 1.
+	const BiomeRegionGrid g = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 4, 4);
+	CHECK(g.worldAt(0, 0) == glm::vec2(-2.0f, -2.0f), "pixel 0,0 -> world (-2,-2)");
+	CHECK(g.worldAt(2, 2) == glm::vec2(0.0f, 0.0f), "pixel 2,2 -> world (0,0)");
+	CHECK(g.worldAt(3, 3) == glm::vec2(1.0f, 1.0f), "pixel 3,3 -> world (1,1)");
+
+	// --- step = 2.
+	const BiomeRegionGrid g2 = makeBiomeRegionGrid(0.0f, 0.0f, 2.0f, 4, 4);
+	CHECK(g2.worldAt(0, 0) == glm::vec2(-4.0f, -4.0f), "step 2: pixel 0,0 -> (-4,-4)");
+	CHECK(g2.worldAt(3, 3) == glm::vec2(2.0f, 2.0f), "step 2: pixel 3,3 -> (2,2)");
+
+	// --- step = 0.5.
+	const BiomeRegionGrid g05 = makeBiomeRegionGrid(0.0f, 0.0f, 0.5f, 4, 4);
+	CHECK(g05.worldAt(0, 0) == glm::vec2(-1.0f, -1.0f), "step 0.5: pixel 0,0 -> (-1,-1)");
+	CHECK(g05.worldAt(3, 3) == glm::vec2(0.5f, 0.5f), "step 0.5: pixel 3,3 -> (0.5,0.5)");
+
+	// --- fractional center.
+	const BiomeRegionGrid gf = makeBiomeRegionGrid(123.47f, -87.23f, 1.0f, 4, 4);
+	CHECK(std::fabs(gf.worldAt(0, 0).x - 121.47f) < 1e-4f &&
+			  std::fabs(gf.worldAt(0, 0).y - (-89.23f)) < 1e-4f,
+		  "fractional center: pixel 0,0 at (121.47, -89.23)");
+
+	// --- negative center.
+	const BiomeRegionGrid gn = makeBiomeRegionGrid(-1000.0f, -2000.0f, 0.5f, 8, 8);
+	CHECK(std::fabs(gn.worldAt(7, 7).x - (-998.5f)) < 1e-3f &&
+			  std::fabs(gn.worldAt(7, 7).y - (-1998.5f)) < 1e-3f,
+		  "negative center: last pixel at (-998.5, -1998.5)");
+
+	// --- columnAt applies the canonical floor() to the pixel's world pos.
+	const BiomeRegionGrid gc = makeBiomeRegionGrid(0.2f, 0.2f, 1.0f, 4, 4);
+	// pixel worlds along x: ..., -0.8, 0.2, ...
+	CHECK(gc.columnAt(1, 1) == glm::ivec2(-1, -1), "world -0.8 -> column -1");
+	CHECK(gc.columnAt(2, 2) == glm::ivec2(0, 0), "world 0.2 -> column 0");
+	CHECK(worldToVoxelColumn(gc.worldAt(3, 1)).x == 1 &&
+			  worldToVoxelColumn(gc.worldAt(3, 1)).y == -1,
+		  "worldAt -> columnAt cross: world (1.2, -0.8) -> column (1, -1)");
+
+	// --- pixelForWorld round-trips exactly for representative centers,
+	// steps (incl. zoom 8 and zoom 0.1), and both grid parities.
+	for (float step : {1.0f, 0.5f, 2.0f, 0.125f, 10.0f})
+	{
+		for (const auto &[cx, cz] : {std::pair{0.0f, 0.0f}, std::pair{123.47f, -87.23f}})
+		{
+			const BiomeRegionGrid grid = makeBiomeRegionGrid(cx, cz, step, 32, 25);
+			for (int z = 0; z < grid.height; ++z)
+			{
+				for (int x = 0; x < grid.width; ++x)
+				{
+					const glm::ivec2 pixel = grid.pixelForWorld(grid.worldAt(x, z));
+					CHECK(pixel.x == x && pixel.y == z,
+						  "pixelForWorld(worldAt(x,z)) must round-trip (step="
+							  << step << " pixel=" << x << "," << z << ")");
+				}
+			}
+			// Image edges and one step beyond them.
+			CHECK(grid.pixelForWorld(grid.worldAt(0, 0)) == glm::ivec2(0, 0),
+				  "edge pixel 0,0 round-trips");
+			CHECK(grid.pixelForWorld(grid.worldAt(31, 24)) == glm::ivec2(31, 24),
+				  "edge pixel 31,24 round-trips");
+			CHECK(grid.pixelForWorld(grid.worldAt(0, 0) - glm::vec2(step, 0.0f)).x == -1,
+				  "one step left of the grid maps to pixel -1");
+			CHECK(grid.pixelForWorld(grid.worldAt(31, 24) + glm::vec2(step, 0.0f)).x == 32,
+				  "one step right of the grid maps to pixel width");
+		}
+	}
+
+	// Extreme world positions must not overflow the pixel computation.
+	const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 32, 32);
+	const glm::ivec2 farPixel = grid.pixelForWorld(glm::vec2(1e9f, -1e9f));
+	CHECK(farPixel.x >= grid.width && farPixel.y < 0,
+		  "extreme world positions resolve outside the grid without overflow");
+
+	std::cout << "BiomeRegionGrid: worldAt/columnAt/pixelForWorld validated\n";
+}
+
+static void testBiomeRegionCancellationAndStats()
+{
+	TerrainGenerator gen(1337);
+
+	// zoom = 0.1 (step 10) over a 256x256 UI map: the tiled path. The
+	// adaptive tile dimension must keep every pixel on the dense
+	// vectorized path (fallback is a safety net only).
+	{
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 10.0f, 256, 256);
+		TerrainGenerator::BiomeRegionStats stats;
+		std::vector<BiomeType> biomes;
+		const bool completed = gen.getBiomeRegion(grid, biomes, {}, &stats);
+		CHECK(completed, "zoom 0.1 map sampling must complete");
+		CHECK(biomes.size() == static_cast<size_t>(256) * 256,
+			  "zoom 0.1 map output size valid");
+		CHECK(stats.denseTiles > 0, "zoom 0.1 must use dense tiles");
+		CHECK(stats.fallbackPixels == 0,
+			  "zoom 0.1 must not use the point-query fallback");
+	}
+
+	// Deterministic multi-tile cancellation: the callback cancels after the
+	// third tile; the call must report interruption and publish nothing.
+	// The callback may be polled concurrently from tile workers, so the
+	// counter is atomic.
+	{
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 10.0f, 256, 256);
+		std::atomic<int> polls{0};
+		std::vector<BiomeType> biomes;
+		const bool completed = gen.getBiomeRegion(grid, biomes,
+												  [&polls] { return polls.fetch_add(1) >= 3; });
+		CHECK(!completed, "cancelled region sampling must report interruption");
+		CHECK(biomes.empty(), "cancelled region sampling must not publish partial results");
+		CHECK(polls.load() < 256, "cancellation must fire before all tiles complete");
+	}
+
+	// A never-cancelling callback must complete identically to no callback.
+	{
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 10.0f, 64, 64);
+		std::vector<BiomeType> biomes;
+		CHECK(gen.getBiomeRegion(grid, biomes, [] { return false; }),
+			  "never-cancelling callback must complete");
+		CHECK(biomes.size() == static_cast<size_t>(64) * 64, "output size intact");
+	}
+
+	// Single-pass domain: an immediately-true callback is honored before
+	// sampling, and nothing partial is returned.
+	{
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 64, 64);
+		std::vector<BiomeType> biomes;
+		CHECK(!gen.getBiomeRegion(grid, biomes, [] { return true; }),
+			  "single-pass cancellation must report interruption");
+		CHECK(biomes.empty(), "single-pass cancellation must publish nothing");
+	}
+
+	// Invalid grids are rejected without sampling.
+	{
+		std::vector<BiomeType> biomes(16, BIOME_PLAINS);
+		CHECK(!gen.getBiomeRegion(makeBiomeRegionGrid(0.0f, 0.0f, 0.0f, 8, 8), biomes),
+			  "zero step must be rejected");
+		CHECK(!gen.getBiomeRegion(makeBiomeRegionGrid(0.0f, 0.0f, -1.0f, 8, 8), biomes),
+			  "negative step must be rejected");
+		CHECK(!gen.getBiomeRegion(makeBiomeRegionGrid(0.0f, 0.0f, std::nanf(""), 8, 8), biomes),
+			  "NaN step must be rejected");
+		CHECK(!gen.getBiomeRegion(makeBiomeRegionGrid(std::nanf(""), 0.0f, 1.0f, 8, 8), biomes),
+			  "NaN center must be rejected");
+		CHECK(biomes.empty(), "invalid grid must clear the output buffer");
+	}
+
+	std::cout << "biome region cancellation: multi-tile and single-pass early exit, "
+			  << "invalid-grid rejection, and dense-path stats validated\n";
+}
+
+static void testBiomeMapGridMatchesPointQueries()
+{
+	// Terrain <-> UI cross test: the biome rendered at the player's map pixel
+	// must equal getBiomeAt() of the player's canonical voxel column whenever
+	// the nearest display pixel actually represents that column.
+	TerrainGenerator gen(1337);
+
+	struct GridCase
+	{
+		float centerX;
+		float centerZ;
+		float zoom;
+		int size;
+	};
+	constexpr GridCase kGrids[] = {
+		{0.0f, 0.0f, 1.0f, 33},        // odd size: center lands on a pixel
+		{0.0f, 0.0f, 0.5f, 32},        // step 2
+		{123.47f, -87.23f, 2.0f, 32},  // step 0.5, fractional center
+		{123.47f, -87.23f, 8.0f, 24},  // step 0.125, fractional center
+		{-0.5f, -1.25f, 1.0f, 32},     // negative near-zero center
+		{500.0f, -500.0f, 0.25f, 32},  // step 4
+	};
+
+	constexpr glm::vec2 kPlayers[] = {
+		{0.0f, 0.0f}, {0.5f, -0.5f}, {-0.1f, 0.1f}, {-0.99f, -0.01f},
+		{123.60f, -87.20f}, {-15.10f, 44.80f}, {100.3f, 200.7f},
+		{0.0f, -0.1f}, {16.0f, -16.0f},
+	};
+
+	int checked = 0;
+	for (const auto &gc : kGrids)
+	{
+		const BiomeRegionGrid grid =
+			makeBiomeRegionGrid(gc.centerX, gc.centerZ, 1.0f / gc.zoom, gc.size, gc.size);
+		std::vector<BiomeType> region;
+		CHECK(gen.getBiomeRegion(grid, region), "grid sampling must complete");
+
+		for (const glm::vec2 &player : kPlayers)
+		{
+			const glm::ivec2 pixel = grid.pixelForWorld(player);
+			if (pixel.x < 0 || pixel.y < 0 ||
+				pixel.x >= grid.width || pixel.y >= grid.height)
+				continue; // marker outside the map is simply not drawn
+
+			const glm::ivec2 column = worldToVoxelColumn(player);
+			// The display pixel represents the player's column only when the
+			// pixel's own world position floors to the same column.
+			if (grid.columnAt(pixel.x, pixel.y) != column)
+				continue;
+
+			const BiomeType mapBiome =
+				region[static_cast<size_t>(pixel.y) * grid.width + pixel.x];
+			const BiomeType pointBiome = gen.getBiomeAt(column.x, column.y);
+			CHECK(mapBiome == pointBiome,
+				  "map pixel under the player marker must match getBiomeAt (grid="
+					  << gc.centerX << "," << gc.centerZ << " zoom=" << gc.zoom
+					  << " player=" << player.x << "," << player.y
+					  << " map=" << biomeTypeString[mapBiome]
+					  << " point=" << biomeTypeString[pointBiome] << ")");
+			++checked;
+		}
+
+		// Pixel walk: place the player exactly at each (strided) pixel's world
+		// position — a fractional position whenever center/step are fractional.
+		// The nearest display pixel then always represents the player's column,
+		// so every visited pair must agree.
+		for (int z = 0; z < grid.height; z += 5)
+		{
+			for (int x = 0; x < grid.width; x += 5)
+			{
+				const glm::vec2 player = grid.worldAt(x, z);
+				const glm::ivec2 pixel = grid.pixelForWorld(player);
+				CHECK(pixel == glm::ivec2(x, z), "player at pixel world maps back to the pixel");
+
+				const glm::ivec2 column = worldToVoxelColumn(player);
+				CHECK(grid.columnAt(x, z) == column,
+					  "pixel column equals player floor column");
+				const BiomeType mapBiome =
+					region[static_cast<size_t>(z) * grid.width + x];
+				const BiomeType pointBiome = gen.getBiomeAt(column.x, column.y);
+				CHECK(mapBiome == pointBiome,
+					  "pixel-walk map biome must match getBiomeAt (zoom="
+						  << gc.zoom << " pixel=" << x << "," << z << ")");
+				++checked;
+			}
+		}
+	}
+	CHECK(checked > 50, "cross test exercised enough pixel/column pairs");
+
+	std::cout << "terrain/UI cross: " << checked
+			  << " player pixel/column pairs agree between biome map and getBiomeAt\n";
+}
+
 static void testBiomeRegionMultiStepAndZoomConsistency()
 {
 	using Clock = std::chrono::steady_clock;
@@ -1604,6 +1893,7 @@ static void testBiomeRegionMultiStepAndZoomConsistency()
 	};
 
 	int totalPixelsVerified = 0;
+	int totalUniqueChunks = 0;
 
 	for (int seed : kTestSeeds)
 	{
@@ -1615,8 +1905,11 @@ static void testBiomeRegionMultiStepAndZoomConsistency()
 
 			for (const auto &tc : kCases)
 			{
+				const BiomeRegionGrid grid =
+					makeBiomeRegionGrid(tc.centerX, tc.centerZ, step, tc.width, tc.height);
 				std::vector<BiomeType> region;
-				gen.getBiomeRegion(tc.centerX, tc.centerZ, step, tc.width, tc.height, region);
+				CHECK(gen.getBiomeRegion(grid, region),
+					  "region sampling must complete (seed=" << seed << " zoom=" << zoom << ")");
 
 				CHECK(region.size() == static_cast<size_t>(tc.width * tc.height),
 					  "region size must match requested dimensions");
@@ -1625,8 +1918,7 @@ static void testBiomeRegionMultiStepAndZoomConsistency()
 				{
 					for (int xi = 0; xi < tc.width; ++xi)
 					{
-						const glm::ivec2 col = TerrainGenerator::computeBiomeRegionDiscreteColumn(
-							tc.centerX, tc.centerZ, step, tc.width, tc.height, xi, zi);
+						const glm::ivec2 col = grid.columnAt(xi, zi);
 						const BiomeType expectedBiome = gen.getBiomeAt(col.x, col.y);
 						const BiomeType actualBiome = region[zi * tc.width + xi];
 
@@ -1651,10 +1943,8 @@ static void testBiomeRegionMultiStepAndZoomConsistency()
 					{
 						for (int xi = 0; xi < tc.width - 1; ++xi)
 						{
-							const glm::ivec2 colA = TerrainGenerator::computeBiomeRegionDiscreteColumn(
-								tc.centerX, tc.centerZ, step, tc.width, tc.height, xi, zi);
-							const glm::ivec2 colB = TerrainGenerator::computeBiomeRegionDiscreteColumn(
-								tc.centerX, tc.centerZ, step, tc.width, tc.height, xi + 1, zi);
+							const glm::ivec2 colA = grid.columnAt(xi, zi);
+							const glm::ivec2 colB = grid.columnAt(xi + 1, zi);
 							if (colA == colB)
 							{
 								CHECK(region[zi * tc.width + xi] == region[zi * tc.width + (xi + 1)],
@@ -1666,7 +1956,9 @@ static void testBiomeRegionMultiStepAndZoomConsistency()
 			}
 		}
 
-		// Direct chunk comparison for integer steps (step = 1.0, 2.0, 4.0)
+		// Direct chunk comparison for integer steps (step = 1.0, 2.0, 4.0).
+		// Chunks are cached so every unique chunk is generated exactly once
+		// instead of once per pixel.
 		for (float step : {1.0f, 2.0f, 4.0f})
 		{
 			constexpr int kSize = 16;
@@ -1675,15 +1967,25 @@ static void testBiomeRegionMultiStepAndZoomConsistency()
 			const float cx = static_cast<float>(originChunkX) + kSize * step * 0.5f;
 			const float cz = static_cast<float>(originChunkZ) + kSize * step * 0.5f;
 
+			const BiomeRegionGrid grid = makeBiomeRegionGrid(cx, cz, step, kSize, kSize);
 			std::vector<BiomeType> region;
-			gen.getBiomeRegion(cx, cz, step, kSize, kSize, region);
+			CHECK(gen.getBiomeRegion(grid, region), "integer-step region sampling must complete");
+
+			std::map<std::pair<int, int>, ChunkData> chunkCache;
+			auto getCachedChunk = [&](int chX, int chZ) -> const ChunkData & {
+				const auto it = chunkCache.find({chX, chZ});
+				if (it != chunkCache.end())
+					return it->second;
+				return chunkCache.emplace(std::make_pair(chX, chZ),
+										  gen.generateChunk(chX, chZ))
+					.first->second;
+			};
 
 			for (int zi = 0; zi < kSize; ++zi)
 			{
 				for (int xi = 0; xi < kSize; ++xi)
 				{
-					const glm::ivec2 col = TerrainGenerator::computeBiomeRegionDiscreteColumn(
-						cx, cz, step, kSize, kSize, xi, zi);
+					const glm::ivec2 col = grid.columnAt(xi, zi);
 
 					// Determine which chunk contains this column
 					const int chX = (col.x >= 0) ? (col.x / CHUNK_SIZE) * CHUNK_SIZE
@@ -1693,34 +1995,49 @@ static void testBiomeRegionMultiStepAndZoomConsistency()
 					const int lx = col.x - chX;
 					const int lz = col.y - chZ;
 
-					ChunkData chunk = gen.generateChunk(chX, chZ);
+					const ChunkData &chunk = getCachedChunk(chX, chZ);
 					const BiomeType chunkBiome = chunk.biomes[lz * CHUNK_SIZE + lx];
 					CHECK(region[zi * kSize + xi] == chunkBiome,
 						  "region pixel for integer step must match chunk data");
 				}
 			}
+
+			totalUniqueChunks = std::max(totalUniqueChunks,
+										 static_cast<int>(chunkCache.size()));
 		}
 	}
 
-	// Performance sanity benchmark on realistic 256x256 UI map
+	// Performance/informational benchmark on a realistic 256x256 UI map.
+	// Not a CI wall-clock gate: printed for calibration and manual regression
+	// tracking across zoom levels (docs/terrain-generation.md).
 	{
 		TerrainGenerator gen(1337);
 		std::vector<BiomeType> fullMap;
 		constexpr int kMapDim = 256;
-		for (float zoom : {0.1f, 0.5f, 1.0f, 2.0f, 8.0f})
+		for (float zoom : {0.1f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f})
 		{
 			const float step = 1.0f / zoom;
+			const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, step, kMapDim, kMapDim);
+			TerrainGenerator::BiomeRegionStats stats;
 			const auto tStart = Clock::now();
-			gen.getBiomeRegion(0.0f, 0.0f, step, kMapDim, kMapDim, fullMap);
+			const bool ok = gen.getBiomeRegion(grid, fullMap, {}, &stats);
 			const double ms = std::chrono::duration<double, std::milli>(Clock::now() - tStart).count();
-			CHECK(fullMap.size() == kMapDim * kMapDim, "256x256 map output size valid");
+			CHECK(ok && fullMap.size() == static_cast<size_t>(kMapDim) * kMapDim,
+				  "256x256 map output size valid");
 			std::cout << "  [UI Map Perf] zoom=" << zoom << " (step=" << step << "): "
-					  << ms << " ms (" << (kMapDim * kMapDim / (ms * 1000.0)) << " Mpixels/sec)\n";
+					  << ms << " ms (" << (kMapDim * kMapDim / (ms * 1000.0)) << " Mpixels/sec)"
+					  << " denseTiles=" << stats.denseTiles
+					  << " fallbackPixels=" << stats.fallbackPixels << '\n';
+			// Deterministic (not wall-clock) regression gate: every UI map
+			// zoom must stay on the vectorized dense tile path.
+			CHECK(stats.fallbackPixels == 0,
+				  "UI map sampling must not fall back to point queries");
 		}
 	}
 
 	std::cout << "biome region multi-step consistency: " << totalPixelsVerified
-			  << " pixels verified across all zoom levels, steps, and fractional coordinates\n";
+			  << " pixels verified across all zoom levels, steps, and fractional coordinates ("
+			  << totalUniqueChunks << " unique chunks generated via cache)\n";
 }
 
 // ---------------------------------------------------------------------------
@@ -1745,6 +2062,10 @@ int main(int argc, char **argv)
 	testFlatRiverChannels();
 	testBiomeRegistry();
 	testBiomeQueryConsistency();
+	testWorldToVoxelColumnConvention();
+	testBiomeRegionGridMapping();
+	testBiomeRegionCancellationAndStats();
+	testBiomeMapGridMatchesPointQueries();
 	testBiomeRegionMultiStepAndZoomConsistency();
 	testPhase3BiomePresence();
 	testPhase3FeatureBlocks();

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -1946,6 +1946,64 @@ static void testBiomeRegionExtremeGridGuard()
 	std::cout << "biome region extreme grid: absurd step handled without overflow\n";
 }
 
+static void testBiomeRegionScratchRetention()
+{
+	TerrainGenerator gen(1337);
+
+	// Retention contract: after any attempt (or explicit trim), no scratch
+	// field may retain capacity above the tiled-path bound. Assert the
+	// bound, not an exact capacity — that is allocator-independent.
+	const auto checkBounded = [](const TerrainGenerator::BiomeRegionScratch &s) {
+		for (const std::vector<float> *field :
+			 {&s.temperature, &s.humidity, &s.weirdness, &s.river,
+			  &s.continental, &s.erosion, &s.peaksValleys, &s.ridge,
+			  &s.height, &s.erosionTemp})
+			CHECK(field->capacity() <= TerrainGenerator::kMaxTileDensePoints,
+				  "retained scratch capacity must stay within the tiled bound");
+	};
+
+	// Helper contract directly: oversized fields are released, while
+	// tiled-sized contents survive for reuse.
+	{
+		TerrainGenerator::BiomeRegionScratch s;
+		s.temperature.resize(TerrainGenerator::kMaxDenseDomainPoints); // oversized
+		s.height.resize(TerrainGenerator::kMaxTileDensePoints + 1);	  // oversized by one
+		s.erosion.resize(TerrainGenerator::kMaxTileDensePoints);	  // tiled-sized
+		s.trimOversizedCapacity();
+		checkBounded(s);
+		CHECK(s.erosion.size() == TerrainGenerator::kMaxTileDensePoints,
+			  "tiled-sized contents must be preserved by the trim");
+	}
+
+	// Dense build cancelled at the final checkpoint: the call failed, yet
+	// the oversized dense capacity must still have been released.
+	{
+		TerrainGenerator::BiomeRegionScratch scratch;
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 256, 256);
+		int polls = 0;
+		std::vector<BiomeType> biomes;
+		const bool completed = gen.getBiomeRegion(grid, biomes, &scratch,
+												  [&polls] { return ++polls >= 2; });
+		CHECK(!completed, "late-cancelled dense build must report interruption");
+		CHECK(biomes.empty(), "late-cancelled dense build must publish nothing");
+		CHECK(polls == 2, "late cancellation must poll before and after the dense pass");
+		checkBounded(scratch);
+	}
+
+	// Successful dense build: same retention invariant on the success path.
+	{
+		TerrainGenerator::BiomeRegionScratch scratch;
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 256, 256);
+		std::vector<BiomeType> biomes;
+		CHECK(gen.getBiomeRegion(grid, biomes, &scratch), "dense build must complete");
+		CHECK(biomes.size() == static_cast<size_t>(256) * 256, "dense output size valid");
+		checkBounded(scratch);
+	}
+
+	std::cout << "biome region scratch retention: oversized capacity trimmed after "
+			  << "success and cancellation, tiled-sized capacity preserved\n";
+}
+
 static void testBiomeMapGridMatchesPointQueries()
 {
 	// Terrain <-> UI cross test: the biome rendered at the player's map pixel
@@ -2241,6 +2299,7 @@ int main(int argc, char **argv)
 	testBiomeRegionCancellationAndStats();
 	testBiomeRegionDeterminism();
 	testBiomeRegionDenseTiledEquivalence();
+	testBiomeRegionScratchRetention();
 	testBiomeRegionExtremeGridGuard();
 	testBiomeMapGridMatchesPointQueries();
 	testBiomeRegionMultiStepAndZoomConsistency();

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -1580,6 +1580,149 @@ static void testBiomeQueryConsistency()
 			  << " columns verified identical across generateChunk, getBiomeAt, and getBiomeRegion\n";
 }
 
+static void testBiomeRegionMultiStepAndZoomConsistency()
+{
+	using Clock = std::chrono::steady_clock;
+	constexpr int kTestSeeds[] = {1337, 42};
+	constexpr float kZoomLevels[] = {0.1f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f};
+
+	struct TestCase
+	{
+		float centerX;
+		float centerZ;
+		int width;
+		int height;
+		const char *description;
+	};
+
+	const TestCase kCases[] = {
+		{0.0f, 0.0f, 32, 32, "origin centered"},
+		{123.47f, -87.23f, 32, 32, "fractional coordinates"},
+		{-0.5f, -1.25f, 32, 32, "near zero negative transition"},
+		{-16.0f, -15.75f, 32, 32, "chunk boundary negative transition"},
+		{500.0f, -500.0f, 48, 48, "large coordinate non-power-of-two"}
+	};
+
+	int totalPixelsVerified = 0;
+
+	for (int seed : kTestSeeds)
+	{
+		TerrainGenerator gen(seed);
+
+		for (float zoom : kZoomLevels)
+		{
+			const float step = 1.0f / zoom;
+
+			for (const auto &tc : kCases)
+			{
+				std::vector<BiomeType> region;
+				gen.getBiomeRegion(tc.centerX, tc.centerZ, step, tc.width, tc.height, region);
+
+				CHECK(region.size() == static_cast<size_t>(tc.width * tc.height),
+					  "region size must match requested dimensions");
+
+				for (int zi = 0; zi < tc.height; ++zi)
+				{
+					for (int xi = 0; xi < tc.width; ++xi)
+					{
+						const glm::ivec2 col = TerrainGenerator::computeBiomeRegionDiscreteColumn(
+							tc.centerX, tc.centerZ, step, tc.width, tc.height, xi, zi);
+						const BiomeType expectedBiome = gen.getBiomeAt(col.x, col.y);
+						const BiomeType actualBiome = region[zi * tc.width + xi];
+
+						CHECK(actualBiome == expectedBiome,
+							  "region pixel must match getBiomeAt (seed=" << seed
+							  << " zoom=" << zoom << " step=" << step
+							  << " case=" << tc.description
+							  << " pixel=(" << xi << "," << zi << ")"
+							  << " col=(" << col.x << "," << col.y << ")"
+							  << " expected=" << biomeTypeString[expectedBiome]
+							  << " got=" << biomeTypeString[actualBiome] << ")");
+
+						++totalPixelsVerified;
+					}
+				}
+
+				// If step < 1.0, verify sub-block discretization:
+				// adjacent pixels mapping to the same discrete column must have identical biomes
+				if (step < 1.0f)
+				{
+					for (int zi = 0; zi < tc.height; ++zi)
+					{
+						for (int xi = 0; xi < tc.width - 1; ++xi)
+						{
+							const glm::ivec2 colA = TerrainGenerator::computeBiomeRegionDiscreteColumn(
+								tc.centerX, tc.centerZ, step, tc.width, tc.height, xi, zi);
+							const glm::ivec2 colB = TerrainGenerator::computeBiomeRegionDiscreteColumn(
+								tc.centerX, tc.centerZ, step, tc.width, tc.height, xi + 1, zi);
+							if (colA == colB)
+							{
+								CHECK(region[zi * tc.width + xi] == region[zi * tc.width + (xi + 1)],
+									  "adjacent pixels on the same column must match");
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Direct chunk comparison for integer steps (step = 1.0, 2.0, 4.0)
+		for (float step : {1.0f, 2.0f, 4.0f})
+		{
+			constexpr int kSize = 16;
+			const int originChunkX = -16;
+			const int originChunkZ = -16;
+			const float cx = static_cast<float>(originChunkX) + kSize * step * 0.5f;
+			const float cz = static_cast<float>(originChunkZ) + kSize * step * 0.5f;
+
+			std::vector<BiomeType> region;
+			gen.getBiomeRegion(cx, cz, step, kSize, kSize, region);
+
+			for (int zi = 0; zi < kSize; ++zi)
+			{
+				for (int xi = 0; xi < kSize; ++xi)
+				{
+					const glm::ivec2 col = TerrainGenerator::computeBiomeRegionDiscreteColumn(
+						cx, cz, step, kSize, kSize, xi, zi);
+
+					// Determine which chunk contains this column
+					const int chX = (col.x >= 0) ? (col.x / CHUNK_SIZE) * CHUNK_SIZE
+												 : ((col.x - (CHUNK_SIZE - 1)) / CHUNK_SIZE) * CHUNK_SIZE;
+					const int chZ = (col.y >= 0) ? (col.y / CHUNK_SIZE) * CHUNK_SIZE
+												 : ((col.y - (CHUNK_SIZE - 1)) / CHUNK_SIZE) * CHUNK_SIZE;
+					const int lx = col.x - chX;
+					const int lz = col.y - chZ;
+
+					ChunkData chunk = gen.generateChunk(chX, chZ);
+					const BiomeType chunkBiome = chunk.biomes[lz * CHUNK_SIZE + lx];
+					CHECK(region[zi * kSize + xi] == chunkBiome,
+						  "region pixel for integer step must match chunk data");
+				}
+			}
+		}
+	}
+
+	// Performance sanity benchmark on realistic 256x256 UI map
+	{
+		TerrainGenerator gen(1337);
+		std::vector<BiomeType> fullMap;
+		constexpr int kMapDim = 256;
+		for (float zoom : {0.1f, 0.5f, 1.0f, 2.0f, 8.0f})
+		{
+			const float step = 1.0f / zoom;
+			const auto tStart = Clock::now();
+			gen.getBiomeRegion(0.0f, 0.0f, step, kMapDim, kMapDim, fullMap);
+			const double ms = std::chrono::duration<double, std::milli>(Clock::now() - tStart).count();
+			CHECK(fullMap.size() == kMapDim * kMapDim, "256x256 map output size valid");
+			std::cout << "  [UI Map Perf] zoom=" << zoom << " (step=" << step << "): "
+					  << ms << " ms (" << (kMapDim * kMapDim / (ms * 1000.0)) << " Mpixels/sec)\n";
+		}
+	}
+
+	std::cout << "biome region multi-step consistency: " << totalPixelsVerified
+			  << " pixels verified across all zoom levels, steps, and fractional coordinates\n";
+}
+
 // ---------------------------------------------------------------------------
 
 int main(int argc, char **argv)
@@ -1602,6 +1745,7 @@ int main(int argc, char **argv)
 	testFlatRiverChannels();
 	testBiomeRegistry();
 	testBiomeQueryConsistency();
+	testBiomeRegionMultiStepAndZoomConsistency();
 	testPhase3BiomePresence();
 	testPhase3FeatureBlocks();
 	testOasisPonds();


### PR DESCRIPTION
## Summary

Resolves the biome inconsistencies from #77 by unifying every consumer — HUD, point queries, region queries, the World/biome map, and the player marker — on one canonical, erosion-aware pipeline and one spatial mapping.

**World generation is unchanged**: seeds, noise graphs, thresholds, and erosion constants are untouched; `generateChunk()` output is bit-for-bit identical (covered by the determinism/border suites).

## Canonical coordinate conventions
- **world → voxel column = `floor()`** everywhere: HUD, `getBiomeAt()`, `getBiomeRegion()`, the biome map, and the player marker (`worldToVoxelColumn()` in `src/Chunk/BiomeRegionGrid.hpp`, hardened against non-finite / int-unrepresentable inputs).
- Map **rendering only**: the player marker is drawn at the nearest display pixel (`round()` via `pixelForWorld`); it is never used to resolve a canonical biome column.

## `BiomeRegionGrid` (new, `src/Chunk/BiomeRegionGrid.hpp`)
Lightweight, dependency-free description of the sampling grid — the single source of truth for pixel ↔ world ↔ column mapping, shared by `TerrainGenerator`, GameUI, and the tests. Explicit parity contract, documented as implemented: even sizes sample `center` exactly at pixel `size/2` (width=4 → −2,−1,0,1); odd sizes straddle it between the two central pixels (width=5 → −2.5…1.5).

## `getBiomeRegion(grid, out, scratch, cancel, stats)`
- Grid-driven sampling of canonical `floor()` columns; erosion always runs at `step = 1.0f` — `grid.step` only selects **which** columns are sampled, never the erosion resolution.
- **Deterministic sequential tiles** — `TerrainGenerator` spawns no threads and owns no CPU policy; the Engine already runs the whole map build as one `TaskPriority::Low` job. Tile order cannot influence the output (determinism test added).
- Adaptive tile dimension (`floor((132 − 2·halo − 1)/step) + 1`, cap 32) keeps **every** UI zoom — including 0.1 — on the vectorized dense path: `fallbackPixels == 0` is asserted in CI; the per-column point-query fallback is a safety net only.
- **Bounded, owned scratch**: `BiomeRegionScratch` replaces the region buffers in the shared `GenBuffers`. The biome-map job owns one persistent per-worker scratch; `getBiomeRegion()` releases oversized dense capacity on **every** exit — after both successful and cancelled/failed attempts — via an unconditional guard, so only the small tiled bound (~0.7 MB) is ever retained across attempts while tiled-sized capacity is reused. Retention is machine-tested after success **and** after late cancellation (`testBiomeRegionScratchRetention`). Bounds are class constants (`kMaxDenseDomainPoints = 516²`, `kMaxTileDensePoints = 132²`), machine-checked via `BiomeRegionStats { denseTiles, fallbackPixels, peakDensePoints, peakScratchBytes }`.
- **Cancellation** is polled before, between, and after tiles; interrupted builds (and post-sampling cancellations) publish nothing, ever.
- **Overflow-safe**: int64 span math, canonical columns clamped to ±1e9 before any `+ NOISE_OFFSET` arithmetic, guards on `step`/center/dimensions (extreme-step grids complete deterministically; tested).

## UI integration
`BiomeMapResult` carries the exact `BiomeRegionGrid` it was sampled with (the old noise-space `gridX/gridZ` lattice is deleted); the player dot is placed via `grid.pixelForWorld()` and draws **nothing** when its center is off-map (no half-clipped rings); superseded/cancelled builds are rejected exactly as before (#84 semantics preserved).

## Tests (new in this PR)
- Hardcoded floor-convention cases (123.60→123, −0.20→−1, −16.01→−17, and the ±0.5/±1/±16 boundary sets), X and Z independently, not derived from the helper under test.
- Grid mapping: `worldAt` expected values for steps 0.125–10 with fractional/negative centers; a parity-contract test; `pixelForWorld` round-trips including image edges and out-of-grid positions.
- Terrain↔UI cross test: 282 player pixel/column pairs agree between the map, the grid, and `getBiomeAt`.
- Determinism: repeated calls and independent same-seed generators produce identical buffers (dense and tiled paths).
- Dense-vs-tiled equivalence: a 260×260 step-2 region assembled from 4×4 dense sub-queries matches the tiled output **bit-for-bit** (protects tile-boundary halos).
- Cancellation: exact checkpoint arithmetic (cancel on the 4th poll ⇒ exactly 3 tiles ran, empty output) and post-sampling cancellation proves fully-sampled results are still discarded.
- Chunk comparisons regenerate each unique chunk once via a cache (~1500 → 16 generations).

## Performance (Release, 256×256 UI map, sequential)

| zoom | 0.1 | 0.25 | 0.5 | 1 | 2 | 4 | 8 |
|------|-----|------|-----|---|---|---|---|
| ms   | 618 | 110  | 30  | 8.3 | 3.0 | 1.8 | 1.5 |

`fallbackPixels = 0` at every zoom; the benchmark prints `denseTiles`, `fallbackPixels`, `peakScratchBytes`, and average ms/tile, and is informational only (no wall-clock CI gate). Zoom ≤ 0.25 is inherent canonical-resolution work (a 0.1 map spans ~2560×2560 blocks); a scheduler-aware parallel follow-up — tiles distributed by the Engine pool per the `buildBiomeRegionPlan`-style API — can be tracked as a separate performance issue if needed.

## Deferred follow-ups
- #88 — scheduler-aware parallel biome-region sampling (Engine ThreadPool, Low priority, no nested blocking)
- #89 — dense scratch reuse without per-refresh allocation churn

## Validation (final head, `225b40f`)
- Build: clean (all targets, MSVC/Release)
- CTest: 8/8 pass (TerrainGeneration, BiomeMapGeneration, VisualLookDefaults, StreamOptHelpers, RenderHelpers, VulkanResourceSmoke, ProfilerWorkerConsistency, Network)
- ASan: clean on `test_terrain` + `test_biome_map`
- TSan: not available under MSVC/Windows; the internal threading this review flagged has been removed entirely (sequential tiles), and the CI Linux side can add a TSan pass
- HUD now resolves the player biome through `worldToVoxelColumn()` (single conversion source); repo sweep found no other manual world→column conversions in UI paths
- Manual in-game checklist (marker follow across x=0 → −0.1, zoom sweeps, supersession bursts, streaming impact) remains to be eyeballed on a GPU session

Closes #77

