### PR TITLE
perf(chunk): avoid redundant pooled voxel clearing before generation

### DIFF
--- a/docs/benchmarks/bench_20260904_093904_682138e5c977_s42_sc9909.txt
+++ b/docs/benchmarks/bench_20260904_093904_682138e5c977_s42_sc9909.txt
@@ -1,0 +1,30 @@
+ft_vox Benchmark Report
+=======================
+Score: 9909 / 10000  Grade: S
+Revision: 682138e5c977
+  git 682138e5c977  branch fix/93-pooled-voxel-clearing  describe 682138e
+  build UTC 2026-09-04T09:38:15Z
+Seed: 42  Duration: 30s  Warmup: 2s  Measured: 30.0006s  Frames: 16499
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 1.80854  min 0.5874  max 7.055
+  p50 1.0365  p95 3.8245  p99 4.0552
+  avg FPS 552.931  1% low FPS 246.597
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.374747  Visibility 0.0600646
+  Acquire 0.964684  Record 0.358083  MeshUpload 0.0456452
+  ImGui 0.0421615  Present 0.0564813
+
+Worker jobs
+  TerrainGen  n=20250  avgMs=1.58569  totalMs=32110.3
+  MeshBuild   n=17407  avgMs=3.06013  totalMs=53267.7
+  MeshLOD     n=504  avgMs=0.0373175  totalMs=18.808
+
+Peaks: chunks=4628 draw=1260 qLoad/Gen/Mesh=1548/3/4
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/bench_20260904_094127_682138e5c977__s42_sc9907.txt
+++ b/docs/benchmarks/bench_20260904_094127_682138e5c977__s42_sc9907.txt
@@ -1,0 +1,30 @@
+ft_vox Benchmark Report
+=======================
+Score: 9907 / 10000  Grade: S
+Revision: 682138e5c977* (dirty tree at build)
+  git 682138e5c977  branch fix/93-pooled-voxel-clearing  describe 682138e-dirty
+  build UTC 2026-09-04T09:40:07Z
+Seed: 42  Duration: 30s  Warmup: 2s  Measured: 30.0007s  Frames: 16018
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 1.86299  min 0.5769  max 16.0556
+  p50 1.157  p95 3.8853  p99 4.2676
+  avg FPS 536.771  1% low FPS 234.324
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.394924  Visibility 0.0616317
+  Acquire 0.962334  Record 0.384902  MeshUpload 0.0477839
+  ImGui 0.0453121  Present 0.0609963
+
+Worker jobs
+  TerrainGen  n=19700  avgMs=1.6637  totalMs=32774.8
+  MeshBuild   n=17213  avgMs=3.14152  totalMs=54074.9
+  MeshLOD     n=250  avgMs=0.039344  totalMs=9.836
+
+Peaks: chunks=4628 draw=1254 qLoad/Gen/Mesh=1603/4/4
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/bench_20260904_094249_682138e5c977__s42_sc9907.txt
+++ b/docs/benchmarks/bench_20260904_094249_682138e5c977__s42_sc9907.txt
@@ -1,0 +1,30 @@
+ft_vox Benchmark Report
+=======================
+Score: 9907 / 10000  Grade: S
+Revision: 682138e5c977* (dirty tree at build)
+  git 682138e5c977  branch fix/93-pooled-voxel-clearing  describe 682138e-dirty
+  build UTC 2026-09-04T09:40:07Z
+Seed: 42  Duration: 30s  Warmup: 2s  Measured: 30.0019s  Frames: 16351
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 1.82516  min 0.5082  max 12.5216
+  p50 1.0859  p95 3.8452  p99 4.1672
+  avg FPS 547.897  1% low FPS 239.969
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.384825  Visibility 0.0601827
+  Acquire 0.950787  Record 0.375891  MeshUpload 0.0460579
+  ImGui 0.0427599  Present 0.0576118
+
+Worker jobs
+  TerrainGen  n=20046  avgMs=1.64423  totalMs=32960.2
+  MeshBuild   n=17349  avgMs=3.09344  totalMs=53668.1
+  MeshLOD     n=367  avgMs=0.0382861  totalMs=14.051
+
+Peaks: chunks=4628 draw=1260 qLoad/Gen/Mesh=1542/3/4
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue-93-pooled-reset.md
+++ b/docs/benchmarks/issue-93-pooled-reset.md
@@ -1,0 +1,72 @@
+# Issue #93: pooled acquisition reset
+
+Measured on 2026-09-04, Windows, MSVC 19.50, Release, NVIDIA RTX 4070 Ti.
+Baseline: `682138e5c977`; after: that revision plus the issue #93 changes.
+
+`ChunkPool::acquire()` now uses `ResetMode::ForGeneration`, avoiding the
+65,536-byte AIR fill. Default reset and pool release still clear voxels.
+The generator's reused-storage reset contract is unchanged.
+
+## Isolated reset cost
+
+Run `build/tests/Release/test_chunk_lifecycle.exe --reset-perf`.
+This compares the old full-reset behavior with the new acquisition behavior
+in one binary, using one preallocated chunk, six alternating rounds of
+100,000 resets per mode. Wall-clock measurements:
+
+| Mode | Total for 600,000 resets | Per reset |
+| --- | ---: | ---: |
+| Full (previous acquisition behavior) | 236.815 ms | 0.395 us |
+| ForGeneration | 43.3161 ms | 0.072 us |
+
+This is a hot-buffer microbenchmark, not an end-to-end speedup estimate.
+It excludes pool locking, generation, and release. No allocator counters were
+instrumented; lifecycle tests verify stable voxel and shell capacities.
+
+## Pure generation control
+
+Three sequential runs of `test_terrain.exe --gen-perf 500 1337` per version:
+
+| Version | Owning ms/chunk (runs 1/2/3) | Pooled-into ms/chunk (runs 1/2/3) |
+| --- | --- | --- |
+| Before | 1.23317 / 1.55271 / 1.19927 | 1.20954 / 1.29059 / 1.20200 |
+| After | 1.26067 / 1.27865 / 1.36961 | 1.27222 / 1.29932 / 1.30979 |
+
+All runs report stable reused-buffer capacities. This benchmark does not call
+`Chunk::reset()` and therefore does not directly measure the optimization.
+The variations do not establish an improvement or a regression in generation.
+
+## Vulkan streaming
+
+Command: `build/Release/ft_vox.exe --seed 42 --benchmark 30`.
+1920x1080, view distance 512, VSync off, IMMEDIATE presentation, 2 s warmup.
+No concurrent build or test during the baseline and final comparison runs.
+
+| Metric | Before | After |
+| --- | ---: | ---: |
+| Measured wall time | 30.0006 s | 30.0019 s |
+| Average frame | 1.80854 ms | 1.82516 ms |
+| Streaming CPU scope | 0.374747 ms | 0.384825 ms |
+| TerrainGen mean | 1.58569 ms | 1.64423 ms |
+| TerrainGen jobs | 20,250 | 20,046 |
+| TerrainGen aggregate | 32,110.3 ms | 32,960.2 ms |
+
+The worker TerrainGen timer starts after acquisition, so it excludes the
+removed fill. These single runs show no end-to-end gain; a sub-microsecond
+acquisition saving is smaller than the observed run-to-run variation.
+The report's `Acquire` scope measures swapchain acquisition, not ChunkPool.
+
+Raw reports:
+
+- Before: [baseline](bench_20260904_093904_682138e5c977_s42_sc9909.txt).
+- After: [isolated comparison](bench_20260904_094249_682138e5c977__s42_sc9907.txt).
+- [Intermediate after run](bench_20260904_094127_682138e5c977__s42_sc9907.txt)
+  overlapped with test execution and is excluded from the comparison.
+
+## Validation
+
+Release builds of `ft_vox`, `test_terrain`, and `test_chunk_lifecycle` pass.
+`ctest --test-dir build -C Release -R 'ChunkLifecycle|TerrainGeneration|StreamOptHelpers' --output-on-failure --timeout 120`
+passes all three suites (41.11 s), including determinism, borders, reused
+generation targets, dirty voxel regeneration, full retirement clearing,
+actual pool reuse, cancelled acquisition, and stable storage capacities.

--- a/docs/engine-architecture.md
+++ b/docs/engine-architecture.md
@@ -158,6 +158,10 @@ At mesh time, sky light is cast down open columns then **flooded** into caves (a
 
 - Preallocated / recycled `Chunk` objects  
 - Avoids allocator thrash when streaming  
+- Acquisition uses `Chunk::ResetMode::ForGeneration`: lifecycle, mesh, and
+  cache state is reset, but voxel clearing is deferred to `generateTerrain()`.
+  Consumers must wait for generation before reading voxel data. Release uses
+  the default full reset, including AIR fill, even if generation was cancelled.
 - Grows with view distance / pressure (see git history for pool growth fixes)  
 
 ### `ThreadPool` (`Engine/ThreadPool.hpp`)

--- a/src/Chunk/Chunk.cpp
+++ b/src/Chunk/Chunk.cpp
@@ -1336,7 +1336,7 @@ void Chunk::rebuildShellFromNeighbors(const Chunk *west, const Chunk *east,
             north->getVoxel(x, y, 0).type;
 }
 
-void Chunk::reset(const glm::vec3 &newPosition)
+void Chunk::reset(const glm::vec3 &newPosition, ResetMode mode)
 {
   // Drop GPU meshes — next upload recreates VMA buffers.
   releaseGPU();
@@ -1358,10 +1358,14 @@ void Chunk::reset(const glm::vec3 &newPosition)
   waterVertices.clear();
   waterIndices.clear();
 
-  // Reset voxels to AIR (keep vector at CHUNK_VOLUME size)
-  if (voxels.size() != CHUNK_VOLUME)
-    voxels.resize(CHUNK_VOLUME);
-  std::fill(voxels.begin(), voxels.end(), Voxel{static_cast<uint8_t>(AIR)});
+  // Generation resets caller-owned storage itself. Avoid another full-buffer
+  // write on acquisition; retirement still leaves a completely empty chunk.
+  if (mode == ResetMode::Full)
+  {
+    if (voxels.size() != CHUNK_VOLUME)
+      voxels.resize(CHUNK_VOLUME);
+    std::fill(voxels.begin(), voxels.end(), Voxel{static_cast<uint8_t>(AIR)});
+  }
 
   activeVoxels.reset();
 

--- a/src/Chunk/Chunk.hpp
+++ b/src/Chunk/Chunk.hpp
@@ -84,7 +84,11 @@ public:
 	void rebuildShellFromNeighbors(const Chunk *west, const Chunk *east,
 								   const Chunk *south, const Chunk *north);
 
-	void reset(const glm::vec3 &newPosition);
+	enum class ResetMode { Full, ForGeneration };
+	/// ForGeneration retains voxel contents until generateTerrain() overwrites
+	/// them. Do not read/mesh those voxels before generation completes.
+	/// Full (the default) also clears voxels, for retirement without regeneration.
+	void reset(const glm::vec3 &newPosition, ResetMode mode = ResetMode::Full);
 
 	uint32_t getOpaqueIndexCount() const { return opaqueIndexCount; }
 

--- a/src/Chunk/ChunkPool.cpp
+++ b/src/Chunk/ChunkPool.cpp
@@ -86,7 +86,7 @@ Chunk *ChunkPool::acquire(const glm::vec3 &worldPosition)
 
 	Chunk *chunk = m_freeList.back();
 	m_freeList.pop_back();
-	chunk->reset(worldPosition);
+	chunk->reset(worldPosition, Chunk::ResetMode::ForGeneration);
 	m_acquiredCount.fetch_add(1, std::memory_order_relaxed);
 	return chunk;
 }

--- a/src/Chunk/ChunkPool.hpp
+++ b/src/Chunk/ChunkPool.hpp
@@ -33,6 +33,7 @@ public:
 	bool ensureCapacity(size_t minCapacity);
 
 	/// Obtain a chunk reset to worldPosition, or nullptr if the free list is empty.
+	/// Must call generateTerrain() before consuming voxel data.
 	/// Thread-safe. Does not heap-allocate overflow chunks.
 	Chunk *acquire(const glm::vec3 &worldPosition);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -244,6 +244,7 @@ add_test(NAME InputRouting COMMAND test_input_routing)
 add_executable(test_chunk_lifecycle
     test_chunk_lifecycle.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/Chunk.cpp
+    ${CMAKE_SOURCE_DIR}/src/Chunk/ChunkPool.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainGenerator.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainVegetation.cpp
     ${FT_VOX_VULKAN_SOURCES}

--- a/tests/test_chunk_lifecycle.cpp
+++ b/tests/test_chunk_lifecycle.cpp
@@ -5,11 +5,13 @@
 // pooled-style storage across reset/regenerate cycles - with the
 // activeVoxels cache staying in sync and no capacity churn.
 #include <Chunk/Chunk.hpp>
+#include <Chunk/ChunkPool.hpp>
 #include <Chunk/TerrainGenerator.hpp>
 
 #include <algorithm>
 #include <array>
 #include <bitset>
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <vector>
@@ -137,8 +139,38 @@ static void checkMatchesOwning(const Chunk &chunk, TerrainGenerator &gen,
 		  "height map matches owning path");
 }
 
-int main()
+// Isolate the acquisition reset cost: alternate both modes over the same
+// preallocated chunk. No generation/allocator/renderer work is timed here.
+static int runResetPerf()
 {
+	using Clock = std::chrono::steady_clock;
+	Chunk chunk(glm::vec3(0.0f));
+	constexpr int iterations = 100000;
+	double fullMs = 0.0, generationMs = 0.0;
+	for (int round = 0; round < 6; ++round)
+	{
+		for (int phase = 0; phase < 2; ++phase)
+		{
+			const bool full = ((round + phase) % 2) == 0;
+			const auto mode = full ? Chunk::ResetMode::Full : Chunk::ResetMode::ForGeneration;
+			const auto start = Clock::now();
+			for (int i = 0; i < iterations; ++i)
+				chunk.reset(glm::vec3(static_cast<float>(i % 64), 0.0f, 0.0f), mode);
+			const double ms = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+			(full ? fullMs : generationMs) += ms;
+		}
+	}
+	std::cout << "[Reset Perf] 600000 resets/mode, alternating order\n"
+			  << "full: " << fullMs << " ms total, " << fullMs / 600000 << " ms/reset\n"
+			  << "for-generation: " << generationMs << " ms total, "
+			  << generationMs / 600000 << " ms/reset\n";
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	if (argc > 1 && std::strcmp(argv[1], "--reset-perf") == 0)
+		return runResetPerf();
 	constexpr int kSeed = 4242;
 	TerrainGenerator gen(kSeed);
 
@@ -180,8 +212,12 @@ int main()
 	const size_t shellCapacity = ChunkStateProbe::shell(c).capacity();
 
 	c.reset(glm::vec3(static_cast<float>(CHUNK_SIZE), 0.0f,
-					  static_cast<float>(CHUNK_SIZE)));
+					  static_cast<float>(CHUNK_SIZE)), Chunk::ResetMode::ForGeneration);
 	CHECK(c.getState() == ChunkState::UNLOADED, "reset returns chunk to UNLOADED");
+	CHECK(sameVoxels(snapC.voxels, ChunkStateProbe::voxels(c)),
+		  "generation reset retains dirty voxels until generation overwrites them");
+	CHECK(ChunkStateProbe::active(c).none(), "reset invalidates active cache");
+	CHECK(c.isShellEmpty(), "reset invalidates neighbor shell");
 	c.generateTerrain(gen);
 	CHECK(c.getState() == ChunkState::GENERATED, "regeneration completes");
 	checkMatchesOwning(c, gen, CHUNK_SIZE, CHUNK_SIZE, "recycled generation");
@@ -190,6 +226,37 @@ int main()
 		  "voxel capacity stable across recycle");
 	CHECK(ChunkStateProbe::shell(c).capacity() == shellCapacity,
 		  "shell capacity stable across recycle");
+
+	// Full reset must still clear storage when a chunk is retired.
+	c.reset(glm::vec3(0.0f));
+	CHECK(std::all_of(ChunkStateProbe::voxels(c).begin(),
+					  ChunkStateProbe::voxels(c).end(),
+					  [](Voxel v) { return v.type == AIR; }),
+		  "default reset clears every voxel");
+	checkActiveCacheInSync(c, "full reset leaves an empty active cache");
+
+	// Exercise the real pool boundary, including cancelled generation.
+	ChunkPool pool(64);
+	Chunk *pooled = pool.acquire(glm::vec3(0.0f));
+	CHECK(pooled != nullptr, "pool acquisition succeeds");
+	if (pooled)
+	{
+		pooled->generateTerrain(gen);
+		pool.release(pooled);
+		CHECK(std::all_of(ChunkStateProbe::voxels(*pooled).begin(),
+						  ChunkStateProbe::voxels(*pooled).end(),
+						  [](Voxel v) { return v.type == AIR; }),
+			  "pool release fully clears retired voxels");
+		Chunk *reused = pool.acquire(glm::vec3(-CHUNK_SIZE, 0.0f, CHUNK_SIZE));
+		CHECK(reused == pooled, "pool reuses released storage");
+		reused->generateTerrain(gen);
+		checkMatchesOwning(*reused, gen, -CHUNK_SIZE, CHUNK_SIZE, "pool reuse");
+		checkActiveCacheInSync(*reused, "pool reuse active cache");
+		pool.release(reused);
+		pooled = pool.acquire(glm::vec3(0.0f));
+		pool.release(pooled); // cancelled before generation
+		CHECK(pool.acquiredCount() == 0, "cancelled acquisition returns to pool");
+	}
 
 	if (g_fails != 0)
 	{


### PR DESCRIPTION
Pooled acquisition cleared all 65,536 voxels even though pool release already emptied the chunk and generateChunkInto() resets caller-owned storage before generating terrain. Skip that extra write on acquisition while preserving the full reset required when retiring chunks.

Implementation:
- Add Chunk::ResetMode with Full as the default and ForGeneration for acquisition. The latter retains voxel contents until generateTerrain() overwrites them, while resetting lifecycle, meshes, and caches.
- Use ForGeneration in ChunkPool::acquire(); keep the full AIR fill in release(), including cancellation before generation and retirement.
- Leave generateChunkInto() and its reused-storage reset contract intact.
- Document the requirement to finish generation before consuming voxels.

Tests and measurements:
- Extend ChunkLifecycle to verify dirty voxel regeneration against the owning path, active-cache and shell invalidation, full retirement clearing, real pool reuse, cancellation, and stable buffer capacities.
- Link ChunkPool.cpp into the lifecycle test and add --reset-perf to compare both reset modes over 600,000 resets each in alternating order.
- Record before/after pure-generation and Vulkan streaming measurements with raw reports and measurement limitations in docs/benchmarks.

Validation:
- Windows/MSVC Release builds pass for ft_vox, test_terrain, and test_chunk_lifecycle.
- Targeted CTest passes 3/3: ChunkLifecycle, TerrainGeneration, and StreamOptHelpers (41.11 s), including determinism and border coverage.
- git diff --check passes.
- Isolated reset: 236.815 ms total / 0.395 us per full reset versus 43.3161 ms total / 0.072 us per ForGeneration reset. This measures a hot buffer and excludes pool locking, generation, and release.
- Three --gen-perf 500 1337 runs per version retain stable capacities; this control does not execute the modified reset path.
- Vulkan --seed 42 --benchmark 30: mean frame time 1.80854 -> 1.82516 ms; TerrainGen mean 1.58569 -> 1.64423 ms. No end-to-end gain established. TerrainGen excludes pool acquisition, and run variation exceeds the isolated saving. Exclude the intermediate run overlapping with tests.
- Allocator counters were not instrumented; Linux/macOS were not tested.

Close #93