### PR TITLE
fix(ui): respect ImGui keyboard capture for gameplay shortcuts and Escape

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -7,6 +7,7 @@
 #include <Chunk/StreamHelpers.hpp>
 #include <Engine/Profiler.hpp>
 #include <Engine/Benchmark.hpp>
+#include <Engine/InputRouting.hpp>
 #include <imgui/imgui.h>
 
 #include <cstdio>
@@ -605,23 +606,50 @@ void Engine::handleEvents()
 		case SDL_EVENT_KEY_DOWN:
 		{
 			const SDL_Keycode key = event.key.key;
+			const bool uiCapturesKeyboard = imgui && imgui->wantCaptureKeyboard();
+			const KeyRoute keyRoute = classifyKeyRoute(static_cast<int>(key));
 
-			// Function / panel shortcuts work even when ImGui wants keyboard.
-			if (gameUi)
+			// Input routing policy (issue #76): F-key panel/VSync shortcuts
+			// are intentional globals (non-text keys); gameplay keys must
+			// not fire while ImGui owns the keyboard, or typing 'p'/'c'/'b'
+			// in a text field would pause the world, steal the cursor, or
+			// toggle overlays.
+			GameUIFrame dummy{};
+			dummy.render = &renderSettings;
+			dummy.paused = &paused;
+			dummy.setVSync = [this](bool v) { setVSync(v); };
+
+			if (keyRoute == KeyRoute::GlobalShortcut)
 			{
-				GameUIFrame dummy{};
-				dummy.render = &renderSettings;
-				dummy.paused = &paused;
-				dummy.setVSync = [this](bool v) { setVSync(v); };
-				if (gameUi->handleShortcut(static_cast<int>(key), dummy))
+				if (gameUi && gameUi->handleGlobalShortcut(static_cast<int>(key), dummy))
 					break;
 			}
 
 			if (key == SDLK_ESCAPE)
 			{
-				running = false;
+				// Escape is forwarded to ImGui first. ImGuiFileDialog
+				// handles its own Escape-to-cancel path; the engine only
+				// decides whether Escape may quit.
+				if (escapeShouldQuit(uiCapturesKeyboard,
+									 gameUi && gameUi->isFileDialogOpen()))
+					running = false;
 				break;
 			}
+
+			if (uiCapturesKeyboard)
+				break;
+
+			if (keyRoute == KeyRoute::GameplayShortcut)
+			{
+				if (gameUi->handleGameplayShortcut(static_cast<int>(key), dummy))
+					break;
+
+				// Engine-owned gameplay keys (C/B/T) fall through here:
+				// classified by the policy, executed by Engine because
+				// their state (mouseCaptured, overlays, selectedTexture)
+				// lives here.
+			}
+
 			if (key == SDLK_C)
 			{
 				mouseCaptured = !mouseCaptured;
@@ -635,7 +663,7 @@ void Engine::handleEvents()
 					worldRenderer->overlays().setShowChunkBorders(showChunkBorders);
 				break;
 			}
-			if (key == SDLK_T && !(imgui && imgui->wantCaptureKeyboard()))
+			if (key == SDLK_T)
 			{
 				int next = static_cast<int>(selectedTexture) + 1;
 				if (next >= static_cast<int>(COUNT))

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -2,6 +2,7 @@
 
 #include <Engine/Profiler.hpp>
 #include <Vulkan/StagingRing.hpp>
+#include <ImGuiFileDialog.h>
 #include <imgui/imgui.h>
 #include <imgui/imgui_impl_vulkan.h>
 #include <SDL3/SDL.h>
@@ -105,8 +106,10 @@ void GameUI::onImGuiVulkanBackendRecreate()
 		m_mapHasTexture = false;
 }
 
-bool GameUI::handleShortcut(int sdlKeycode, GameUIFrame &frame)
+bool GameUI::handleGlobalShortcut(int sdlKeycode, GameUIFrame &frame)
 {
+	// Intentionally global (issue #76): function keys no text field can
+	// produce, so they work even while ImGui captures the keyboard.
 	switch (sdlKeycode)
 	{
 	case SDLK_F1:
@@ -137,6 +140,18 @@ bool GameUI::handleShortcut(int sdlKeycode, GameUIFrame &frame)
 			frame.setVSync(frame.render->vsyncEnabled);
 		}
 		return true;
+	default:
+		break;
+	}
+	return false;
+}
+
+bool GameUI::handleGameplayShortcut(int sdlKeycode, GameUIFrame &frame)
+{
+	// Gameplay state changes (issue #76): the caller gates these behind
+	// !wantCaptureKeyboard() so typing in an ImGui text field is inert.
+	switch (sdlKeycode)
+	{
 	case SDLK_P:
 		if (frame.paused)
 		{
@@ -148,6 +163,11 @@ bool GameUI::handleShortcut(int sdlKeycode, GameUIFrame &frame)
 		break;
 	}
 	return false;
+}
+
+bool GameUI::isFileDialogOpen() const
+{
+	return ImGuiFileDialog::Instance()->IsOpened();
 }
 
 void GameUI::draw(GameUIFrame &frame)

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -97,9 +97,20 @@ public:
 	/// Draw all panels. Call between ImGui beginFrame / endFrame.
 	void draw(GameUIFrame &frame);
 
-	/// Keyboard shortcuts that don't need ImGui capture (F-keys, etc.).
-	/// Returns true if a toggle consumed the key.
-	bool handleShortcut(int sdlKeycode, GameUIFrame &frame);
+	/// Keyboard shortcut handling, split by input-routing policy (issue #76):
+	/// - handleGlobalShortcut: intentional global non-text shortcuts
+	///   (F1-F7 panel toggles, F10 VSync) - honored even while ImGui
+	///   captures the keyboard.
+	/// - handleGameplayShortcut: gameplay state changes (P pause) - the
+	///   caller must only invoke these while ImGui does NOT capture the
+	///   keyboard, so typing in a text field stays inert.
+	/// Returns true if the key was consumed.
+	bool handleGlobalShortcut(int sdlKeycode, GameUIFrame &frame);
+	bool handleGameplayShortcut(int sdlKeycode, GameUIFrame &frame);
+
+	/// Used by Engine to prevent application quit while the modal handles
+	/// Escape itself (ImGuiFileDialog cancels via IGFD_EXIT_KEY).
+	bool isFileDialogOpen() const;
 
 	bool showHud() const { return m_showHud; }
 	bool showGraphics() const { return m_showGraphics; }

--- a/src/Engine/InputRouting.hpp
+++ b/src/Engine/InputRouting.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+// Input routing policy for keyboard events while ImGui may own the keyboard
+// (issue #76). Pure and header-only so the policy stays unit-testable
+// without ImGui or the engine.
+//
+// Policy summary:
+// - F1-F7 (panel toggles) and F10 (VSync) are intentional GLOBAL shortcuts:
+//   they are function keys no text field can produce, so they keep working
+//   even while ImGui captures the keyboard.
+// - Gameplay keys (P = pause, C = mouse capture, B = chunk borders,
+//   T = selected block) act on game state and MUST be suppressed while
+//   ImGui captures the keyboard: typing 'p' in an InputText would
+//   otherwise pause the world, 'c' would steal the cursor, 'b'/'t' would
+//   toggle overlays. Classification and execution are separate: P is
+//   executed by GameUI, C/B/T by Engine - both only when the UI does not
+//   capture the keyboard.
+// - Escape is special: it is offered to the active UI/modal first
+//   (ImGuiFileDialog cancels itself via IGFD_EXIT_KEY); the app quits only
+//   when the UI does not own the keyboard and no application modal is open.
+#include <SDL3/SDL_keycode.h>
+
+enum class KeyRoute
+{
+	GlobalShortcut,	   // F1-F7 panel toggles, F10 VSync
+	GameplayShortcut,  // P pause; C/B/T are Engine-owned gameplay keys
+	NotGameUIShortcut  // not handled by GameUI shortcut routing
+};
+
+inline KeyRoute classifyKeyRoute(int sdlKeycode)
+{
+	switch (sdlKeycode)
+	{
+	case SDLK_F1:
+	case SDLK_F2:
+	case SDLK_F3:
+	case SDLK_F4:
+	case SDLK_F5:
+	case SDLK_F6:
+	case SDLK_F7:
+	case SDLK_F10: // VSync toggle: explicit global policy (non-text key)
+		return KeyRoute::GlobalShortcut;
+	case SDLK_P:
+	case SDLK_C:
+	case SDLK_B:
+	case SDLK_T:
+		return KeyRoute::GameplayShortcut;
+	default:
+		return KeyRoute::NotGameUIShortcut;
+	}
+}
+
+inline bool escapeShouldQuit(bool uiCapturesKeyboard, bool modalDialogOpen)
+{
+	return !uiCapturesKeyboard && !modalDialogOpen;
+}

--- a/src/ImGuiFileDialog/ImGuiFileDialogConfig.h
+++ b/src/ImGuiFileDialog/ImGuiFileDialogConfig.h
@@ -79,8 +79,11 @@
 /////////////////////////////////
 
 // by ex you can quit the dialog by pressing the key excape
-// #define USE_DIALOG_EXIT_WITH_KEY
-// #define IGFD_EXIT_KEY ImGuiKey_Escape
+// Enabled for issue #76: with the modal open, Escape cancels the dialog
+// itself (unless an input/search field is being edited - then it first
+// ends the edit, per the native ImGuiFileDialog behavior).
+#define USE_DIALOG_EXIT_WITH_KEY
+#define IGFD_EXIT_KEY ImGuiKey_Escape
 
 /////////////////////////////////
 //// WIDGETS ////////////////////

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -220,6 +220,23 @@ target_link_libraries(test_biome_map PRIVATE
 add_test(NAME BiomeMapGeneration COMMAND test_biome_map)
 
 # ---------------------------------------------------------------------------
+# Input routing policy (issue #76): global vs gameplay shortcuts, Escape
+# ---------------------------------------------------------------------------
+add_executable(test_input_routing
+    test_input_routing.cpp
+)
+
+target_include_directories(test_input_routing PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(test_input_routing PRIVATE
+    SDL3::SDL3
+)
+
+add_test(NAME InputRouting COMMAND test_input_routing)
+
+# ---------------------------------------------------------------------------
 # Chunk lifecycle (issue #78 review): move semantics + direct pooled
 # generation via Chunk::generateTerrain. Links the Vulkan buffer helpers
 # Chunk.cpp depends on; never touches a real device.

--- a/tests/test_input_routing.cpp
+++ b/tests/test_input_routing.cpp
@@ -1,0 +1,74 @@
+// Input routing policy (issue #76): classifies which keyboard shortcuts are
+// intentionally global while ImGui captures the keyboard, which are gameplay
+// keys that must be suppressed, and when Escape is allowed to quit.
+#include <Engine/InputRouting.hpp>
+
+#include <iostream>
+
+static int g_fails = 0;
+
+#define CHECK(cond, msg)                                                       \
+	do                                                                         \
+	{                                                                          \
+		if (!(cond))                                                           \
+		{                                                                      \
+			std::cerr << "FAIL: " << msg << " (" << __LINE__ << ")\n";         \
+			++g_fails;                                                         \
+		}                                                                      \
+	} while (0)
+
+static void checkRoute(int key, KeyRoute expected, const char *name)
+{
+	CHECK(classifyKeyRoute(key) == expected, name);
+}
+
+int main()
+{
+	// Global panel / application shortcuts: F1-F7 panel toggles, F10 VSync.
+	// These are intentionally global (non-text function keys).
+	checkRoute(SDLK_F1, KeyRoute::GlobalShortcut, "F1 global");
+	checkRoute(SDLK_F2, KeyRoute::GlobalShortcut, "F2 global");
+	checkRoute(SDLK_F3, KeyRoute::GlobalShortcut, "F3 global");
+	checkRoute(SDLK_F4, KeyRoute::GlobalShortcut, "F4 global");
+	checkRoute(SDLK_F5, KeyRoute::GlobalShortcut, "F5 global");
+	checkRoute(SDLK_F6, KeyRoute::GlobalShortcut, "F6 global");
+	checkRoute(SDLK_F7, KeyRoute::GlobalShortcut, "F7 global");
+	checkRoute(SDLK_F10, KeyRoute::GlobalShortcut, "F10 global (explicit VSync policy)");
+
+	// Gameplay shortcuts must be routed behind !wantCaptureKeyboard. P is
+	// executed by GameUI; C/B/T are Engine-owned gameplay keys classified
+	// by the same policy (mouse capture, chunk borders, selected block).
+	checkRoute(SDLK_P, KeyRoute::GameplayShortcut, "P gameplay");
+	checkRoute(SDLK_C, KeyRoute::GameplayShortcut, "C gameplay");
+	checkRoute(SDLK_B, KeyRoute::GameplayShortcut, "B gameplay");
+	checkRoute(SDLK_T, KeyRoute::GameplayShortcut, "T gameplay");
+
+	// Escape is special (UI/modal routing first, then possibly quit) and
+	// must never enter the shortcut routes.
+	checkRoute(SDLK_ESCAPE, KeyRoute::NotGameUIShortcut, "Escape not a GameUI shortcut");
+
+	// Anything else (text input, digits, other letters) stays inert.
+	checkRoute(SDLK_A, KeyRoute::NotGameUIShortcut, "A not a shortcut");
+	checkRoute(SDLK_1, KeyRoute::NotGameUIShortcut, "digit not a shortcut");
+	checkRoute(SDLK_SPACE, KeyRoute::NotGameUIShortcut, "space not a shortcut");
+	checkRoute(SDLK_RETURN, KeyRoute::NotGameUIShortcut, "return not a shortcut");
+
+	// This helper only decides whether the application may quit.
+	// Modal dismissal itself is handled by ImGuiFileDialog.
+	CHECK(escapeShouldQuit(false, false), "escape quits with free UI");
+	CHECK(!escapeShouldQuit(true, false),
+		  "escape does not quit while ImGui captures keyboard");
+	CHECK(!escapeShouldQuit(false, true),
+		  "escape does not quit while a modal dialog is open");
+	CHECK(!escapeShouldQuit(true, true),
+		  "escape does not quit when UI captures and a modal is open");
+
+	if (g_fails != 0)
+	{
+		std::cerr << g_fails << " check(s) failed\n";
+		return 1;
+	}
+	std::cout << "PASS: input routing policy - global F-keys, gated gameplay "
+			  << "keys, Escape quit gating\n";
+	return 0;
+}


### PR DESCRIPTION
`handleEvents()` handled gameplay keys and Escape unconditionally after forwarding events to ImGui, so typing in any ImGui text field could pause the world ('p'), steal the cursor via relative mouse mode ('c'), toggle chunk borders ('b') or cycle the selected block ('t'), and Escape always terminated the application even when it was meant to dismiss a popup or dialog.

## Input routing policy

Factored into a pure header-only helper (`Engine/InputRouting.hpp`) so it is unit-testable without ImGui:

- **`classifyKeyRoute()`**: F1-F7 panel toggles and F10 VSync are intentional **global** shortcuts (non-text function keys) and keep working while ImGui captures the keyboard. **P, C, B, T** are classified **gameplay** keys — suppressed while the UI captures the keyboard. Classification and execution are separate: P runs in `GameUI::handleGameplayShortcut()`, C/B/T stay Engine-owned (their state lives there); the route is computed once per key.
- **`escapeShouldQuit()`**: Escape quits only when ImGui does not consume keyboard input AND no application modal (resource-pack file dialog) is open. `GameUI::handleShortcut()` is split into `handleGlobalShortcut()` (F1-F7, F10) and `handleGameplayShortcut()` (P); `GameUI::isFileDialogOpen()` feeds the Escape gate.

**ImGuiFileDialog Escape exit enabled via `USE_DIALOG_EXIT_WITH_KEY` + `IGFD_EXIT_KEY ImGuiKey_Escape`** (native mechanism in `ImGuiFileDialogConfig.h`): with the modal open, Escape cancels the dialog itself — unless an input/search field is being edited, in which case it first ends the edit (native behavior). The engine never closes the dialog; it only decides whether Escape may quit. `WASD`/camera suppression in `processInput()` is unchanged.

## Tests

- New `test_input_routing` target covers the policy matrix: F1-F7/F10 global, P/C/B/T gameplay, Escape outside the routes, arbitrary text keys inert, and the four `escapeShouldQuit` combinations (the helper only decides whether the app may quit — modal dismissal itself is ImGuiFileDialog's job, not unit-tested here).
- Validation: build clean; `test_input_routing` passes; **ctest 10/10**; runtime `--seed 42 --benchmark 10` clean (score S, no event-loop regression).

## Manual validation before merge/close (issue #76)

- [ ] Graphics → Resource Pack → Browse: dialog open → **Escape closes the dialog, application stays alive**, pause unchanged, mouse capture unchanged
- [ ] While editing the dialog path/search field: first Escape ends the edit, second closes the dialog (native component behavior)
- [ ] Typing `p` / `c` / `b` / `t` in the pack-path InputText: no pause, no capture, no border toggle, no texture cycle
- [ ] F1-F7 keep toggling panels during text input (including the panel containing the field) without inconsistent state; F10 toggles VSync under capture (intentional)
- [ ] `P` / `C` / `B` / `T` still work normally with no field focused
- [ ] WASD while an InputText is active: camera does not move
- [ ] Capture mouse (`C`), open dialog, type `c`: capture is not toggled

The issue is intentionally **not** auto-closed by this PR: close #76 manually once the Escape/dialog scenarios above are validated in-game.
