### PR TITLE
perf(terrain): generate chunks directly into pooled storage (issue #78)

### DIFF
--- a/src/Chunk/Chunk.cpp
+++ b/src/Chunk/Chunk.cpp
@@ -56,6 +56,8 @@ Chunk::Chunk(Chunk &&other) noexcept
       neighborShellVoxels(std::move(other.neighborShellVoxels)),
       biomeGrassColors(other.biomeGrassColors),
       biomeFoliageColors(other.biomeFoliageColors),
+      biomeTypes(other.biomeTypes),
+      heightMap(other.heightMap),
       vertices(std::move(other.vertices)), indices(std::move(other.indices)),
       waterVertices(std::move(other.waterVertices)), waterIndices(std::move(other.waterIndices)),
       m_isLODMesh(other.m_isLODMesh)
@@ -82,6 +84,8 @@ Chunk &Chunk::operator=(Chunk &&other) noexcept
     neighborShellVoxels = std::move(other.neighborShellVoxels);
     biomeGrassColors = other.biomeGrassColors;
     biomeFoliageColors = other.biomeFoliageColors;
+    biomeTypes = other.biomeTypes;
+    heightMap = other.heightMap;
     vertices = std::move(other.vertices);
     indices = std::move(other.indices);
     waterVertices = std::move(other.waterVertices);
@@ -249,8 +253,8 @@ void Chunk::generateTerrain(TerrainGenerator &generator)
   neighborShellVoxels.resize(kBorderVoxelCount);
 
   ChunkGenerationTarget target{
-      .voxels = voxels,
-      .borderVoxels = neighborShellVoxels,
+      .voxels = std::span<Voxel, CHUNK_VOLUME>(voxels),
+      .borderVoxels = std::span<uint8_t, kBorderVoxelCount>(neighborShellVoxels),
       .biomes = biomeTypes,
       .heightMap = heightMap,
       .grassColors = biomeGrassColors,

--- a/src/Chunk/Chunk.cpp
+++ b/src/Chunk/Chunk.cpp
@@ -173,11 +173,6 @@ void Chunk::setVoxel(int x, int y, int z, TextureType type)
   }
 }
 
-void Chunk::setVoxels(const std::vector<Voxel> &voxels)
-{
-  this->voxels = voxels;
-}
-
 bool Chunk::deleteVoxel(const glm::vec3 &position)
 {
   int x = static_cast<int>(position.x - this->position.x);
@@ -243,19 +238,24 @@ void Chunk::generateTerrain(TerrainGenerator &generator)
   if (state.load() != ChunkState::UNLOADED)
     return;
 
-  std::fill(neighborShellVoxels.begin(), neighborShellVoxels.end(),
-            static_cast<uint8_t>(AIR));
-
   // Ensure we use integer coordinates aligned with world grid
   int genX = static_cast<int>(std::round(position.x));
   int genZ = static_cast<int>(std::round(position.z));
 
-  auto chunkData = generator.generateChunk(genX, genZ);
-  setVoxels(chunkData.voxels);
+  // Generate directly into this pooled chunk's reusable storage: no
+  // temporary ChunkData and no CHUNK_VOLUME / border-shell copies after
+  // generation. resize() only ever grows once; pool recycles keep capacity.
+  voxels.resize(CHUNK_VOLUME);
+  neighborShellVoxels.resize(kBorderVoxelCount);
 
-  neighborShellVoxels = chunkData.borderVoxels;
-  biomeGrassColors = chunkData.grassColors;
-  biomeFoliageColors = chunkData.foliageColors;
+  ChunkGenerationTarget target{
+      .voxels = voxels,
+      .borderVoxels = neighborShellVoxels,
+      .biomes = biomeTypes,
+      .heightMap = heightMap,
+      .grassColors = biomeGrassColors,
+      .foliageColors = biomeFoliageColors};
+  generator.generateChunkInto(genX, genZ, target);
 
   // Update bitset for active voxels
   activeVoxels.reset(); // Clear all bits first
@@ -1364,8 +1364,10 @@ void Chunk::reset(const glm::vec3 &newPosition)
   // Clear shell — keep capacity for reuse
   neighborShellVoxels.clear();
 
-  // Reset biome colors
+  // Reset biome colors and per-column generation state
   biomeGrassColors.fill(0);
   biomeFoliageColors.fill(0);
+  biomeTypes.fill(static_cast<BiomeType>(0));
+  heightMap.fill(0);
 }
 

--- a/src/Chunk/Chunk.hpp
+++ b/src/Chunk/Chunk.hpp
@@ -130,4 +130,9 @@ private:
 
 private:
 	size_t m_activeIndex{SIZE_MAX};
+
+	// Testing hook (issue #78 review): lets the chunk lifecycle test verify
+	// full move semantics - including per-column generation state - without
+	// exposing that state in the public API.
+	friend struct ChunkStateProbe;
 };

--- a/src/Chunk/Chunk.hpp
+++ b/src/Chunk/Chunk.hpp
@@ -44,8 +44,6 @@ public:
 	void setState(ChunkState state);
 	ChunkState getState() const;
 
-	void setVoxels(const std::vector<Voxel> &voxels);
-
 	Voxel &getVoxel(uint32_t x, uint32_t y, uint32_t z);
 	const Voxel &getVoxel(uint32_t x, uint32_t y, uint32_t z) const;
 	bool isVoxelActive(int x, int y, int z) const;
@@ -114,6 +112,12 @@ private:
 
 	std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> biomeGrassColors{};
 	std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> biomeFoliageColors{};
+
+	// Per-column generation state, filled by generateTerrain() (biomes feed
+	// vegetation/border passes; heightMap mirrors ChunkData::heightMap).
+	// Fully reset on every generation and pool recycle.
+	std::array<BiomeType, CHUNK_SIZE * CHUNK_SIZE> biomeTypes{};
+	std::array<int, CHUNK_SIZE * CHUNK_SIZE> heightMap{};
 
 	uint32_t opaqueIndexCount{0};
 	uint32_t waterIndexCount{0};

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -731,8 +731,8 @@ ChunkData TerrainGenerator::generateChunk(int chunkX, int chunkZ)
   chunkData.borderVoxels.resize(kBorderVoxelCount);
 
   ChunkGenerationTarget target{
-      .voxels = chunkData.voxels,
-      .borderVoxels = chunkData.borderVoxels,
+      .voxels = std::span<Voxel, CHUNK_VOLUME>(chunkData.voxels),
+      .borderVoxels = std::span<uint8_t, kBorderVoxelCount>(chunkData.borderVoxels),
       .biomes = chunkData.biomes,
       .heightMap = chunkData.heightMap,
       .grassColors = chunkData.grassColors,
@@ -744,9 +744,6 @@ ChunkData TerrainGenerator::generateChunk(int chunkX, int chunkZ)
 void TerrainGenerator::generateChunkInto(int chunkX, int chunkZ,
                                          const ChunkGenerationTarget &target)
 {
-  assert(target.voxels.size() == static_cast<size_t>(CHUNK_VOLUME));
-  assert(target.borderVoxels.size() == kBorderVoxelCount);
-
   using Clock = std::chrono::steady_clock;
   const auto totalStart =
       m_activeProfile ? Clock::now() : Clock::time_point{};

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -723,21 +723,54 @@ TerrainGenerator &TerrainGenerator::getThreadLocal(int seed)
 
 ChunkData TerrainGenerator::generateChunk(int chunkX, int chunkZ)
 {
+  // Owning convenience wrapper (tests/tools): allocate fresh storage and
+  // generate into it. The streaming hot path uses generateChunkInto() with
+  // caller-owned reusable storage instead.
+  ChunkData chunkData;
+  chunkData.voxels.resize(CHUNK_VOLUME);
+  chunkData.borderVoxels.resize(kBorderVoxelCount);
+
+  ChunkGenerationTarget target{
+      .voxels = chunkData.voxels,
+      .borderVoxels = chunkData.borderVoxels,
+      .biomes = chunkData.biomes,
+      .heightMap = chunkData.heightMap,
+      .grassColors = chunkData.grassColors,
+      .foliageColors = chunkData.foliageColors};
+  generateChunkInto(chunkX, chunkZ, target);
+  return chunkData;
+}
+
+void TerrainGenerator::generateChunkInto(int chunkX, int chunkZ,
+                                         const ChunkGenerationTarget &target)
+{
+  assert(target.voxels.size() == static_cast<size_t>(CHUNK_VOLUME));
+  assert(target.borderVoxels.size() == kBorderVoxelCount);
+
   using Clock = std::chrono::steady_clock;
   const auto totalStart =
       m_activeProfile ? Clock::now() : Clock::time_point{};
-  ChunkData chunkData;
-  chunkData.voxels.assign(CHUNK_VOLUME, {TextureType::AIR});
-  chunkData.borderVoxels.assign(18 * (CHUNK_HEIGHT + 2) * 18,
-                                static_cast<uint8_t>(AIR));
+
+  // Reset semantics: the destination storage is reused across pooled
+  // chunks, so fully re-initialize every field before generating. Nothing
+  // from a previously generated chunk may leak into this one.
+  std::fill(target.voxels.begin(), target.voxels.end(),
+            Voxel{TextureType::AIR});
+  std::fill(target.borderVoxels.begin(), target.borderVoxels.end(),
+            static_cast<uint8_t>(AIR));
+  std::fill(target.biomes.begin(), target.biomes.end(),
+            static_cast<BiomeType>(0));
+  std::fill(target.heightMap.begin(), target.heightMap.end(), 0);
+  std::fill(target.grassColors.begin(), target.grassColors.end(), 0u);
+  std::fill(target.foliageColors.begin(), target.foliageColors.end(), 0u);
 
   // Generate the main chunk data
-  generateChunkBatch(chunkData, chunkX, chunkZ);
+  generateChunkBatch(target, chunkX, chunkZ);
 
   // Generate vegetation (trees, cacti, etc.)
   const auto vegetationStart =
       m_activeProfile ? Clock::now() : Clock::time_point{};
-  generateVegetation(chunkData, chunkX, chunkZ);
+  generateVegetation(target, chunkX, chunkZ);
   if (m_activeProfile)
     m_activeProfile->vegetationMs +=
         std::chrono::duration<double, std::milli>(Clock::now() -
@@ -747,7 +780,7 @@ ChunkData TerrainGenerator::generateChunk(int chunkX, int chunkZ)
   // Generate border voxels for mesh optimization
   const auto borderStart =
       m_activeProfile ? Clock::now() : Clock::time_point{};
-  generateChunkBorders(chunkData, chunkX, chunkZ);
+  generateChunkBorders(target, chunkX, chunkZ);
   if (m_activeProfile)
   {
     m_activeProfile->borderMs +=
@@ -758,8 +791,6 @@ ChunkData TerrainGenerator::generateChunk(int chunkX, int chunkZ)
             .count();
     ++m_activeProfile->chunks;
   }
-
-  return chunkData;
 }
 
 ChunkData TerrainGenerator::generateChunkProfiled(
@@ -875,7 +906,7 @@ BiomeType TerrainGenerator::evaluateBiomeAt(
                         continental, erosion, pv, riverVal, height);
 }
 
-void TerrainGenerator::generateChunkBatch(ChunkData &chunkData, int chunkX,
+void TerrainGenerator::generateChunkBatch(const ChunkGenerationTarget &chunkData, int chunkX,
                                           int chunkZ)
 {
   using Clock = std::chrono::steady_clock;
@@ -2231,7 +2262,7 @@ inline TextureType logTypeForBiome(BiomeType biome, uint32_t h)
 
 } // namespace
 
-void TerrainGenerator::generateVegetation(ChunkData &chunkData, int chunkX, int chunkZ)
+void TerrainGenerator::generateVegetation(const ChunkGenerationTarget &chunkData, int chunkX, int chunkZ)
 {
   float chunkXf = static_cast<float>(chunkX) + NOISE_OFFSET;
   float chunkZf = static_cast<float>(chunkZ) + NOISE_OFFSET;
@@ -2743,7 +2774,7 @@ TextureType TerrainGenerator::getVoxelTypeAt(int worldX, int worldY, int worldZ,
 // BORDER GENERATION
 // =============================================
 
-void TerrainGenerator::generateChunkBorders(ChunkData &chunkData, int chunkX,
+void TerrainGenerator::generateChunkBorders(const ChunkGenerationTarget &chunkData, int chunkX,
                                             int chunkZ)
 {
   auto setBorderVoxel = [&](int lx, int ly, int lz, TextureType type)

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -38,11 +38,11 @@ constexpr size_t kBorderVoxelCount =
 // to memory owned by the caller - pooled Chunk storage at runtime, an owning
 // ChunkData in tests/tools. generateChunkInto() fully resets every field
 // before generating, so reused storage cannot leak data between chunks.
-// Fixed extents make a wrong-sized destination a type-level contract
-// (debug-verified at construction from sized ranges) instead of a runtime
-// check on the hot path. View semantics: a const target still allows
-// writing through its spans (only the span members themselves are
-// protected).
+// Fixed extents encode the required target sizes in the type. Callers
+// constructing these spans from dynamically-sized storage must ensure the
+// backing ranges have exactly the required sizes (debug builds verify this
+// at construction). View semantics: a const target still allows writing
+// through its spans (only the span members themselves are protected).
 struct ChunkGenerationTarget
 {
   std::span<Voxel, CHUNK_VOLUME> voxels;

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <functional>
 #include <glm/glm.hpp>
+#include <span>
 #include <unordered_map>
 #include <memory>
 #include <cstdint>
@@ -27,6 +28,26 @@ struct ChunkData
   // Precomputed packed RGBA biome colors per column (for mesh generation)
   std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> grassColors;
   std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> foliageColors;
+};
+
+// 1-thick neighbor shell around a chunk (18 x (CHUNK_HEIGHT + 2) x 18).
+constexpr size_t kBorderVoxelCount =
+    static_cast<size_t>(18) * (CHUNK_HEIGHT + 2) * 18;
+
+// Caller-owned destination storage for one chunk generation. The spans refer
+// to memory owned by the caller - pooled Chunk storage at runtime, an owning
+// ChunkData in tests/tools. generateChunkInto() fully resets every field
+// before generating, so reused storage cannot leak data between chunks.
+// View semantics: a const target still allows writing through its spans
+// (only the span members themselves are protected).
+struct ChunkGenerationTarget
+{
+  std::span<Voxel> voxels;                // size() == CHUNK_VOLUME
+  std::span<uint8_t> borderVoxels;        // size() == kBorderVoxelCount
+  std::span<BiomeType, CHUNK_SIZE * CHUNK_SIZE> biomes;
+  std::span<int, CHUNK_SIZE * CHUNK_SIZE> heightMap;
+  std::span<uint32_t, CHUNK_SIZE * CHUNK_SIZE> grassColors;
+  std::span<uint32_t, CHUNK_SIZE * CHUNK_SIZE> foliageColors;
 };
 
 struct TerrainGenerationProfile
@@ -80,7 +101,16 @@ public:
   static constexpr float NOISE_OFFSET = 10000.0f;
 
   explicit TerrainGenerator(int seed = 1337);
+  // Owning convenience wrapper (tests/tools): allocates a fresh ChunkData
+  // and generates into it. The runtime streaming hot path must use
+  // generateChunkInto() instead so pooled storage is reused directly.
   ChunkData generateChunk(int chunkX, int chunkZ);
+  // Generates a chunk directly into caller-owned reusable storage. Fully
+  // resets all destination state first (voxels, neighbor shell, biomes,
+  // height map, colors), so nothing leaks from a previously generated
+  // chunk. Equivalent output to generateChunk().
+  void generateChunkInto(int chunkX, int chunkZ,
+                         const ChunkGenerationTarget &target);
   ChunkData generateChunkProfiled(int chunkX, int chunkZ,
                                   TerrainGenerationProfile &profile);
 
@@ -277,8 +307,8 @@ private:
   // =============================================
 
   // Core terrain generation
-  void generateChunkBatch(ChunkData &chunkData, int chunkX, int chunkZ);
-  void generateChunkBorders(ChunkData &chunkData, int chunkX, int chunkZ);
+  void generateChunkBatch(const ChunkGenerationTarget &chunkData, int chunkX, int chunkZ);
+  void generateChunkBorders(const ChunkGenerationTarget &chunkData, int chunkX, int chunkZ);
 
   // Height calculation (weirdness drives river valley width, matching determineBiome)
   int calculateHeight(float continental, float erosion, float peaksValleys,
@@ -325,22 +355,22 @@ private:
                            float continental, float erosion, float pv, float riverVal, int height) const;
 
   // Vegetation generation
-  void generateVegetation(ChunkData &chunkData, int chunkX, int chunkZ);
-  void placeTree(ChunkData &chunkData, int localX, int localZ, int baseY, BiomeType biome, int worldX, int worldZ);
-  void placeOakTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeBirchTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeSpruceTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeJungleTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeAcaciaTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeDarkOakTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeCherryTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeRedwoodTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placePalmTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeMangroveTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeBamboo(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeGiantMushroom(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeCactus(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
-  void placeIceSpike(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void generateVegetation(const ChunkGenerationTarget &chunkData, int chunkX, int chunkZ);
+  void placeTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, BiomeType biome, int worldX, int worldZ);
+  void placeOakTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeBirchTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeSpruceTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeJungleTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeAcaciaTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeDarkOakTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeCherryTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeRedwoodTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placePalmTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeMangroveTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeBamboo(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeGiantMushroom(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeCactus(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
+  void placeIceSpike(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ);
 
   // Per-tree deterministic RNG from world position
   static inline uint32_t treeHash(int worldX, int worldZ, int seed)
@@ -373,7 +403,7 @@ private:
   }
 
   // Safe voxel setting (bounds checking)
-  inline bool setVoxelSafe(ChunkData &chunkData, int x, int y, int z, TextureType type)
+  inline bool setVoxelSafe(const ChunkGenerationTarget &chunkData, int x, int y, int z, TextureType type)
   {
     if (x < 0 || x >= CHUNK_SIZE || z < 0 || z >= CHUNK_SIZE ||
         y < 0 || y >= CHUNK_HEIGHT)

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -38,12 +38,15 @@ constexpr size_t kBorderVoxelCount =
 // to memory owned by the caller - pooled Chunk storage at runtime, an owning
 // ChunkData in tests/tools. generateChunkInto() fully resets every field
 // before generating, so reused storage cannot leak data between chunks.
-// View semantics: a const target still allows writing through its spans
-// (only the span members themselves are protected).
+// Fixed extents make a wrong-sized destination a type-level contract
+// (debug-verified at construction from sized ranges) instead of a runtime
+// check on the hot path. View semantics: a const target still allows
+// writing through its spans (only the span members themselves are
+// protected).
 struct ChunkGenerationTarget
 {
-  std::span<Voxel> voxels;                // size() == CHUNK_VOLUME
-  std::span<uint8_t> borderVoxels;        // size() == kBorderVoxelCount
+  std::span<Voxel, CHUNK_VOLUME> voxels;
+  std::span<uint8_t, kBorderVoxelCount> borderVoxels;
   std::span<BiomeType, CHUNK_SIZE * CHUNK_SIZE> biomes;
   std::span<int, CHUNK_SIZE * CHUNK_SIZE> heightMap;
   std::span<uint32_t, CHUNK_SIZE * CHUNK_SIZE> grassColors;

--- a/src/Chunk/TerrainVegetation.cpp
+++ b/src/Chunk/TerrainVegetation.cpp
@@ -5,7 +5,7 @@
 // Vegetation placers (trees, cactus, ice spikes) — split out of TerrainGenerator.cpp
 // so core noise/batch generation stays scannable.
 
-void TerrainGenerator::placeTree(ChunkData &chunkData, int localX, int localZ,
+void TerrainGenerator::placeTree(const ChunkGenerationTarget &chunkData, int localX, int localZ,
                                  int baseY, BiomeType biome, int worldX, int worldZ)
 {
   // Mix tree types within biomes for variety
@@ -89,7 +89,7 @@ void TerrainGenerator::placeTree(ChunkData &chunkData, int localX, int localZ,
   }
 }
 
-void TerrainGenerator::placeOakTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
+void TerrainGenerator::placeOakTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
 {
   uint32_t h = treeHash(worldX, worldZ, m_seed + 100);
 
@@ -129,7 +129,7 @@ void TerrainGenerator::placeOakTree(ChunkData &chunkData, int localX, int localZ
   }
 }
 
-void TerrainGenerator::placeBirchTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
+void TerrainGenerator::placeBirchTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
 {
   uint32_t h = treeHash(worldX, worldZ, m_seed + 150);
 
@@ -164,7 +164,7 @@ void TerrainGenerator::placeBirchTree(ChunkData &chunkData, int localX, int loca
   }
 }
 
-void TerrainGenerator::placeSpruceTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
+void TerrainGenerator::placeSpruceTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
 {
   uint32_t h = treeHash(worldX, worldZ, m_seed + 300);
 
@@ -209,7 +209,7 @@ void TerrainGenerator::placeSpruceTree(ChunkData &chunkData, int localX, int loc
   }
 }
 
-void TerrainGenerator::placeJungleTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
+void TerrainGenerator::placeJungleTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
 {
   uint32_t h = treeHash(worldX, worldZ, m_seed + 400);
 
@@ -259,7 +259,7 @@ void TerrainGenerator::placeJungleTree(ChunkData &chunkData, int localX, int loc
   }
 }
 
-void TerrainGenerator::placeAcaciaTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
+void TerrainGenerator::placeAcaciaTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
 {
   uint32_t h = treeHash(worldX, worldZ, m_seed + 450);
 
@@ -300,7 +300,7 @@ void TerrainGenerator::placeAcaciaTree(ChunkData &chunkData, int localX, int loc
   }
 }
 
-void TerrainGenerator::placeDarkOakTree(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
+void TerrainGenerator::placeDarkOakTree(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
 {
   uint32_t h = treeHash(worldX, worldZ, m_seed + 480);
 
@@ -351,7 +351,7 @@ void TerrainGenerator::placeDarkOakTree(ChunkData &chunkData, int localX, int lo
   }
 }
 
-void TerrainGenerator::placeCherryTree(ChunkData &chunkData, int localX, int localZ,
+void TerrainGenerator::placeCherryTree(const ChunkGenerationTarget &chunkData, int localX, int localZ,
                                        int baseY, int worldX, int worldZ)
 {
   const uint32_t h = treeHash(worldX, worldZ, m_seed + 520);
@@ -380,7 +380,7 @@ void TerrainGenerator::placeCherryTree(ChunkData &chunkData, int localX, int loc
   }
 }
 
-void TerrainGenerator::placeRedwoodTree(ChunkData &chunkData, int localX, int localZ,
+void TerrainGenerator::placeRedwoodTree(const ChunkGenerationTarget &chunkData, int localX, int localZ,
                                         int baseY, int worldX, int worldZ)
 {
   const uint32_t h = treeHash(worldX, worldZ, m_seed + 540);
@@ -418,7 +418,7 @@ void TerrainGenerator::placeRedwoodTree(ChunkData &chunkData, int localX, int lo
   setVoxelSafe(chunkData, localX + 1, topY + 1, localZ, TextureType::SPRUCE_LEAVES);
 }
 
-void TerrainGenerator::placePalmTree(ChunkData &chunkData, int localX, int localZ,
+void TerrainGenerator::placePalmTree(const ChunkGenerationTarget &chunkData, int localX, int localZ,
                                      int baseY, int worldX, int worldZ)
 {
   const uint32_t h = treeHash(worldX, worldZ, m_seed + 560);
@@ -451,7 +451,7 @@ void TerrainGenerator::placePalmTree(ChunkData &chunkData, int localX, int local
   }
 }
 
-void TerrainGenerator::placeMangroveTree(ChunkData &chunkData, int localX, int localZ,
+void TerrainGenerator::placeMangroveTree(const ChunkGenerationTarget &chunkData, int localX, int localZ,
                                          int baseY, int worldX, int worldZ)
 {
   const uint32_t h = treeHash(worldX, worldZ, m_seed + 580);
@@ -496,7 +496,7 @@ void TerrainGenerator::placeMangroveTree(ChunkData &chunkData, int localX, int l
   }
 }
 
-void TerrainGenerator::placeBamboo(ChunkData &chunkData, int localX, int localZ,
+void TerrainGenerator::placeBamboo(const ChunkGenerationTarget &chunkData, int localX, int localZ,
                                    int baseY, int worldX, int worldZ)
 {
   const uint32_t h = treeHash(worldX, worldZ, m_seed + 600);
@@ -509,7 +509,7 @@ void TerrainGenerator::placeBamboo(ChunkData &chunkData, int localX, int localZ,
   }
 }
 
-void TerrainGenerator::placeGiantMushroom(ChunkData &chunkData, int localX,
+void TerrainGenerator::placeGiantMushroom(const ChunkGenerationTarget &chunkData, int localX,
                                           int localZ, int baseY, int worldX,
                                           int worldZ)
 {
@@ -538,7 +538,7 @@ void TerrainGenerator::placeGiantMushroom(ChunkData &chunkData, int localX,
   setVoxelSafe(chunkData, localX, topY + 1, localZ, cap);
 }
 
-void TerrainGenerator::placeCactus(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
+void TerrainGenerator::placeCactus(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
 {
   uint32_t h = treeHash(worldX, worldZ, m_seed + 500);
   int height = 1 + static_cast<int>(h & 3); // 1–4 blocks
@@ -567,7 +567,7 @@ void TerrainGenerator::placeCactus(ChunkData &chunkData, int localX, int localZ,
   }
 }
 
-void TerrainGenerator::placeIceSpike(ChunkData &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
+void TerrainGenerator::placeIceSpike(const ChunkGenerationTarget &chunkData, int localX, int localZ, int baseY, int worldX, int worldZ)
 {
   uint32_t h = treeHash(worldX, worldZ, m_seed + 600);
   int height = 8 + static_cast<int>(h % 18); // 8–25 tall

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -258,6 +258,20 @@ target_link_libraries(test_chunk_lifecycle PRIVATE
     Threads::Threads
 )
 
+if(UNIX AND NOT APPLE)
+    target_link_libraries(test_chunk_lifecycle PRIVATE ${CMAKE_DL_LIBS})
+endif()
+
+if(APPLE)
+    target_link_libraries(test_chunk_lifecycle PRIVATE
+        "-framework Metal"
+        "-framework Foundation"
+        "-framework QuartzCore"
+        "-framework IOKit"
+        "-framework IOSurface"
+    )
+endif()
+
 add_test(NAME ChunkLifecycle COMMAND test_chunk_lifecycle)
 
 # ---------------------------------------------------------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -220,6 +220,47 @@ target_link_libraries(test_biome_map PRIVATE
 add_test(NAME BiomeMapGeneration COMMAND test_biome_map)
 
 # ---------------------------------------------------------------------------
+# Chunk lifecycle (issue #78 review): move semantics + direct pooled
+# generation via Chunk::generateTerrain. Links the Vulkan buffer helpers
+# Chunk.cpp depends on; never touches a real device.
+# ---------------------------------------------------------------------------
+add_executable(test_chunk_lifecycle
+    test_chunk_lifecycle.cpp
+    ${CMAKE_SOURCE_DIR}/src/Chunk/Chunk.cpp
+    ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainGenerator.cpp
+    ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainVegetation.cpp
+    ${FT_VOX_VULKAN_SOURCES}
+)
+
+target_include_directories(test_chunk_lifecycle PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${Vulkan_INCLUDE_DIRS}
+)
+
+target_compile_definitions(test_chunk_lifecycle PRIVATE
+    VK_NO_PROTOTYPES
+    GLM_FORCE_DEPTH_ZERO_TO_ONE
+    GLM_ENABLE_EXPERIMENTAL
+)
+
+if(APPLE)
+    target_compile_definitions(test_chunk_lifecycle PRIVATE VK_USE_PLATFORM_METAL_EXT)
+elseif(WIN32)
+    target_compile_definitions(test_chunk_lifecycle PRIVATE VK_USE_PLATFORM_WIN32_KHR)
+endif()
+
+target_link_libraries(test_chunk_lifecycle PRIVATE
+    glm
+    FastNoise2
+    SDL3::SDL3
+    volk::volk
+    GPUOpen::VulkanMemoryAllocator
+    Threads::Threads
+)
+
+add_test(NAME ChunkLifecycle COMMAND test_chunk_lifecycle)
+
+# ---------------------------------------------------------------------------
 # Profiler worker consistency and stress test (Issue #79)
 # ---------------------------------------------------------------------------
 add_executable(test_profiler

--- a/tests/test_chunk_lifecycle.cpp
+++ b/tests/test_chunk_lifecycle.cpp
@@ -1,0 +1,202 @@
+// Chunk lifecycle (issue #78 review): move semantics must carry the FULL
+// generation state (including the per-column biomeTypes/heightMap added by
+// the direct-to-pooled-storage change), and generateTerrain() must produce
+// data identical to the owning generateChunk() path directly into reusable
+// pooled-style storage across reset/regenerate cycles - with the
+// activeVoxels cache staying in sync and no capacity churn.
+#include <Chunk/Chunk.hpp>
+#include <Chunk/TerrainGenerator.hpp>
+
+#include <algorithm>
+#include <array>
+#include <bitset>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+static int g_fails = 0;
+
+#define CHECK(cond, msg)                                                       \
+	do                                                                         \
+	{                                                                          \
+		if (!(cond))                                                           \
+		{                                                                      \
+			std::cerr << "FAIL: " << msg << " (" << __LINE__ << ")\n";         \
+			++g_fails;                                                         \
+		}                                                                      \
+	} while (0)
+
+// Friend probe declared in Chunk.hpp: verifies full private state without
+// exposing per-column generation data through the public API.
+struct ChunkStateProbe
+{
+	static const std::vector<Voxel> &voxels(const Chunk &c) { return c.voxels; }
+	static const std::vector<uint8_t> &shell(const Chunk &c)
+	{
+		return c.neighborShellVoxels;
+	}
+	static const std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> &grass(const Chunk &c)
+	{
+		return c.biomeGrassColors;
+	}
+	static const std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> &foliage(const Chunk &c)
+	{
+		return c.biomeFoliageColors;
+	}
+	static const std::array<BiomeType, CHUNK_SIZE * CHUNK_SIZE> &biomes(const Chunk &c)
+	{
+		return c.biomeTypes;
+	}
+	static const std::array<int, CHUNK_SIZE * CHUNK_SIZE> &heights(const Chunk &c)
+	{
+		return c.heightMap;
+	}
+	static const std::bitset<CHUNK_VOLUME> &active(const Chunk &c)
+	{
+		return c.activeVoxels;
+	}
+};
+
+struct ChunkSnapshot
+{
+	std::vector<Voxel> voxels;
+	std::vector<uint8_t> shell;
+	std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> grass{};
+	std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> foliage{};
+	std::array<BiomeType, CHUNK_SIZE * CHUNK_SIZE> biomes{};
+	std::array<int, CHUNK_SIZE * CHUNK_SIZE> heights{};
+	std::bitset<CHUNK_VOLUME> active;
+	ChunkState state{ChunkState::UNLOADED};
+
+	static ChunkSnapshot capture(const Chunk &c)
+	{
+		ChunkSnapshot s;
+		s.voxels = ChunkStateProbe::voxels(c);
+		s.shell = ChunkStateProbe::shell(c);
+		s.grass = ChunkStateProbe::grass(c);
+		s.foliage = ChunkStateProbe::foliage(c);
+		s.biomes = ChunkStateProbe::biomes(c);
+		s.heights = ChunkStateProbe::heights(c);
+		s.active = ChunkStateProbe::active(c);
+		s.state = c.getState();
+		return s;
+	}
+};
+
+static bool sameVoxels(const std::vector<Voxel> &a, const std::vector<Voxel> &b)
+{
+	return a.size() == b.size() &&
+		   std::memcmp(a.data(), b.data(), a.size() * sizeof(Voxel)) == 0;
+}
+
+static bool sameState(const ChunkSnapshot &a, const ChunkSnapshot &b)
+{
+	return a.state == b.state && sameVoxels(a.voxels, b.voxels) &&
+		   a.shell == b.shell && a.grass == b.grass &&
+		   a.foliage == b.foliage && a.biomes == b.biomes &&
+		   a.heights == b.heights && a.active == b.active;
+}
+
+/// Every non-air voxel must have its activeVoxels bit set and vice versa -
+/// the direct-generation path rebuilds this cache from the same buffer it
+/// generated into, so a storage change could desynchronize them.
+static void checkActiveCacheInSync(const Chunk &chunk, const char *label)
+{
+	const auto &voxels = ChunkStateProbe::voxels(chunk);
+	const auto &active = ChunkStateProbe::active(chunk);
+	bool inSync = voxels.size() == CHUNK_VOLUME;
+	for (size_t i = 0; inSync && i < CHUNK_VOLUME; ++i)
+		inSync = active[i] == (voxels[i].type != static_cast<uint8_t>(AIR));
+	CHECK(inSync, label);
+}
+
+static void checkMatchesOwning(const Chunk &chunk, TerrainGenerator &gen,
+							   int chunkX, int chunkZ, const char *label)
+{
+	const ChunkData reference = gen.generateChunk(chunkX, chunkZ);
+	const auto &shell = ChunkStateProbe::shell(chunk);
+	CHECK(shell.size() == kBorderVoxelCount, "shell fully sized after generation");
+	CHECK(std::memcmp(reference.voxels.data(),
+					  ChunkStateProbe::voxels(chunk).data(),
+					  CHUNK_VOLUME * sizeof(Voxel)) == 0,
+		  "voxels match owning path");
+	CHECK(std::memcmp(reference.borderVoxels.data(), shell.data(),
+					  shell.size()) == 0,
+		  "shell matches owning path");
+	CHECK(std::equal(reference.grassColors.begin(), reference.grassColors.end(),
+					 ChunkStateProbe::grass(chunk).begin()),
+		  "grass colors match owning path");
+	CHECK(std::equal(reference.foliageColors.begin(), reference.foliageColors.end(),
+					 ChunkStateProbe::foliage(chunk).begin()),
+		  "foliage colors match owning path");
+	CHECK(std::equal(reference.biomes.begin(), reference.biomes.end(),
+					 ChunkStateProbe::biomes(chunk).begin()),
+		  "biomes match owning path");
+	CHECK(std::equal(reference.heightMap.begin(), reference.heightMap.end(),
+					 ChunkStateProbe::heights(chunk).begin()),
+		  "height map matches owning path");
+}
+
+int main()
+{
+	constexpr int kSeed = 4242;
+	TerrainGenerator gen(kSeed);
+
+	// 1) generateTerrain fills complete, correct state at position A.
+	Chunk a(glm::vec3(0.0f, 0.0f, 0.0f));
+	CHECK(a.getState() == ChunkState::UNLOADED, "fresh chunk starts UNLOADED");
+	a.generateTerrain(gen);
+	CHECK(a.getState() == ChunkState::GENERATED, "generation completes");
+	CHECK(ChunkStateProbe::voxels(a).size() == static_cast<size_t>(CHUNK_VOLUME),
+		  "voxel storage fully sized");
+	checkActiveCacheInSync(a, "activeVoxels cache in sync after generation");
+	checkMatchesOwning(a, gen, 0, 0, "initial generation");
+	const ChunkSnapshot snapA = ChunkSnapshot::capture(a);
+	// A generated chunk must not be trivially empty (a real surface chunk
+	// carries thousands of solid blocks; an empty/reset one would be ~0).
+	int solid = 0;
+	for (size_t i = 0; i < CHUNK_VOLUME; ++i)
+		solid += snapA.voxels[i].type != static_cast<uint8_t>(AIR);
+	CHECK(solid > 1024, "generation produced substantial terrain");
+
+	// 2) Move-construction carries the full generation state.
+	Chunk b(std::move(a));
+	const ChunkSnapshot snapB = ChunkSnapshot::capture(b);
+	CHECK(sameState(snapA, snapB),
+		  "move-constructor must preserve full generation state");
+	CHECK(b.getState() == ChunkState::GENERATED, "moved chunk keeps GENERATED");
+
+	// 3) Move-assignment carries the full generation state.
+	Chunk c(glm::vec3(9876.0f, 0.0f, -4321.0f));
+	c = std::move(b);
+	const ChunkSnapshot snapC = ChunkSnapshot::capture(c);
+	CHECK(sameState(snapA, snapC),
+		  "move-assignment must preserve full generation state");
+
+	// 4) Pool-like recycle: reset + regenerate at a new position must match
+	// the owning path for the new coordinate, keep the active cache in sync,
+	// and never grow the buffers (capacity churn would defeat ChunkPool).
+	const size_t voxelCapacity = ChunkStateProbe::voxels(c).capacity();
+	const size_t shellCapacity = ChunkStateProbe::shell(c).capacity();
+
+	c.reset(glm::vec3(static_cast<float>(CHUNK_SIZE), 0.0f,
+					  static_cast<float>(CHUNK_SIZE)));
+	CHECK(c.getState() == ChunkState::UNLOADED, "reset returns chunk to UNLOADED");
+	c.generateTerrain(gen);
+	CHECK(c.getState() == ChunkState::GENERATED, "regeneration completes");
+	checkMatchesOwning(c, gen, CHUNK_SIZE, CHUNK_SIZE, "recycled generation");
+	checkActiveCacheInSync(c, "activeVoxels cache in sync after recycle");
+	CHECK(ChunkStateProbe::voxels(c).capacity() == voxelCapacity,
+		  "voxel capacity stable across recycle");
+	CHECK(ChunkStateProbe::shell(c).capacity() == shellCapacity,
+		  "shell capacity stable across recycle");
+
+	if (g_fails != 0)
+	{
+		std::cerr << g_fails << " check(s) failed\n";
+		return 1;
+	}
+	std::cout << "PASS: chunk lifecycle - moves carry full state, "
+			  << "recycled generateTerrain matches owning path, capacities stable\n";
+	return 0;
+}

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -382,8 +382,10 @@ struct TargetBuffers
 	ChunkGenerationTarget target()
 	{
 		return ChunkGenerationTarget{
-			.voxels = voxels, .borderVoxels = shell, .biomes = biomes,
-			.heightMap = heightMap, .grassColors = grass, .foliageColors = foliage};
+			.voxels = std::span<Voxel, CHUNK_VOLUME>(voxels),
+			.borderVoxels = std::span<uint8_t, kBorderVoxelCount>(shell),
+			.biomes = biomes, .heightMap = heightMap,
+			.grassColors = grass, .foliageColors = foliage};
 	}
 
 	void poison()
@@ -397,20 +399,23 @@ struct TargetBuffers
 	}
 };
 
+/// Byte-compare the raw buffers (voxels/shell are byte-oriented: Voxel is a
+/// single uint8_t) and semantically compare the typed arrays via
+/// std::equal - portable and independent of representation.
 static bool chunkDataMatchesTarget(const ChunkData &reference, const TargetBuffers &buffers)
 {
 	return std::memcmp(reference.voxels.data(), buffers.voxels.data(),
 					   CHUNK_VOLUME * sizeof(Voxel)) == 0 &&
 		   std::memcmp(reference.borderVoxels.data(), buffers.shell.data(),
 					   buffers.shell.size()) == 0 &&
-		   std::memcmp(reference.biomes.data(), buffers.biomes.data(),
-					   sizeof(buffers.biomes)) == 0 &&
-		   std::memcmp(reference.heightMap.data(), buffers.heightMap.data(),
-					   sizeof(buffers.heightMap)) == 0 &&
-		   std::memcmp(reference.grassColors.data(), buffers.grass.data(),
-					   sizeof(buffers.grass)) == 0 &&
-		   std::memcmp(reference.foliageColors.data(), buffers.foliage.data(),
-					   sizeof(buffers.foliage)) == 0;
+		   std::equal(reference.biomes.begin(), reference.biomes.end(),
+					  buffers.biomes.begin()) &&
+		   std::equal(reference.heightMap.begin(), reference.heightMap.end(),
+					  buffers.heightMap.begin()) &&
+		   std::equal(reference.grassColors.begin(), reference.grassColors.end(),
+					  buffers.grass.begin()) &&
+		   std::equal(reference.foliageColors.begin(), reference.foliageColors.end(),
+					  buffers.foliage.begin());
 }
 
 /// generateChunkInto (the streaming hot path) must reproduce the owning
@@ -434,16 +439,28 @@ static void testGenerateChunkIntoTarget()
 			  "generateChunkInto matches owning generateChunk");
 	}
 
-	// 2) Reuse reset: poisoned storage from a previous generation must be
-	// fully overwritten - every field, every voxel.
+	// 2) Pool-like reuse: poisoned storage from a previous generation must
+	// be fully overwritten - every field, every voxel - and successive
+	// generations into the SAME buffers through very different terrain
+	// (far-apart coords) must each match the owning path exactly. Buffer
+	// capacity must never change: generateChunkInto() may not reallocate.
 	TargetBuffers reused;
 	reused.poison();
-	gen.generateChunkInto(64, 96, reused.target());
+	const size_t voxelCapacity = reused.voxels.capacity();
+	const size_t shellCapacity = reused.shell.capacity();
+	const int reuseCoords[][2] = {
+		{64, 96}, {4096, -4096}, {-8192, 8192}};
+	for (const auto &coord : reuseCoords)
 	{
-		const ChunkData reference = gen.generateChunk(64, 96);
+		gen.generateChunkInto(coord[0], coord[1], reused.target());
+		const ChunkData reference = gen.generateChunk(coord[0], coord[1]);
 		CHECK(chunkDataMatchesTarget(reference, reused),
 			  "poisoned reuse leaves no leaked data");
 	}
+	CHECK(reused.voxels.capacity() == voxelCapacity,
+		  "reused voxel capacity stable across generations");
+	CHECK(reused.shell.capacity() == shellCapacity,
+		  "reused shell capacity stable across generations");
 
 	// 3) Concurrent generation into per-thread buffers (thread-local
 	// generators) must match the sequential owning path.
@@ -473,7 +490,8 @@ static void testGenerateChunkIntoTarget()
 	CHECK(concurrentOk, "concurrent generateChunkInto matches owning path");
 
 	std::cout << "generateChunkInto: byte-identical on " << std::size(coords)
-			  << " chunks, poisoned reuse fully reset, "
+			  << " chunks, poisoned reuse fully reset across "
+			  << std::size(reuseCoords) << " sequential coords, capacities stable, "
 			  << std::size(threaded) << " concurrent chunks match\n";
 }
 
@@ -1502,6 +1520,93 @@ static int oreGroup(TextureType type)
 	default:
 		return -1;
 	}
+}
+
+/// Issue #78 review: informative wall-clock comparison between the owning
+/// path and the pooled-target path over identical coordinates. NOT a CI
+/// gate (runner variance) - the deterministic criteria are structural and
+/// live in testGenerateChunkIntoTarget (capacity stability, byte equality).
+///   ./test_terrain --gen-perf [chunks] [seed]
+static int runGenPerf(int argc, char **argv)
+{
+	const int chunks = (argc > 2) ? std::clamp(std::atoi(argv[2]), 1, 100000) : 500;
+	const int seed = (argc > 3) ? std::atoi(argv[3]) : 1337;
+
+	TerrainGenerator gen(seed);
+	constexpr int kSpan = 8; // 8x8 chunk region, revisited ring
+	auto coordFor = [](int i, int &cx, int &cz) {
+		cx = (i % kSpan) * CHUNK_SIZE;
+		cz = (i / kSpan) * CHUNK_SIZE;
+	};
+
+	using Clock = std::chrono::steady_clock;
+
+	// Warm-up both paths (caches, allocator).
+	{
+		TargetBuffers warm;
+		for (int i = 0; i < 16; ++i)
+		{
+			int cx, cz;
+			coordFor(i, cx, cz);
+			auto owned = gen.generateChunk(cx, cz);
+			(void)owned;
+			gen.generateChunkInto(cx, cz, warm.target());
+		}
+	}
+
+	// A. owning path: allocates + frees a ChunkData per chunk (old hot path).
+	double owningMsPerChunk = 0.0;
+	{
+		const auto start = Clock::now();
+		for (int i = 0; i < chunks; ++i)
+		{
+			int cx, cz;
+			coordFor(i, cx, cz);
+			auto owned = gen.generateChunk(cx, cz);
+			(void)owned;
+		}
+		const double totalMs =
+			std::chrono::duration<double, std::milli>(Clock::now() - start)
+				.count();
+		owningMsPerChunk = totalMs / chunks;
+	}
+
+	// B. pooled-target path: same buffers reused every iteration.
+	TargetBuffers reusable;
+	const size_t voxelCapacity = reusable.voxels.capacity();
+	const size_t shellCapacity = reusable.shell.capacity();
+	double pooledMsPerChunk = 0.0;
+	{
+		const auto start = Clock::now();
+		for (int i = 0; i < chunks; ++i)
+		{
+			int cx, cz;
+			coordFor(i, cx, cz);
+			gen.generateChunkInto(cx, cz, reusable.target());
+		}
+		const double totalMs =
+			std::chrono::duration<double, std::milli>(Clock::now() - start)
+				.count();
+		pooledMsPerChunk = totalMs / chunks;
+	}
+	const bool capacityStable =
+		reusable.voxels.capacity() == voxelCapacity &&
+		reusable.shell.capacity() == shellCapacity;
+
+	const double deltaPct =
+		owningMsPerChunk > 0.0
+			? (pooledMsPerChunk - owningMsPerChunk) / owningMsPerChunk * 100.0
+			: 0.0;
+
+	std::cout << "[Chunk Gen Perf] seed=" << seed << " chunks=" << chunks
+			  << "\nowning:      " << owningMsPerChunk << " ms/chunk"
+			  << "\npooled-into: " << pooledMsPerChunk << " ms/chunk"
+			  << "\ndelta:       " << deltaPct << "%"
+			  << "\nreused-buffer capacity stable: "
+			  << (capacityStable ? "yes" : "NO") << "\n";
+
+	CHECK(capacityStable, "gen-perf reused-buffer capacity must stay stable");
+	return g_fails != 0 ? 1 : 0;
 }
 
 static int runWorldStats(int argc, char **argv)
@@ -2629,6 +2734,8 @@ int main(int argc, char **argv)
 		return runHeightHistogram(argc, argv);
 	if (argc > 1 && std::strcmp(argv[1], "--profile") == 0)
 		return runTerrainProfile(argc, argv);
+	if (argc > 1 && std::strcmp(argv[1], "--gen-perf") == 0)
+		return runGenPerf(argc, argv);
 	if (argc > 1 && std::strcmp(argv[1], "--world-stats") == 0)
 		return runWorldStats(argc, argv);
 

--- a/tests/test_terrain.cpp
+++ b/tests/test_terrain.cpp
@@ -364,6 +364,119 @@ static EdgeStats checkEdge(const ChunkData &owner, int shellLx, int shellLz,
 	return stats;
 }
 
+// ---------------------------------------------------------------------------
+// Generation into caller-owned storage (issue #78)
+// ---------------------------------------------------------------------------
+
+struct TargetBuffers
+{
+	std::vector<Voxel> voxels;
+	std::vector<uint8_t> shell;
+	std::array<BiomeType, CHUNK_SIZE * CHUNK_SIZE> biomes{};
+	std::array<int, CHUNK_SIZE * CHUNK_SIZE> heightMap{};
+	std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> grass{};
+	std::array<uint32_t, CHUNK_SIZE * CHUNK_SIZE> foliage{};
+
+	TargetBuffers() : voxels(CHUNK_VOLUME), shell(kBorderVoxelCount) {}
+
+	ChunkGenerationTarget target()
+	{
+		return ChunkGenerationTarget{
+			.voxels = voxels, .borderVoxels = shell, .biomes = biomes,
+			.heightMap = heightMap, .grassColors = grass, .foliageColors = foliage};
+	}
+
+	void poison()
+	{
+		std::fill(voxels.begin(), voxels.end(), Voxel{static_cast<uint8_t>(0xAA)});
+		std::fill(shell.begin(), shell.end(), static_cast<uint8_t>(0xFF));
+		biomes.fill(static_cast<BiomeType>(0x7F));
+		heightMap.fill(-123456);
+		grass.fill(0xDEADBEEFu);
+		foliage.fill(0xDEADBEEFu);
+	}
+};
+
+static bool chunkDataMatchesTarget(const ChunkData &reference, const TargetBuffers &buffers)
+{
+	return std::memcmp(reference.voxels.data(), buffers.voxels.data(),
+					   CHUNK_VOLUME * sizeof(Voxel)) == 0 &&
+		   std::memcmp(reference.borderVoxels.data(), buffers.shell.data(),
+					   buffers.shell.size()) == 0 &&
+		   std::memcmp(reference.biomes.data(), buffers.biomes.data(),
+					   sizeof(buffers.biomes)) == 0 &&
+		   std::memcmp(reference.heightMap.data(), buffers.heightMap.data(),
+					   sizeof(buffers.heightMap)) == 0 &&
+		   std::memcmp(reference.grassColors.data(), buffers.grass.data(),
+					   sizeof(buffers.grass)) == 0 &&
+		   std::memcmp(reference.foliageColors.data(), buffers.foliage.data(),
+					   sizeof(buffers.foliage)) == 0;
+}
+
+/// generateChunkInto (the streaming hot path) must reproduce the owning
+/// generateChunk byte-for-byte, fully reset reused storage (no data may leak
+/// from a previously generated chunk), and stay deterministic when driven
+/// concurrently from per-thread generators.
+static void testGenerateChunkIntoTarget()
+{
+	constexpr int kSeed = 777;
+	TerrainGenerator gen(kSeed);
+	const int coords[][2] = {
+		{0, 0}, {CHUNK_SIZE, -CHUNK_SIZE}, {-5 * CHUNK_SIZE, 3 * CHUNK_SIZE}, {160, -80}};
+
+	// 1) Fresh-buffer equivalence with the owning path.
+	for (const auto &coord : coords)
+	{
+		const ChunkData reference = gen.generateChunk(coord[0], coord[1]);
+		TargetBuffers buffers;
+		gen.generateChunkInto(coord[0], coord[1], buffers.target());
+		CHECK(chunkDataMatchesTarget(reference, buffers),
+			  "generateChunkInto matches owning generateChunk");
+	}
+
+	// 2) Reuse reset: poisoned storage from a previous generation must be
+	// fully overwritten - every field, every voxel.
+	TargetBuffers reused;
+	reused.poison();
+	gen.generateChunkInto(64, 96, reused.target());
+	{
+		const ChunkData reference = gen.generateChunk(64, 96);
+		CHECK(chunkDataMatchesTarget(reference, reused),
+			  "poisoned reuse leaves no leaked data");
+	}
+
+	// 3) Concurrent generation into per-thread buffers (thread-local
+	// generators) must match the sequential owning path.
+	const std::pair<int, int> threaded[] = {
+		{0, 0}, {CHUNK_SIZE, -CHUNK_SIZE}, {-160, 96}, {512, 512}};
+	std::vector<ChunkData> references;
+	references.reserve(std::size(threaded));
+	for (const auto &coord : threaded)
+		references.push_back(gen.generateChunk(coord.first, coord.second));
+
+	std::vector<std::future<bool>> futures;
+	futures.reserve(std::size(threaded));
+	for (size_t reverse = std::size(threaded); reverse-- > 0;)
+	{
+		futures.push_back(std::async(std::launch::async,
+			[&references, &threaded, reverse]() {
+				TargetBuffers local;
+				TerrainGenerator::getThreadLocal(kSeed).generateChunkInto(
+					threaded[reverse].first, threaded[reverse].second,
+					local.target());
+				return chunkDataMatchesTarget(references[reverse], local);
+			}));
+	}
+	bool concurrentOk = true;
+	for (auto &future : futures)
+		concurrentOk = future.get() && concurrentOk;
+	CHECK(concurrentOk, "concurrent generateChunkInto matches owning path");
+
+	std::cout << "generateChunkInto: byte-identical on " << std::size(coords)
+			  << " chunks, poisoned reuse fully reset, "
+			  << std::size(threaded) << " concurrent chunks match\n";
+}
+
 static void testBorderConsistency()
 {
 	constexpr int kSeed = 777;
@@ -2525,6 +2638,7 @@ int main(int argc, char **argv)
 	testDeterminismSameSeed();
 	testDifferentSeedsDiffer();
 	testConcurrentAndMultiSeedDeterminism();
+	testGenerateChunkIntoTarget();
 	testTerrainProfilingDoesNotChangeOutput();
 	testBorderConsistency();
 	testBorderTrunks();


### PR DESCRIPTION
The streaming hot path allocated a temporary ChunkData for every generated chunk (a 65,536-voxel vector plus the 18x258x18 neighbor shell), filled it, copied both into the already-allocated pooled Chunk storage, then destroyed the temporaries - allocator traffic and memory bandwidth exactly where ChunkPool was supposed to save us.

## Generation API

- **`ChunkGenerationTarget`**: caller-owned destination storage as spans (voxels, border shell, biomes, heightMap, grass/foliage colors). `voxels`/`borderVoxels` are **fixed-extent spans** (`std::span<Voxel, CHUNK_VOLUME>`, `std::span<uint8_t, kBorderVoxelCount>`), so a wrong-sized destination is a type-level contract (debug-verified at construction) instead of a release-compiled-out assert. View semantics: a const target still allows writing through its spans.
- **`TerrainGenerator::generateChunkInto(chunkX, chunkZ, target)`**: runs the unchanged batch/vegetation/border pipeline directly into the target, with reset semantics - every destination field is fully re-initialized first, so nothing leaks between pooled chunks.
- **`generateChunk()`** remains as a thin owning wrapper for tests/tools; the streaming hot path no longer uses it. Profiling counters live in `generateChunkInto`, so both paths profile identically.
- The internal pipeline (generateChunkBatch, generateVegetation + place* helpers, generateChunkBorders, setVoxelSafe) takes the target instead of `ChunkData&`; bodies unchanged.

## Chunk integration

- `Chunk::generateTerrain()` sizes its pooled vectors once (capacity survives pool recycles) and passes them plus the biome colors and new per-column `biomeTypes`/`heightMap` arrays straight to `generateChunkInto`: no temporary ChunkData, no CHUNK_VOLUME copy, no border-shell copy.
- **Move semantics carry the full generation state**: the move constructor and move assignment transfer `biomeTypes`/`heightMap` alongside everything else (a regression test guards this).
- `setVoxels()` (whose only caller was the eliminated copy) removed; `Chunk::reset()` clears the new per-column state.

## Tests

- **new `test_chunk_lifecycle` target** (links real Chunk.cpp, no Vulkan device): generateTerrain output byte-identical to the owning path (voxels, shell, colors, biomes, height map), `activeVoxels` cache in perfect sync with the buffer, move-construction/move-assignment preserve full state, pool-style reset+regeneration matches the owning path with stable capacities. Private state reached via a `ChunkStateProbe` friend - no public API added.
- `testGenerateChunkIntoTarget`: byte-identical vs owning path, **poisoned reuse** fully overwritten through three very different far-apart chunks in the same buffers, typed arrays compared with `std::equal`, capacity-stability checks.
- Concurrent `generateChunkInto` from per-thread generators matches the sequential reference.

## Benchmark (Release, Windows, `--gen-perf 500 1337`, informative - not a CI gate)

```
owning:      1.209 ms/chunk
pooled-into: 1.206 ms/chunk
delta:       -0.3%
reused-buffer capacity stable: yes
```

Pure single-threaded generation time is essentially unchanged; the win is structural: zero steady-state voxel/shell allocation per chunk and zero post-generation copies. Under concurrent streaming this removes allocator contention and memory bandwidth from the worker hot path. Runtime streaming (`ft_vox --seed 42 --benchmark 20`) is clean through the new path: 9,598 TerrainGen jobs, 3,024-chunk peak, no errors.

## Validation

- build clean; test_terrain, test_stream_opt, test_chunk_lifecycle pass
- ctest **9/9** (new ChunkLifecycle test)
- ASan clean on test_terrain, test_stream_opt and test_chunk_lifecycle
- runtime streaming smoke: `--seed 42 --benchmark 20` clean (numbers above); visual smoke over long fast flights still worth a manual pass before merge

Known follow-up: the pooled voxel buffer is currently cleared twice per acquisition (`Chunk::reset()` then `generateChunkInto()` reset) - tracked in #93, intentionally out of scope here.

Close #78


## Platform link blocks for test_chunk_lifecycle (review follow-up, 109b1ba)

The ChunkLifecycle test target links the same Vulkan helpers as `test_vulkan_resources` (volk, VMA, staging ring) and now carries the same platform link blocks as its sibling: `CMAKE_DL_LIBS` on Linux, and the Metal/Foundation/QuartzCore/IOKit/IOSurface frameworks on macOS. Compile definitions unchanged; no Linux platform define (SDL handles Wayland/X11). The `ChunkGenerationTarget` comment was also corrected: fixed extents encode the required sizes in the type, but callers constructing from dynamically-sized storage (vectors have runtime sizes) must ensure exact sizes - debug builds verify at construction.

Validation (Windows, AMD Ryzen): build clean; `test_chunk_lifecycle` passes; ctest **9/9**; runtime `--seed 42 --benchmark 20` clean (3,020-chunk peak). ASan clean on test_terrain / test_stream_opt / test_chunk_lifecycle for the code as of 90471ee; the 109b1ba delta is link-only on non-Windows platforms plus comments, so it does not affect Windows binaries. Linux/macOS link paths mirror the proven `test_vulkan_resources` setup; the repository has no Linux/macOS build CI, so an actual build on those platforms is still the remaining check before merge.
