### PR TITLE
fix(terrain): drop unsynchronized biome-config initialized flag (#81)

### DIFF
--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -2,6 +2,7 @@
 #include <Chunk/StreamHelpers.hpp>
 #include <Renderer/MinecraftTextures.hpp>
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <mutex>
@@ -11,7 +12,6 @@
 // =============================================
 
 std::array<BiomeConfig, BIOME_COUNT> TerrainGenerator::s_biomeConfigs;
-bool TerrainGenerator::s_biomeConfigsInitialized = false;
 static std::once_flag s_biomeConfigsOnceFlag;
 
 void TerrainGenerator::initBiomeConfigs()
@@ -209,17 +209,18 @@ void TerrainGenerator::initBiomeConfigs()
         0.0f, 0.0f, 0.0f, 0.0f,
         glm::vec3(0.30f, 0.68f, 0.54f), glm::vec3(0.24f, 0.60f, 0.48f),
         false, false, 0.0f};
-
-    s_biomeConfigsInitialized = true; });
+  });
 }
 
 const BiomeConfig &TerrainGenerator::getBiomeConfig(BiomeType biome)
 {
-  if (!s_biomeConfigsInitialized)
-  {
-    initBiomeConfigs();
-  }
-  return s_biomeConfigs[biome];
+  // std::call_once is the sole synchronization for initialization: repeated
+  // calls are cheap and everything written inside the once-block is visible
+  // to every caller once it returns. A separate initialized flag here would
+  // be read and written outside that mechanism and would race.
+  initBiomeConfigs();
+  assert(static_cast<std::size_t>(biome) < BIOME_COUNT);
+  return s_biomeConfigs[static_cast<std::size_t>(biome)];
 }
 
 // =============================================

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -259,7 +259,8 @@ private:
 
   // Biome configurations (static)
   static std::array<BiomeConfig, BIOME_COUNT> s_biomeConfigs;
-  static bool s_biomeConfigsInitialized;
+  // Lazily fills s_biomeConfigs exactly once; std::call_once is the single
+  // synchronization mechanism, so this is safe to call from any thread.
   static void initBiomeConfigs();
   // =============================================
   // SETUP METHODS

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -114,6 +114,97 @@ static bool isChunkLocalFeature(uint8_t raw)
 }
 
 // ---------------------------------------------------------------------------
+// Biome config initialization (issue #81)
+// ---------------------------------------------------------------------------
+
+/// First access to getBiomeConfig() from many threads at once must be
+/// race-free: std::call_once is the only synchronization and there is no
+/// separate initialized flag. This must run before anything else constructs
+/// a TerrainGenerator so initialization is genuinely first triggered
+/// concurrently, not by a prior single-threaded call.
+static void testBiomeConfigConcurrentInit()
+{
+	constexpr int kThreads = 8;
+	constexpr int kSweeps = 64;
+
+	// Wave 1: concurrent first access. Every read must return a fully
+	// formed config — a torn or partially applied initialization would
+	// show up as out-of-range fields (and as a TSan report on Linux CI).
+	std::atomic<int> invalid{0};
+	{
+		std::vector<std::future<void>> futures;
+		futures.reserve(kThreads);
+		for (int t = 0; t < kThreads; ++t)
+		{
+			futures.push_back(std::async(std::launch::async, [&invalid]() {
+				for (int sweep = 0; sweep < kSweeps; ++sweep)
+				{
+					for (int b = 0; b < BIOME_COUNT; ++b)
+					{
+						const BiomeConfig &cfg =
+							TerrainGenerator::getBiomeConfig(static_cast<BiomeType>(b));
+						const bool fieldsOk =
+							cfg.subsurfaceDepth >= 0 && cfg.subsurfaceDepth <= 16 &&
+							cfg.treeDensity >= 0.0f && cfg.treeDensity <= 1.0f &&
+							cfg.bushDensity >= 0.0f && cfg.bushDensity <= 1.0f &&
+							cfg.rockDensity >= 0.0f && cfg.rockDensity <= 1.0f &&
+							cfg.fallenLogDensity >= 0.0f && cfg.fallenLogDensity <= 1.0f &&
+							cfg.surfacePerturbAmp >= 0.0f && cfg.surfacePerturbAmp <= 16.0f &&
+							cfg.surfaceBlock >= TextureType::BEDROCK &&
+							cfg.surfaceBlock < TextureType::COUNT &&
+							cfg.subsurfaceBlock >= TextureType::BEDROCK &&
+							cfg.subsurfaceBlock < TextureType::COUNT &&
+							cfg.underwaterBlock >= TextureType::BEDROCK &&
+							cfg.underwaterBlock < TextureType::COUNT &&
+							std::isfinite(cfg.grassColor.x) && std::isfinite(cfg.grassColor.y) &&
+							std::isfinite(cfg.grassColor.z) &&
+							std::isfinite(cfg.foliageColor.x) && std::isfinite(cfg.foliageColor.y) &&
+							std::isfinite(cfg.foliageColor.z);
+						if (!fieldsOk)
+							++invalid;
+					}
+				}
+			}));
+		}
+		for (auto &f : futures)
+			f.get();
+	}
+	CHECK(invalid.load() == 0, "concurrent first access returned invalid biome configs");
+
+	// Wave 2: after initialization, every thread must observe byte-identical
+	// configs for all biomes — identical and complete, as before the change.
+	std::vector<BiomeConfig> reference;
+	reference.reserve(BIOME_COUNT);
+	for (int b = 0; b < BIOME_COUNT; ++b)
+		reference.push_back(TerrainGenerator::getBiomeConfig(static_cast<BiomeType>(b)));
+
+	std::atomic<int> mismatches{0};
+	{
+		std::vector<std::future<void>> futures;
+		futures.reserve(kThreads);
+		for (int t = 0; t < kThreads; ++t)
+		{
+			futures.push_back(std::async(std::launch::async, [&reference, &mismatches]() {
+				for (int b = 0; b < BIOME_COUNT; ++b)
+				{
+					const BiomeConfig &cfg =
+						TerrainGenerator::getBiomeConfig(static_cast<BiomeType>(b));
+					if (std::memcmp(&cfg, &reference[b], sizeof(BiomeConfig)) != 0)
+						++mismatches;
+				}
+			}));
+		}
+		for (auto &f : futures)
+			f.get();
+	}
+	CHECK(mismatches.load() == 0, "biome configs differ between threads after init");
+
+	std::cout << "biome configs: " << kThreads << " threads x " << kSweeps
+			  << " concurrent first-access sweeps of all " << BIOME_COUNT
+			  << " biomes, identical across threads afterwards\n";
+}
+
+// ---------------------------------------------------------------------------
 // Determinism
 // ---------------------------------------------------------------------------
 
@@ -2385,6 +2476,9 @@ int main(int argc, char **argv)
 	if (argc > 1 && std::strcmp(argv[1], "--world-stats") == 0)
 		return runWorldStats(argc, argv);
 
+	// Issue #81: must stay the first test — it exercises the concurrent
+	// FIRST access to getBiomeConfig() before any TerrainGenerator exists.
+	testBiomeConfigConcurrentInit();
 	testDeterminismSameSeed();
 	testDifferentSeedsDiffer();
 	testConcurrentAndMultiSeedDeterminism();

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <barrier>
 #include <array>
 #include <chrono>
 #include <cmath>
@@ -17,6 +18,7 @@
 #include <limits>
 #include <map>
 #include <string>
+#include <thread>
 #include <vector>
 
 static int g_fails = 0;
@@ -117,62 +119,102 @@ static bool isChunkLocalFeature(uint8_t raw)
 // Biome config initialization (issue #81)
 // ---------------------------------------------------------------------------
 
+/// Sanity net for a config read from getBiomeConfig(): a torn or partially
+/// applied initialization would surface as out-of-range fields. It is NOT a
+/// proof of race-free initialization on its own — that guarantee comes from
+/// std::call_once plus a ThreadSanitizer run (Linux CI; TSan is unavailable
+/// under MSVC).
+static bool isValidBiomeConfig(const BiomeConfig &cfg)
+{
+	return cfg.subsurfaceDepth >= 0 && cfg.subsurfaceDepth <= 16 &&
+		   cfg.treeDensity >= 0.0f && cfg.treeDensity <= 1.0f &&
+		   cfg.bushDensity >= 0.0f && cfg.bushDensity <= 1.0f &&
+		   cfg.rockDensity >= 0.0f && cfg.rockDensity <= 1.0f &&
+		   cfg.fallenLogDensity >= 0.0f && cfg.fallenLogDensity <= 1.0f &&
+		   cfg.surfacePerturbAmp >= 0.0f && cfg.surfacePerturbAmp <= 16.0f &&
+		   cfg.surfaceBlock >= TextureType::BEDROCK &&
+		   cfg.surfaceBlock < TextureType::COUNT &&
+		   cfg.subsurfaceBlock >= TextureType::BEDROCK &&
+		   cfg.subsurfaceBlock < TextureType::COUNT &&
+		   cfg.underwaterBlock >= TextureType::BEDROCK &&
+		   cfg.underwaterBlock < TextureType::COUNT &&
+		   std::isfinite(cfg.grassColor.x) && std::isfinite(cfg.grassColor.y) &&
+		   std::isfinite(cfg.grassColor.z) &&
+		   std::isfinite(cfg.foliageColor.x) && std::isfinite(cfg.foliageColor.y) &&
+		   std::isfinite(cfg.foliageColor.z);
+}
+
+/// Member-wise equality of two biome configs. Configs are built from
+/// deterministic literals, so exact float comparison is correct (no
+/// epsilon). Member-wise rather than memcmp to stay independent of any
+/// padding bytes in the struct.
+static bool sameBiomeConfig(const BiomeConfig &a, const BiomeConfig &b)
+{
+	return a.surfaceBlock == b.surfaceBlock &&
+		   a.subsurfaceBlock == b.subsurfaceBlock &&
+		   a.underwaterBlock == b.underwaterBlock &&
+		   a.subsurfaceDepth == b.subsurfaceDepth &&
+		   a.treeDensity == b.treeDensity &&
+		   a.bushDensity == b.bushDensity &&
+		   a.rockDensity == b.rockDensity &&
+		   a.fallenLogDensity == b.fallenLogDensity &&
+		   a.grassColor == b.grassColor &&
+		   a.foliageColor == b.foliageColor &&
+		   a.hasSnow == b.hasSnow &&
+		   a.hasCacti == b.hasCacti &&
+		   a.surfacePerturbAmp == b.surfacePerturbAmp;
+}
+
 /// First access to getBiomeConfig() from many threads at once must be
 /// race-free: std::call_once is the only synchronization and there is no
-/// separate initialized flag. This must run before anything else constructs
-/// a TerrainGenerator so initialization is genuinely first triggered
+/// separate initialized flag. A std::barrier releases all workers at the
+/// same logical instant (no sleep/yield timing games), and every thread's
+/// very first lookup targets the same biome so the single call_once really
+/// is contended. This must run before anything else constructs a
+/// TerrainGenerator so initialization is genuinely first triggered
 /// concurrently, not by a prior single-threaded call.
 static void testBiomeConfigConcurrentInit()
 {
 	constexpr int kThreads = 8;
 	constexpr int kSweeps = 64;
 
-	// Wave 1: concurrent first access. Every read must return a fully
-	// formed config — a torn or partially applied initialization would
-	// show up as out-of-range fields (and as a TSan report on Linux CI).
+	// Wave 1: barrier-synchronized concurrent first access.
 	std::atomic<int> invalid{0};
 	{
-		std::vector<std::future<void>> futures;
-		futures.reserve(kThreads);
+		std::barrier start{kThreads};
+		std::vector<std::thread> threads;
+		threads.reserve(kThreads);
 		for (int t = 0; t < kThreads; ++t)
 		{
-			futures.push_back(std::async(std::launch::async, [&invalid]() {
+			threads.emplace_back([&start, &invalid]() {
+				start.arrive_and_wait();
+
+				// Real concurrent first access: all threads hit the same
+				// getBiomeConfig() / std::call_once at the same instant.
+				if (!isValidBiomeConfig(
+						TerrainGenerator::getBiomeConfig(BIOME_PLAINS)))
+					++invalid;
+
 				for (int sweep = 0; sweep < kSweeps; ++sweep)
 				{
 					for (int b = 0; b < BIOME_COUNT; ++b)
 					{
-						const BiomeConfig &cfg =
-							TerrainGenerator::getBiomeConfig(static_cast<BiomeType>(b));
-						const bool fieldsOk =
-							cfg.subsurfaceDepth >= 0 && cfg.subsurfaceDepth <= 16 &&
-							cfg.treeDensity >= 0.0f && cfg.treeDensity <= 1.0f &&
-							cfg.bushDensity >= 0.0f && cfg.bushDensity <= 1.0f &&
-							cfg.rockDensity >= 0.0f && cfg.rockDensity <= 1.0f &&
-							cfg.fallenLogDensity >= 0.0f && cfg.fallenLogDensity <= 1.0f &&
-							cfg.surfacePerturbAmp >= 0.0f && cfg.surfacePerturbAmp <= 16.0f &&
-							cfg.surfaceBlock >= TextureType::BEDROCK &&
-							cfg.surfaceBlock < TextureType::COUNT &&
-							cfg.subsurfaceBlock >= TextureType::BEDROCK &&
-							cfg.subsurfaceBlock < TextureType::COUNT &&
-							cfg.underwaterBlock >= TextureType::BEDROCK &&
-							cfg.underwaterBlock < TextureType::COUNT &&
-							std::isfinite(cfg.grassColor.x) && std::isfinite(cfg.grassColor.y) &&
-							std::isfinite(cfg.grassColor.z) &&
-							std::isfinite(cfg.foliageColor.x) && std::isfinite(cfg.foliageColor.y) &&
-							std::isfinite(cfg.foliageColor.z);
-						if (!fieldsOk)
+						const BiomeConfig &cfg = TerrainGenerator::getBiomeConfig(
+							static_cast<BiomeType>(b));
+						if (!isValidBiomeConfig(cfg))
 							++invalid;
 					}
 				}
-			}));
+			});
 		}
-		for (auto &f : futures)
-			f.get();
+		for (auto &thread : threads)
+			thread.join();
 	}
 	CHECK(invalid.load() == 0, "concurrent first access returned invalid biome configs");
 
-	// Wave 2: after initialization, every thread must observe byte-identical
-	// configs for all biomes — identical and complete, as before the change.
+	// Wave 2: after initialization, every thread must observe member-wise
+	// identical configs for all biomes — identical and complete, as before
+	// the change.
 	std::vector<BiomeConfig> reference;
 	reference.reserve(BIOME_COUNT);
 	for (int b = 0; b < BIOME_COUNT; ++b)
@@ -180,28 +222,29 @@ static void testBiomeConfigConcurrentInit()
 
 	std::atomic<int> mismatches{0};
 	{
-		std::vector<std::future<void>> futures;
-		futures.reserve(kThreads);
+		std::vector<std::thread> threads;
+		threads.reserve(kThreads);
 		for (int t = 0; t < kThreads; ++t)
 		{
-			futures.push_back(std::async(std::launch::async, [&reference, &mismatches]() {
+			threads.emplace_back([&reference, &mismatches]() {
 				for (int b = 0; b < BIOME_COUNT; ++b)
 				{
-					const BiomeConfig &cfg =
-						TerrainGenerator::getBiomeConfig(static_cast<BiomeType>(b));
-					if (std::memcmp(&cfg, &reference[b], sizeof(BiomeConfig)) != 0)
+					const BiomeConfig &cfg = TerrainGenerator::getBiomeConfig(
+						static_cast<BiomeType>(b));
+					if (!sameBiomeConfig(cfg, reference[b]))
 						++mismatches;
 				}
-			}));
+			});
 		}
-		for (auto &f : futures)
-			f.get();
+		for (auto &thread : threads)
+			thread.join();
 	}
 	CHECK(mismatches.load() == 0, "biome configs differ between threads after init");
 
-	std::cout << "biome configs: " << kThreads << " threads x " << kSweeps
-			  << " concurrent first-access sweeps of all " << BIOME_COUNT
-			  << " biomes, identical across threads afterwards\n";
+	std::cout << "biome configs: " << kThreads
+			  << " barrier-synchronized threads hit the same first lookup, "
+			  << kSweeps << " sweeps of all " << BIOME_COUNT
+			  << " biomes, member-wise identical across threads afterwards\n";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
getBiomeConfig() guarded initBiomeConfigs() with a plain non-atomic `s_biomeConfigsInitialized` bool that was read and written outside any common synchronization mechanism. If the first call happened on multiple threads at once, one thread could read the flag while another wrote it from inside the `std::call_once` body - a data race under the C++ memory model, masked in practice only by startup ordering (the engine constructs `TerrainGenerator` on the main thread before workers spawn).

`std::call_once` alone is the correct and sufficient mechanism: repeated calls are cheap and all writes inside the once-block are visible to every caller once it returns. The redundant flag is now removed:

- `getBiomeConfig()` unconditionally routes through `initBiomeConfigs()`; the constructor keeps its proactive call, later calls are no-ops
- index is validated by a debug assert (`getBiomeConfig` is public API); no silent runtime clamp
- `initBiomeConfigs()` documented as the single synchronization point
- verified: no other direct reads of `s_biomeConfigs` exist outside `initBiomeConfigs()`/`getBiomeConfig()`; zero references to the removed flag remain

## Concurrency test

Added as the FIRST test in `test_terrain` main, before any `TerrainGenerator` can exist, so initialization is genuinely first triggered concurrently:

- **`std::barrier` synchronizes all first callers**: 8 raw threads (explicit `join`, no `std::async`) rendezvous and their very first lookup targets the same biome (`BIOME_PLAINS`), so the single `std::call_once` is contended by every thread at the same logical instant - no sleep/yield timing games
- then 64 sweeps of all 31 biomes, each config checked by `isValidBiomeConfig()` (densities in [0,1], valid block ids, finite colors) - a sanity net only; the race guarantee comes from `std::call_once` plus TSan
- a second wave verifies all threads observe **member-wise identical** configs afterwards (`sameBiomeConfig()`, exact float comparison - configs are deterministic literals; no `memcmp`, so struct padding is irrelevant)
- the test runs first in every process, so repeating the binary re-exercises the `once_flag` first access each time

## Validation

- Release build clean
- `test_terrain`: 20/20 repeated runs pass
- Debug build (index assert active) passes
- full ctest 8/8
- ASan clean on `test_biome_map` (no ASan rerun for the test-only follow-up commit)
- **TSan not run**: ThreadSanitizer is unavailable under MSVC; the first-access test must be validated under TSan on Linux CI (`-fsanitize=thread -fno-omit-frame-pointer -g`)

Close #81
