### PR TITLE
perf(ui): retain dense biome-region scratch via owner-set retention cap

### DIFF
--- a/docs/terrain-generation.md
+++ b/docs/terrain-generation.md
@@ -201,11 +201,14 @@ Biome sampling is unified across the engine via a canonical erosion-aware pipeli
     vectorized dense path. A direct per-column `evaluateBiomeColumn` fallback remains as
     a safety net only. An optional cancellation callback is polled before every tile.
   - Scratch is a dedicated `BiomeRegionScratch` owned by the caller (pass `nullptr` to
-    use an internal thread-local fallback); `getBiomeRegion()` trims oversized dense
-    capacity on **every** exit — successful or cancelled/failed attempts alike — so only
-    the small tiled bound is ever retained across attempts, while tiled-sized capacity
-    survives for cheap reuse. The biome-map job owns one persistent scratch under this
-    policy. `BiomeRegionStats` reports `denseTiles`, `fallbackPixels`,
+    use an internal thread-local fallback whose retention is bounded to the tiled path).
+    `getBiomeRegion()` trims every field above the scratch's `retainedPointsCap` on
+    **every** exit — successful or cancelled/failed attempts alike. The default cap
+    keeps only tiled-path capacity; a producer with a single dedicated scratch may
+    raise the cap up to `kMaxDenseDomainPoints` so dense builds reuse capacity across
+    refreshes without allocation churn — retention then stays bounded (~10.6 MiB for
+    that one scratch, never per pool worker). The biome-map job owns exactly one such
+    process-wide scratch. `BiomeRegionStats` reports `denseTiles`, `fallbackPixels`,
     `peakDensePoints`, and `peakScratchBytes` to keep the bound verifiable.
 - **UI consistency**: HUD biome and World / Biome map use the same canonical generated-column biome definition as loaded terrain at every zoom level. `BiomeMapResult` carries the exact `BiomeRegionGrid` it was sampled with, and the player marker is placed via `grid.pixelForWorld()`; markers outside the grid are simply not drawn.
 

--- a/docs/terrain-generation.md
+++ b/docs/terrain-generation.md
@@ -201,14 +201,16 @@ Biome sampling is unified across the engine via a canonical erosion-aware pipeli
     vectorized dense path. A direct per-column `evaluateBiomeColumn` fallback remains as
     a safety net only. An optional cancellation callback is polled before every tile.
   - Scratch is a dedicated `BiomeRegionScratch` owned by the caller (pass `nullptr` to
-    use an internal thread-local fallback whose retention is bounded to the tiled path).
-    `getBiomeRegion()` trims every field above the scratch's `retainedPointsCap` on
-    **every** exit — successful or cancelled/failed attempts alike. The default cap
-    keeps only tiled-path capacity; a producer with a single dedicated scratch may
-    raise the cap up to `kMaxDenseDomainPoints` so dense builds reuse capacity across
-    refreshes without allocation churn — retention then stays bounded (~10.6 MiB for
-    that one scratch, never per pool worker). The biome-map job owns exactly one such
-    process-wide scratch. `BiomeRegionStats` reports `denseTiles`, `fallbackPixels`,
-    `peakDensePoints`, and `peakScratchBytes` to keep the bound verifiable.
+    use an internal thread-local fallback). The retention contract after **every**
+    `getBiomeRegion()` exit — success, cancellation, invalid request, or exception — is
+    `capacity() <= min(retainedPointsCap, kMaxDenseDomainPoints)` for every field:
+    - default owner: tiled retention (`kMaxTileDensePoints` per field);
+    - dedicated biome-map owner: dense retention (one process-wide scratch with
+      `retainedPointsCap = kMaxDenseDomainPoints`, so dense builds reuse capacity
+      across refreshes without allocation churn — never one per pool worker);
+    - absolute maximum: `kMaxDenseDomainPoints` per field, a logical retained payload
+      of ~10 MiB per scratch (516² points × 10 float fields × 4 bytes).
+    `BiomeRegionStats` reports `denseTiles`, `fallbackPixels`, `peakDensePoints`, and
+    `peakScratchBytes` to keep the bound verifiable.
 - **UI consistency**: HUD biome and World / Biome map use the same canonical generated-column biome definition as loaded terrain at every zoom level. `BiomeMapResult` carries the exact `BiomeRegionGrid` it was sampled with, and the player marker is placed via `grid.pixelForWorld()`; markers outside the grid are simply not drawn.
 

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -595,13 +595,14 @@ static thread_local TerrainGenerator::BiomeRegionScratch s_biomeRegionScratch;
 
 void TerrainGenerator::BiomeRegionScratch::trimOversizedCapacity()
 {
-  // Releases capacity above the tiled-path bound. getBiomeRegion() calls
-  // this on every exit through an unconditional guard — after successful
-  // AND cancelled/failed attempts — so oversized dense capacity is never
-  // retained across attempts while tiled-sized capacity survives for
-  // cheap reuse. Call it manually only when mutating a scratch outside
-  // getBiomeRegion().
-  const size_t keep = kMaxTileDensePoints;
+  // Releases per-field capacity above the scratch's retention bound (the
+  // owner-set retainedPointsCap, clamped to the dense-path absolute). The
+  // default bound keeps only tiled-path capacity; owners of a single
+  // dedicated scratch may retain dense capacity for churn-free reuse.
+  // getBiomeRegion() calls this on every exit through an unconditional
+  // guard - after successful AND cancelled/failed attempts. Call it
+  // manually only when mutating a scratch outside getBiomeRegion().
+  const size_t keep = std::min(retainedPointsCap, kMaxDenseDomainPoints);
   for (std::vector<float> *field : {&temperature, &humidity, &weirdness, &river,
                                     &continental, &erosion, &peaksValleys,
                                     &ridge, &height, &erosionTemp})

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -1684,24 +1684,25 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
                                       BiomeRegionStats *outStats) const
 {
   outBiomes.clear();
-  if (!grid.valid())
-    return false;
 
   // Scratch owned by the caller when provided; otherwise a dedicated
   // thread-local so region capacity never lands in the shared chunk
-  // generation buffers.
+  // generation buffers. Resolved before any early return so the retention
+  // policy below holds on absolutely every exit.
   BiomeRegionScratch &bufs = scratch ? *scratch : s_biomeRegionScratch;
 
-  // Unconditional cleanup on EVERY exit — success, cancellation, early
-  // failure, or an exception propagating out — so no path can retain the
-  // ~10 MiB dense peak (this makes cancelled biome-map builds as
-  // memory-safe as successful ones). Tiled-sized capacity survives for
-  // cheap reuse.
+  // Enforce the scratch owner's retention policy on every exit - success,
+  // cancellation, invalid request, or an exception propagating out.
+  // Generic scratches retain at most the tiled bound; dedicated owners may
+  // retain dense capacity up to kMaxDenseDomainPoints.
   struct ScratchTrimGuard
   {
     BiomeRegionScratch &target;
     ~ScratchTrimGuard() { target.trimOversizedCapacity(); }
   } trimGuard{bufs};
+
+  if (!grid.valid())
+    return false;
 
   BiomeRegionStats localStats;
   BiomeRegionStats &stats = outStats ? *outStats : localStats;

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -126,24 +126,27 @@ public:
     std::vector<float> height;
     std::vector<float> erosionTemp;
 
-    // Per-field capacity retained across attempts (points). After every
-    // getBiomeRegion() exit, capacity() <= retainedPointsCap for all
-    // fields. The default keeps only tiled-path capacity so a generic
-    // scratch stays small no matter who owns it; a producer with a single
-    // dedicated scratch (e.g. the biome-map job) may raise it up to
+    // Per-field capacity retained across attempts (points). The contract
+    // after getBiomeRegion() returns - on success, cancellation, invalid
+    // request, or exception - is exactly:
+    //
+    //   capacity() <= min(retainedPointsCap, kMaxDenseDomainPoints)
+    //
+    // for every field. The default keeps only tiled-path capacity so a
+    // generic scratch stays small no matter who owns it; a producer with a
+    // single dedicated scratch (e.g. the biome-map job) may raise it up to
     // kMaxDenseDomainPoints to reuse dense capacity across refreshes
-    // without allocation churn - retention then stays bounded by
-    // kMaxDenseDomainPoints * kBiomeRegionScratchFields * sizeof(float)
-    // (~10.6 MiB) for that one scratch. Values above kMaxDenseDomainPoints
-    // are clamped by trimOversizedCapacity().
+    // without allocation churn - retention then stays bounded to the
+    // absolute maximum of kMaxDenseDomainPoints points per field, i.e.
+    // a logical payload of ~10 MiB for that one scratch
+    // (516^2 points x 10 fields x 4 bytes).
     size_t retainedPointsCap{kMaxTileDensePoints};
 
     // Releases per-field capacity above retainedPointsCap (clamped to
     // kMaxDenseDomainPoints). getBiomeRegion() runs this automatically on
-    // every exit - after successful AND cancelled/failed attempts - so
-    // capacity above the scratch's retention bound is never retained
-    // across attempts. Call it manually only when mutating a scratch
-    // outside getBiomeRegion().
+    // every exit - after successful AND cancelled/failed attempts - so the
+    // contract above always holds. Call it manually only when mutating a
+    // scratch outside getBiomeRegion().
     void trimOversizedCapacity();
   };
 

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -101,6 +101,14 @@ public:
   // synchronization is required of the callable.
   using BiomeCancelCheck = std::function<bool()>;
 
+  // Domain point-count bounds. No region buffer may exceed these without an
+  // explicit fallback path; kMaxDenseDomainPoints bounds the single-pass
+  // dense scratch (~10 MiB across all 10 float fields), kMaxTileDensePoints
+  // the per-tile scratch (~68 KB per field).
+  static constexpr size_t kMaxDenseDomainPoints = 516 * 516;
+  static constexpr size_t kMaxTileDensePoints = 132 * 132;
+  static constexpr size_t kBiomeRegionScratchFields = 10;
+
   // Scratch working set for one getBiomeRegion() call. Owned by the caller
   // so heavy capacity is not retained indefinitely inside TerrainGenerator's
   // shared thread-local chunk buffers. Reuse one scratch per producer job
@@ -118,22 +126,26 @@ public:
     std::vector<float> height;
     std::vector<float> erosionTemp;
 
-    // Releases capacity above the tiled-path bound. getBiomeRegion() runs
-    // this automatically on every exit — after successful AND
-    // cancelled/failed attempts — so oversized dense capacity is never
-    // retained across attempts while tiled-sized capacity survives for
-    // cheap reuse. Call it manually only when mutating a scratch outside
-    // getBiomeRegion().
+    // Per-field capacity retained across attempts (points). After every
+    // getBiomeRegion() exit, capacity() <= retainedPointsCap for all
+    // fields. The default keeps only tiled-path capacity so a generic
+    // scratch stays small no matter who owns it; a producer with a single
+    // dedicated scratch (e.g. the biome-map job) may raise it up to
+    // kMaxDenseDomainPoints to reuse dense capacity across refreshes
+    // without allocation churn - retention then stays bounded by
+    // kMaxDenseDomainPoints * kBiomeRegionScratchFields * sizeof(float)
+    // (~10.6 MiB) for that one scratch. Values above kMaxDenseDomainPoints
+    // are clamped by trimOversizedCapacity().
+    size_t retainedPointsCap{kMaxTileDensePoints};
+
+    // Releases per-field capacity above retainedPointsCap (clamped to
+    // kMaxDenseDomainPoints). getBiomeRegion() runs this automatically on
+    // every exit - after successful AND cancelled/failed attempts - so
+    // capacity above the scratch's retention bound is never retained
+    // across attempts. Call it manually only when mutating a scratch
+    // outside getBiomeRegion().
     void trimOversizedCapacity();
   };
-
-  // Domain point-count bounds. No region buffer may exceed these without an
-  // explicit fallback path; kMaxDenseDomainPoints bounds the single-pass
-  // scratch (~10 MiB across all 10 float fields), kMaxTileDensePoints the
-  // per-tile scratch (~68 KB per field).
-  static constexpr size_t kMaxDenseDomainPoints = 516 * 516;
-  static constexpr size_t kMaxTileDensePoints = 132 * 132;
-  static constexpr size_t kBiomeRegionScratchFields = 10;
 
   // Counters describing how a getBiomeRegion() call was executed.
   struct BiomeRegionStats

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -1323,6 +1323,16 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 		m_mapJob.requestId = requestId;
 		m_mapJob.cancel = cancelToken;
 
+		// One scratch for the whole biome-map subsystem: dense capacity is
+		// retained across refreshes (no per-refresh reallocation churn),
+		// bounded in total by kMaxDenseDomainPoints and owned by GameUI so
+		// no pool worker keeps a private copy.
+		if (!m_mapScratch)
+		{
+			m_mapScratch = std::make_shared<TerrainGenerator::BiomeRegionScratch>();
+			m_mapScratch->retainedPointsCap = TerrainGenerator::kMaxDenseDomainPoints;
+		}
+
 		BiomeMapRequest req{
 			.requestId = requestId,
 			.worldGenerationId = frame.worldGenerationId,
@@ -1330,7 +1340,8 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 			.center = m_mapCenter,
 			.size = m_mapSize,
 			.zoom = m_mapZoom,
-			.cancelToken = cancelToken
+			.cancelToken = cancelToken,
+			.scratch = m_mapScratch
 		};
 
 		if (frame.submitBiomeMap)

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -201,6 +201,12 @@ private:
 
 	BiomeMapJob m_mapJob{};
 	BiomeMapUpload m_pendingUpload{};
+	// Single process-wide region scratch for the biome-map job (never one
+	// per pool worker): its retention cap allows dense-capacity reuse so
+	// refreshes do not re-allocate the ~10 MiB dense peak, while the total
+	// retained memory stays bounded by kMaxDenseDomainPoints (~10.6 MiB).
+	// Shared ownership keeps it alive for the duration of an in-flight job.
+	std::shared_ptr<TerrainGenerator::BiomeRegionScratch> m_mapScratch;
 
 	VkContext *m_vk{nullptr};
 	ImmediateCommands *m_imm{nullptr};

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -203,9 +203,13 @@ private:
 	BiomeMapUpload m_pendingUpload{};
 	// Single process-wide region scratch for the biome-map job (never one
 	// per pool worker): its retention cap allows dense-capacity reuse so
-	// refreshes do not re-allocate the ~10 MiB dense peak, while the total
-	// retained memory stays bounded by kMaxDenseDomainPoints (~10.6 MiB).
-	// Shared ownership keeps it alive for the duration of an in-flight job.
+	// refreshes do not re-allocate the dense peak, while retention stays
+	// bounded by kMaxDenseDomainPoints per field (~10 MiB logical payload
+	// in total). The scratch holds only scratch floats - no seed- or
+	// world-dependent state - so it survives world/seed changes and is
+	// never reset on map invalidation; shared ownership releases it at
+	// GameUI destruction. Shared ownership keeps it alive for the duration
+	// of an in-flight job.
 	std::shared_ptr<TerrainGenerator::BiomeRegionScratch> m_mapScratch;
 
 	VkContext *m_vk{nullptr};

--- a/src/Engine/GameUIBiomeMap.cpp
+++ b/src/Engine/GameUIBiomeMap.cpp
@@ -66,14 +66,17 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 
 	TerrainGenerator &gen = TerrainGenerator::getThreadLocal(req.seed);
 	std::vector<BiomeType> biomes;
-	// Scratch owned by this job (not by TerrainGenerator internals):
-	// tiled-sized capacity is reused across refreshes, while oversized
-	// dense capacity is released after every attempt — successful or
-	// cancelled — by getBiomeRegion's exit guard.
-	static thread_local TerrainGenerator::BiomeRegionScratch scratch;
+	// Scratch provided by the request's owner when available: one shared
+	// scratch whose retainedPointsCap policy controls retention (the biome
+	// map retains dense capacity for churn-free refreshes). When absent,
+	// getBiomeRegion falls back to its internal thread-local scratch, which
+	// keeps only tiled-sized capacity. Either way, getBiomeRegion's exit
+	// guard enforces the bound after every attempt - successful or cancelled.
+	TerrainGenerator::BiomeRegionScratch *scratch =
+		req.scratch ? req.scratch.get() : nullptr;
 	// Cancellation is checked before, during (between tiles), and after the
 	// region sampling; an interrupted build publishes nothing.
-	if (!gen.getBiomeRegion(grid, biomes, &scratch, [&] { return cancelled(); }))
+	if (!gen.getBiomeRegion(grid, biomes, scratch, [&] { return cancelled(); }))
 		return {};
 
 	// Checkpoint 3: before RGBA allocation

--- a/src/Engine/GameUIBiomeMap.hpp
+++ b/src/Engine/GameUIBiomeMap.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Chunk/BiomeRegionGrid.hpp>
+#include <Chunk/TerrainGenerator.hpp>
 #include <utils.hpp>
 
 #include <atomic>
@@ -58,6 +59,12 @@ struct BiomeMapRequest
 	std::shared_ptr<std::atomic<bool>> cancelToken;
 	/// Optional injectable test seam hook invoked before sampling.
 	std::function<void()> onCheckpoint;
+	/// Owner-controlled region scratch for the sampling job. When set, the
+	/// job reuses it across refreshes (retention bounded by the scratch's
+	/// retainedPointsCap); when null, getBiomeRegion falls back to an
+	/// internal thread-local scratch. Shared ownership keeps the scratch
+	/// alive for the duration of the job even if the owner goes away.
+	std::shared_ptr<TerrainGenerator::BiomeRegionScratch> scratch;
 };
 
 struct BiomeMapResult

--- a/src/Engine/GameUIBiomeMap.hpp
+++ b/src/Engine/GameUIBiomeMap.hpp
@@ -64,6 +64,8 @@ struct BiomeMapRequest
 	/// retainedPointsCap); when null, getBiomeRegion falls back to an
 	/// internal thread-local scratch. Shared ownership keeps the scratch
 	/// alive for the duration of the job even if the owner goes away.
+	/// Access relies on the single-flight biome-map job contract (at most
+	/// one in-flight request at a time), so no synchronization is needed.
 	std::shared_ptr<TerrainGenerator::BiomeRegionScratch> scratch;
 };
 

--- a/tests/test_biome_map.cpp
+++ b/tests/test_biome_map.cpp
@@ -667,6 +667,31 @@ static void test_request_scratch_reuse()
 	CHECK(!res3.valid, "pre-cancelled build must stay invalid");
 	CHECK(scratch->temperature.capacity() == retained,
 		  "cancelled build must not grow the retained scratch");
+
+	// Zoom sweep dense -> tiled -> dense: switching zooms must not
+	// reintroduce churn — the retained dense capacity survives the tiled
+	// build untouched and is reused when returning to a dense zoom.
+	req.cancelToken = nullptr;
+
+	req.requestId = 24;
+	req.zoom = 0.5f; // dense
+	BiomeMapResult res4 = generateBiomeMap(req);
+	CHECK(res4.valid && isBiomeMapResultAcceptable(res4, 3, 42, 24), "dense build valid");
+	const size_t denseCapacity = scratch->temperature.capacity();
+
+	req.requestId = 25;
+	req.zoom = 0.1f; // tiled path
+	BiomeMapResult res5 = generateBiomeMap(req);
+	CHECK(res5.valid && isBiomeMapResultAcceptable(res5, 3, 42, 25), "tiled build valid");
+	CHECK(scratch->temperature.capacity() == denseCapacity,
+		  "tiled build must not disturb the retained dense capacity");
+
+	req.requestId = 26;
+	req.zoom = 0.5f; // dense again
+	BiomeMapResult res6 = generateBiomeMap(req);
+	CHECK(res6.valid && isBiomeMapResultAcceptable(res6, 3, 42, 26), "dense rebuild valid");
+	CHECK(scratch->temperature.capacity() == denseCapacity,
+		  "returning to dense zoom must reuse the retained capacity without churn");
 }
 
 int main()

--- a/tests/test_biome_map.cpp
+++ b/tests/test_biome_map.cpp
@@ -622,6 +622,53 @@ static void test_semantic_supersession_still_cancels_slow_job()
 		  "Cancelled / superseded slow job must be rejected against new active request ID");
 }
 
+static void test_request_scratch_reuse()
+{
+	// The request-owned scratch is reused across refreshes: dense capacity
+	// is retained (bounded by the absolute dense bound, never per worker)
+	// and the second dense build does not grow it (no allocation churn),
+	// while results stay valid and acceptable.
+	auto scratch = std::make_shared<TerrainGenerator::BiomeRegionScratch>();
+	scratch->retainedPointsCap = TerrainGenerator::kMaxDenseDomainPoints;
+
+	BiomeMapRequest req{
+		.requestId = 21,
+		.worldGenerationId = 3,
+		.seed = 42,
+		.center = {0.f, 0.f},
+		.size = 256,
+		.zoom = 0.5f, // dense single-pass path (peak scratch)
+		.cancelToken = nullptr,
+		.onCheckpoint = nullptr,
+		.scratch = scratch
+	};
+
+	BiomeMapResult res1 = generateBiomeMap(req);
+	CHECK(res1.valid, "dense map build with request scratch must be valid");
+	CHECK(isBiomeMapResultAcceptable(res1, 3, 42, 21), "first result acceptable");
+	const size_t retained = scratch->temperature.capacity();
+	CHECK(retained > TerrainGenerator::kMaxTileDensePoints &&
+			  retained <= TerrainGenerator::kMaxDenseDomainPoints,
+		  "dense scratch capacity must be retained within the absolute bound");
+
+	req.requestId = 22;
+	BiomeMapResult res2 = generateBiomeMap(req);
+	CHECK(res2.valid, "second dense map build must be valid");
+	CHECK(isBiomeMapResultAcceptable(res2, 3, 42, 22), "second result acceptable");
+	CHECK(scratch->temperature.capacity() == retained,
+		  "second dense build must reuse the retained scratch without churn");
+
+	// A cancelled build through the same scratch must not disturb retention
+	// policy or leak the capacity above the cap.
+	auto token = std::make_shared<std::atomic<bool>>(true);
+	req.requestId = 23;
+	req.cancelToken = token;
+	BiomeMapResult res3 = generateBiomeMap(req);
+	CHECK(!res3.valid, "pre-cancelled build must stay invalid");
+	CHECK(scratch->temperature.capacity() == retained,
+		  "cancelled build must not grow the retained scratch");
+}
+
 int main()
 {
 	std::cout << "[test_biome_map] Running tests...\n";
@@ -632,6 +679,7 @@ int main()
 	test_cancellation_mid_flight();
 	test_rapid_request_cancellation_sequence();
 	test_player_dot_painting();
+	test_request_scratch_reuse();
 	test_biome_map_upload_validation();
 	test_deferred_upload_superseded_rejection();
 	test_player_movement_supersession();

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -1954,13 +1954,14 @@ static void testBiomeRegionScratchRetention()
 	// Retention contract: after any attempt (or explicit trim), no scratch
 	// field may retain capacity above the tiled-path bound. Assert the
 	// bound, not an exact capacity — that is allocator-independent.
-	const auto checkBounded = [](const TerrainGenerator::BiomeRegionScratch &s) {
+	const auto checkBounded = [](const TerrainGenerator::BiomeRegionScratch &s,
+								 size_t cap = TerrainGenerator::kMaxTileDensePoints) {
 		for (const std::vector<float> *field :
 			 {&s.temperature, &s.humidity, &s.weirdness, &s.river,
 			  &s.continental, &s.erosion, &s.peaksValleys, &s.ridge,
 			  &s.height, &s.erosionTemp})
-			CHECK(field->capacity() <= TerrainGenerator::kMaxTileDensePoints,
-				  "retained scratch capacity must stay within the tiled bound");
+			CHECK(field->capacity() <= cap,
+				  "retained scratch capacity must stay within the retention policy");
 	};
 
 	// Helper contract directly: oversized fields are released, while
@@ -2034,6 +2035,69 @@ static void testBiomeRegionScratchRetention()
 		CHECK(gen.getBiomeRegion(grid, third, &scratch), "dense build 3 must complete");
 		CHECK(scratch.temperature.capacity() <= TerrainGenerator::kMaxDenseDomainPoints,
 			  "retention cap must clamp to the absolute dense bound");
+
+		// Late cancellation under the dense cap: retention stays exactly
+		// within the policy — neither released below it nor grown past the
+		// absolute bound.
+		int polls = 0;
+		const bool cancelled = !gen.getBiomeRegion(grid, third, &scratch,
+												   [&polls] { return ++polls >= 2; });
+		CHECK(cancelled, "late-cancelled dense build must report interruption");
+		CHECK(third.empty(), "late-cancelled dense build must publish nothing");
+		checkBounded(scratch, TerrainGenerator::kMaxDenseDomainPoints);
+	}
+
+	// Policy enforced even when the cap is LOWERED and the next request is
+	// invalid: dense retained -> policy lowered -> invalid request -> the
+	// exit guard must still apply the new (lower) policy to all 10 fields.
+	{
+		TerrainGenerator::BiomeRegionScratch scratch;
+		scratch.retainedPointsCap = TerrainGenerator::kMaxDenseDomainPoints;
+		const BiomeRegionGrid denseGrid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 256, 256);
+		std::vector<BiomeType> biomes;
+		CHECK(gen.getBiomeRegion(denseGrid, biomes, &scratch),
+			  "dense build must complete");
+		CHECK(scratch.temperature.capacity() > TerrainGenerator::kMaxTileDensePoints,
+			  "dense capacity must be retained under the dense cap");
+
+		scratch.retainedPointsCap = TerrainGenerator::kMaxTileDensePoints;
+		const BiomeRegionGrid invalidGrid = makeBiomeRegionGrid(0.0f, 0.0f, 0.0f, 256, 256);
+		CHECK(!gen.getBiomeRegion(invalidGrid, biomes, &scratch),
+			  "invalid grid must be rejected");
+		checkBounded(scratch);
+	}
+
+	// Zero retention cap: after a call, no capacity is retained at all.
+	// The trim swaps with empty vectors, so the applied policy bound (0)
+	// holds exactly; asserted through the same bound-based helper.
+	{
+		TerrainGenerator::BiomeRegionScratch scratch;
+		scratch.retainedPointsCap = 0;
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 64, 64);
+		std::vector<BiomeType> biomes;
+		CHECK(gen.getBiomeRegion(grid, biomes, &scratch),
+			  "build with zero retention cap must complete");
+		checkBounded(scratch, 0);
+	}
+
+	// Growing dense sizes: capacity grows once for the larger domain, then
+	// stays reusable for smaller ones (no shrink, no churn).
+	{
+		TerrainGenerator::BiomeRegionScratch scratch;
+		scratch.retainedPointsCap = TerrainGenerator::kMaxDenseDomainPoints;
+		const BiomeRegionGrid small = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 128, 128);
+		const BiomeRegionGrid large = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 256, 256);
+		std::vector<BiomeType> biomes;
+		CHECK(gen.getBiomeRegion(small, biomes, &scratch), "small dense build must complete");
+		const size_t c1 = scratch.temperature.capacity();
+		CHECK(gen.getBiomeRegion(large, biomes, &scratch), "large dense build must complete");
+		const size_t c2 = scratch.temperature.capacity();
+		CHECK(gen.getBiomeRegion(small, biomes, &scratch), "small dense rebuild must complete");
+		const size_t c3 = scratch.temperature.capacity();
+		CHECK(c1 < c2, "capacity must grow once for the larger dense domain");
+		CHECK(c2 == c3, "capacity must stay reusable for smaller domains");
+		CHECK(c2 <= TerrainGenerator::kMaxDenseDomainPoints,
+			  "grown capacity must stay within the absolute dense bound");
 	}
 
 	std::cout << "biome region scratch retention: oversized capacity trimmed after "

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <future>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -1973,6 +1974,14 @@ static void testBiomeRegionScratchRetention()
 		checkBounded(s);
 		CHECK(s.erosion.size() == TerrainGenerator::kMaxTileDensePoints,
 			  "tiled-sized contents must be preserved by the trim");
+
+		// A retention cap above the absolute dense bound is clamped by the
+		// trim, so even a misconfigured owner cannot exceed the bound.
+		s.retainedPointsCap = std::numeric_limits<size_t>::max();
+		s.temperature.resize(TerrainGenerator::kMaxDenseDomainPoints + 1);
+		s.trimOversizedCapacity();
+		CHECK(s.temperature.capacity() <= TerrainGenerator::kMaxDenseDomainPoints,
+			  "retention cap above the dense bound must clamp");
 	}
 
 	// Dense build cancelled at the final checkpoint: the call failed, yet
@@ -2000,8 +2009,36 @@ static void testBiomeRegionScratchRetention()
 		checkBounded(scratch);
 	}
 
+	// Owner-set retention policy: a dedicated scratch may retain dense
+	// capacity (up to the absolute bound) so successive dense builds reuse
+	// it without allocation churn.
+	{
+		TerrainGenerator::BiomeRegionScratch scratch;
+		scratch.retainedPointsCap = TerrainGenerator::kMaxDenseDomainPoints;
+		const BiomeRegionGrid grid = makeBiomeRegionGrid(0.0f, 0.0f, 1.0f, 256, 256);
+
+		std::vector<BiomeType> first, second, third;
+		CHECK(gen.getBiomeRegion(grid, first, &scratch), "dense build 1 must complete");
+		const size_t retained = scratch.temperature.capacity();
+		CHECK(retained > TerrainGenerator::kMaxTileDensePoints &&
+				  retained <= TerrainGenerator::kMaxDenseDomainPoints,
+			  "dense capacity must be retained within the absolute bound");
+
+		CHECK(gen.getBiomeRegion(grid, second, &scratch), "dense build 2 must complete");
+		CHECK(scratch.temperature.capacity() == retained,
+			  "successive dense builds must reuse the retained scratch (no churn)");
+		CHECK(first == second, "reused scratch must produce identical output");
+
+		// The cap clamps to the absolute dense bound, even for absurd values.
+		scratch.retainedPointsCap = std::numeric_limits<size_t>::max();
+		CHECK(gen.getBiomeRegion(grid, third, &scratch), "dense build 3 must complete");
+		CHECK(scratch.temperature.capacity() <= TerrainGenerator::kMaxDenseDomainPoints,
+			  "retention cap must clamp to the absolute dense bound");
+	}
+
 	std::cout << "biome region scratch retention: oversized capacity trimmed after "
-			  << "success and cancellation, tiled-sized capacity preserved\n";
+			  << "success and cancellation, tiled-sized capacity preserved, "
+			  << "owner-set dense retention churn-free and bounded\n";
 }
 
 static void testBiomeMapGridMatchesPointQueries()


### PR DESCRIPTION
Closes the allocation-churn half of the memory strategy: dense biome-map builds (zoom >= ~0.5 on a 256x256 map, ~10 MiB peak scratch) reused to re-allocate their full scratch on every refresh because the unconditional exit trim reduced everything back to the tiled bound.

Owner-set retention policy
- BiomeRegionScratch gains retainedPointsCap (default kMaxTileDensePoints): after every getBiomeRegion() exit - success, cancellation, failure, or exception - per-field capacity is trimmed to the scratch's own cap, clamped to kMaxDenseDomainPoints. The default keeps generic/internal scratubes bounded to the tiled path exactly as before, so the bounded-retention contract of PR #87 is unchanged for every existing owner; retention tests still pass as-is.
- Producers with a single dedicated scratch may raise the cap to kMaxDenseDomainPoints for churn-free dense reuse, bounded at ~10.6 MiB total for that one scratch.

Single process-wide map scratch
- BiomeMapRequest carries an optional shared_ptr<TerrainGenerator::BiomeRegionScratch>. GameUI owns exactly one such scratch with the dense retention cap - never one per pool worker - and passes it into each biome-map request. Shared ownership keeps it alive for the duration of an in-flight job even if GameUI is torn down; the single-flight job contract (#74/#75/#84) makes concurrent access impossible.
- generateBiomeMap() uses the request scratch when present and otherwise falls back to getBiomeRegion's internal thread-local (tiled-bound) scratch; no more function-local thread_local in the UI layer.

Tests
- Retention policy: a dense-cap scratch retains capacity within [kMaxTileDensePoints, kMaxDenseDomainPoints] after a dense build, a second dense build leaves capacity bit-for-bit unchanged (no churn) and produces identical biomes, and an absurd cap (SIZE_MAX) is clamped to the absolute bound by the trim.
- test_biome_map: two successive request-scratch map builds reuse the retained capacity without growth, and a cancelled build through the same scratch neither grows it nor breaks the policy.

Docs: terrain-generation.md scratch bullet now describes the owner-set retention policy and the single process-wide map scratch.

Validation: build clean; ctest 8/8; ASan clean on test_terrain and test_biome_map; retention contract of PR #87 unchanged for the default policy.

Close #89