### PR TITLE
perf(terrain): schedule biome map tiles through the Engine thread pool

### DIFF
--- a/docs/benchmarks/bench_20260904_101251_6f1fbd8ac7a6__s42_sc10000.txt
+++ b/docs/benchmarks/bench_20260904_101251_6f1fbd8ac7a6__s42_sc10000.txt
@@ -1,0 +1,34 @@
+ft_vox Benchmark Report
+=======================
+Score: 10000 / 10000  Grade: S
+Revision: 6f1fbd8ac7a6* (dirty tree at build)
+  git 6f1fbd8ac7a6  branch perf/88-parallel-biome-region  describe 6f1fbd8-dirty
+  build UTC 2026-09-04T10:11:48Z
+Seed: 42  Duration: 15s  Warmup: 2s  Measured: 15.0011s  Frames: 2999
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 4.99149  min 3.4693  max 7.6715
+  p50 4.9912  p95 4.9927  p99 5.0014
+  avg FPS 200.341  1% low FPS 199.944
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.426466  Visibility 0.0265185
+  Acquire 0.0105572  Record 0.222893  MeshUpload 0.0366954
+  ImGui 0.0655858  Present 4.25357
+
+Worker jobs
+  TerrainGen  n=7200  avgMs=1.57173  totalMs=11316.5
+  MeshBuild   n=5399  avgMs=2.9515  totalMs=15935.1
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+Biome map: zoom=0.1 mode=sequential (fixed center when enabled)
+  TerrainQueue n=7200 avgMs=0.00999458 totalMs=71.961
+  MeshQueue n=5399 avgMs=0.00969865 totalMs=52.363
+  BiomeMap n=9 avgMs=664.308 totalMs=5978.77
+Peaks: chunks=1957 draw=429 qLoad/Gen/Mesh=2243/3/3
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/bench_20260904_101310_6f1fbd8ac7a6__s42_sc10000.txt
+++ b/docs/benchmarks/bench_20260904_101310_6f1fbd8ac7a6__s42_sc10000.txt
@@ -1,0 +1,34 @@
+ft_vox Benchmark Report
+=======================
+Score: 10000 / 10000  Grade: S
+Revision: 6f1fbd8ac7a6* (dirty tree at build)
+  git 6f1fbd8ac7a6  branch perf/88-parallel-biome-region  describe 6f1fbd8-dirty
+  build UTC 2026-09-04T10:11:48Z
+Seed: 42  Duration: 15s  Warmup: 2s  Measured: 15.0002s  Frames: 2993
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 5.00096  min 4.8869  max 29.1626
+  p50 4.9914  p95 4.9927  p99 5
+  avg FPS 199.962  1% low FPS 200
+  frames >16.7ms: 1  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.414646  Visibility 0.0234317
+  Acquire 0.0105741  Record 0.211711  MeshUpload 0.0320863
+  ImGui 0.0652757  Present 4.28507
+
+Worker jobs
+  TerrainGen  n=6423  avgMs=1.56174  totalMs=10031
+  MeshBuild   n=4747  avgMs=2.94787  totalMs=13993.5
+  MeshLOD     n=268  avgMs=0.0641381  totalMs=17.189
+
+Biome map: zoom=0.1 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=6423 avgMs=0.00920847 totalMs=59.146
+  MeshQueue n=5015 avgMs=0.00955753 totalMs=47.931
+  BiomeMap n=14 avgMs=93.0621 totalMs=1302.87
+Peaks: chunks=1942 draw=539 qLoad/Gen/Mesh=3308/1/2
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue-88-biome-map-scheduling.md
+++ b/docs/benchmarks/issue-88-biome-map-scheduling.md
@@ -1,0 +1,115 @@
+# Issue #88: Engine-scheduled biome map tiles
+
+Measured 2026-09-04 on Windows, MSVC Release, NVIDIA GeForce RTX 4070 Ti.
+Base revision: `6f1fbd8ac7a6`; measurements include this working-tree change.
+
+## Implementation and priority contract
+
+`TerrainGenerator::getBiomeRegion()` remains sequential. The new plan API
+describes independent rectangles in the original sampling grid;
+`getBiomeRegionTile()` samples one rectangle with the existing canonical
+erosion/biome pipeline. Tile-local output never changes world-coordinate
+rounding. Reverse-order and concurrent assembly match sequential output.
+
+The Engine's `submitBiomeMap()` uses the existing ThreadPool, with at most
+eight active tile lanes and Low priority for planning and every tile. Each
+tile queues its successor separately, giving High/Normal chunk work another
+scheduling opportunity. ThreadPool searches all queues at each priority
+before considering the next priority. Work already executing is not
+preempted. Task-count publication and sleeper notifications are synchronized
+with queue visibility and the condition-variable wait transition.
+
+A submission sentinel plus an atomic remaining-work count prevents early
+publication. The last task converts the disjoint biome writes to RGBA and
+resolves the result future; no pool worker waits for children. Exceptions
+and cancellation drain submitted tasks and produce an invalid result.
+GameUI keeps its existing single-flight and stale-result rules.
+
+Maps spanning at most 128 blocks use one Low job with the UI-owned scratch.
+Parallel sampling never shares that scratch: each visited worker retains
+at most ~0.7 MiB of region scratch. No native threads are added. Retention
+is per visited worker, not per lane, because tasks can migrate between workers.
+
+## Standalone map latency
+
+Run `build/tests/Release/test_biome_map.exe --map-perf`.
+256x256 pixels, seed 1337, center (-123.6, 432.1), eight workers. Both paths
+are warmed, then measured three times with alternating order. Values are
+mean wall-clock latency in milliseconds; scheduled time includes queueing,
+assembly, and RGBA conversion. Every measured output is checked byte-for-byte.
+
+| Zoom | Sequential | Scheduled |
+| --- | ---: | ---: |
+| 0.1 | 617.361 | 84.2733 |
+| 0.25 | 109.146 | 16.8534 |
+| 0.5 | 28.3086 | 4.7153 |
+| 1 | 8.25587 | 1.73337 |
+| 2 | 3.22343 | 3.3601 |
+| 4 | 1.92967 | 2.16207 |
+| 8 | 1.85937 | 1.5362 |
+
+Zoom 0.1 improves by about 7.3x. Small maps intentionally stay sequential;
+their sub-millisecond variations are not evidence of a speedup.
+
+## Streaming with the map open
+
+Reproduce the control and scheduled runs:
+
+```powershell
+./build/Release/ft_vox.exe --seed 42 --benchmark 15 --benchmark-map 0.1 --benchmark-map-sequential
+./build/Release/ft_vox.exe --seed 42 --benchmark 15 --benchmark-map 0.1
+```
+
+Both run the same binary and scheduler. The control uses the previous
+one-Low-job map algorithm, so this comparison isolates map scheduling rather
+than comparing binaries with different instrumentation. The World panel is
+open with a fixed map center and normal one-second refresh cadence; camera
+movement does not cancel the map. Follow-player cancellation is covered by
+tests, not this latency experiment.
+
+Engine pool: 16 workers, map lanes capped at eight. Viewport 1920x1080,
+view distance 512, IMMEDIATE presentation, VSync off, two-second warmup,
+15-second measurement. No concurrent build or tests. Observed frame times
+clustered near 5 ms with most time in Present; these runs do not establish
+an uncapped rendering-throughput improvement.
+
+| Metric | Sequential map | Scheduled map |
+| --- | ---: | ---: |
+| Completed maps | 9 | 14 |
+| Mean map latency, including queueing | 664.308 ms | 93.0621 ms |
+| TerrainGen mean execution | 1.57173 ms | 1.56174 ms |
+| MeshBuild mean execution | 2.9515 ms | 2.94787 ms |
+| Terrain task mean queue wait | 0.00999458 ms | 0.00920847 ms |
+| Mesh task mean queue wait (full + LOD) | 0.00969865 ms | 0.00955753 ms |
+| Mean Streaming CPU scope | 0.426466 ms | 0.414646 ms |
+| Mean frame | 4.99149 ms | 5.00096 ms |
+| TerrainGen completed tasks | 7200 | 6423 |
+| MeshBuild completed tasks | 5399 | 4747 |
+
+The map latency improves about 7.1x while measured mean chunk execution and
+queue waits remain similar. Task counts and queue peaks differ between the
+two runs; these single runs are not a throughput or tail-latency guarantee.
+Queue metrics measure enqueue-to-worker-start, excluding the time a chunk
+spends awaiting admission by the streaming budget. No queue percentiles or
+allocator counters were collected.
+
+Raw reports:
+
+- [Sequential map](bench_20260904_101251_6f1fbd8ac7a6__s42_sc10000.txt)
+- [Scheduled map](bench_20260904_101310_6f1fbd8ac7a6__s42_sc10000.txt)
+
+## Validation
+
+- Full Release build and all ten CTest suites, including Vulkan resource smoke.
+- Terrain determinism and dense-vs-tiled border parity remain covered by
+  `TerrainGeneration`.
+- `BiomeMapGeneration`: reverse-order plan assembly, exact pixel coverage,
+  fractional/negative coordinates, odd dimensions and partial edge tiles,
+  extreme steps, scratch retention, invalid rectangles, late tile
+  cancellation, one/four-worker parity, cancellation of queued work,
+  exception completion, and pool shutdown draining.
+- A gated two-worker regression verifies that queued High/Normal tasks in
+  other queues precede local Low work.
+- Existing world/seed/request rejection, single-flight refresh, scratch
+  reuse, and upload-policy tests remain enabled.
+- Linux/macOS and thread/address sanitizers were not run locally.

--- a/docs/engine-architecture.md
+++ b/docs/engine-architecture.md
@@ -168,6 +168,10 @@ At mesh time, sky light is cast down open columns then **flooded** into caves (a
 
 - Work-stealing workers for **terrain generation** and **meshing**  
 - Priorities via task priority helpers (near camera first)  
+- Biome maps use up to eight Low-priority tile lanes, yielding back to the pool
+  after each tile. High/Normal work is searched across all queues first. The
+  final tile publishes via an atomic completion count; workers never wait for
+  child tasks. GameUI still permits only one map build at a time.
 
 **Rule:** GPU upload, VMA destroy, and descriptor/buffer free related to live draws happen on the **main thread** after appropriate retire delay — never free mesh buffers still referenced by in-flight frames.
 

--- a/docs/terrain-generation.md
+++ b/docs/terrain-generation.md
@@ -187,8 +187,10 @@ Biome sampling is unified across the engine via a canonical erosion-aware pipeli
   (`col = floor(sampleWorldCoord)`), ensuring adjacent pixels on the same column resolve
   identically. Erosion always runs at `step = 1.0f` — `grid.step` only selects which
   canonical columns are sampled, never the erosion resolution. The call runs sequentially
-  on the calling thread (no internal threads; the Engine schedules the whole call as one
-  `TaskPriority::Low` job) and is deterministic: tile order never influences the output.
+  on the calling thread (no internal threads) and is deterministic: tile order never
+  influences the output. The Engine uses `buildBiomeRegionPlan()` and
+  `getBiomeRegionTile()` to schedule independent output rectangles in the original grid.
+  Rectangles are never recentered, preserving canonical column rounding exactly.
   Returns `false` (with the output cleared) when the grid is invalid or the optional
   cancellation callback fires; partial results are never produced:
   - Small dense domains (≤ 516×516 haloed block bounding box): sampled in a single
@@ -212,5 +214,16 @@ Biome sampling is unified across the engine via a canonical erosion-aware pipeli
       of ~10 MiB per scratch (516² points × 10 float fields × 4 bytes).
     `BiomeRegionStats` reports `denseTiles`, `fallbackPixels`, `peakDensePoints`, and
     `peakScratchBytes` to keep the bound verifiable.
+- **Engine scheduling**: `submitBiomeMap()` schedules at most eight tile lanes on the
+  existing `ThreadPool`, all at `TaskPriority::Low`. Each tile queues its successor
+  separately so chunk/mesh High and Normal work is considered between tiles. The pool
+  searches all worker queues for a higher priority before selecting lower-priority work;
+  already-running tiles are not preempted. A submission sentinel and atomic remaining
+  count let the last task assemble/publish without any worker waiting for its children.
+  GameUI retains its single-flight, cancellation, and stale-result checks. A failed or
+  cancelled build drains all submitted tiles and returns no partial pixels.
+  Each visited pool worker retains at most tiled scratch (~0.7 MiB); parallel tiles
+  never write the shared UI scratch. Maps spanning at most 128 blocks remain one Low
+  job and reuse the UI scratch. No additional native threads are created.
 - **UI consistency**: HUD biome and World / Biome map use the same canonical generated-column biome definition as loaded terrain at every zoom level. `BiomeMapResult` carries the exact `BiomeRegionGrid` it was sampled with, and the player marker is placed via `grid.pixelForWorld()`; markers outside the grid are simply not drawn.
 

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -236,8 +236,11 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 		const TaskPriority prio = calculateTaskPriority(queue[i].distSq, lodThreshSq);
 		chunk->setInTransit(true);
 		m_pendingGenJobsCount.fetch_add(1);
-		m_threadPool->enqueue(prio, [chunk, seed, this]() {
+		const auto queuedAt = std::chrono::steady_clock::now();
+		m_threadPool->enqueue(prio, [chunk, seed, this, queuedAt]() {
 			const auto t0 = std::chrono::steady_clock::now();
+			GetProfiler().addWorkerSample("TerrainQueue",
+				std::chrono::duration<float, std::milli>(t0 - queuedAt).count());
 			TerrainGenerator &localGen = TerrainGenerator::getThreadLocal(seed);
 			chunk->generateTerrain(localGen);
 			const float ms = std::chrono::duration<float, std::milli>(
@@ -318,8 +321,11 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 		if (distSq > lodThreshSq)
 		{
 			m_pendingMeshJobsCount.fetch_add(1);
-			m_threadPool->enqueue(prio, [chunk, this]() {
+			const auto queuedAt = std::chrono::steady_clock::now();
+			m_threadPool->enqueue(prio, [chunk, this, queuedAt]() {
 				const auto t0 = std::chrono::steady_clock::now();
+				GetProfiler().addWorkerSample("MeshQueue",
+					std::chrono::duration<float, std::milli>(t0 - queuedAt).count());
 				chunk->generateLODMesh();
 				const float ms = std::chrono::duration<float, std::milli>(
 									 std::chrono::steady_clock::now() - t0)
@@ -337,8 +343,11 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 		{
 			ensureShellPopulated(chunk, ci);
 			m_pendingMeshJobsCount.fetch_add(1);
-			m_threadPool->enqueue(prio, [chunk, this]() {
+			const auto queuedAt = std::chrono::steady_clock::now();
+			m_threadPool->enqueue(prio, [chunk, this, queuedAt]() {
 				const auto t0 = std::chrono::steady_clock::now();
+				GetProfiler().addWorkerSample("MeshQueue",
+					std::chrono::duration<float, std::milli>(t0 - queuedAt).count());
 				chunk->generateMesh();
 				const float ms = std::chrono::duration<float, std::milli>(
 									 std::chrono::steady_clock::now() - t0)

--- a/src/Chunk/TerrainGenerator.cpp
+++ b/src/Chunk/TerrainGenerator.cpp
@@ -1712,6 +1712,42 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
                                       const BiomeCancelCheck &shouldCancel,
                                       BiomeRegionStats *outStats) const
 {
+  return getBiomeRegionTile(grid, {0, 0, grid.width, grid.height},
+                            outBiomes, scratch, shouldCancel, outStats);
+}
+
+std::vector<TerrainGenerator::BiomeRegionTile>
+TerrainGenerator::buildBiomeRegionPlan(const BiomeRegionGrid &grid)
+{
+  if (!grid.valid())
+    return {};
+  // Bounded canonical domains with a two-column erosion halo. Clamping in
+  // float before conversion also handles extremely small positive steps.
+  const float maxSpan = std::sqrt(static_cast<float>(kMaxTileDensePoints));
+  const float dim = std::floor((maxSpan - 5.0f) / grid.step) + 1.0f;
+  const int tileDim = static_cast<int>(std::clamp(dim, 1.0f, 32.0f));
+  std::vector<BiomeRegionTile> plan;
+  for (int z = 0; z < grid.height;)
+  {
+    const int height = std::min(tileDim, grid.height - z);
+    for (int x = 0; x < grid.width;)
+    {
+      const int width = std::min(tileDim, grid.width - x);
+      plan.push_back({x, z, width, height});
+      x += width;
+    }
+    z += height;
+  }
+  return plan;
+}
+
+bool TerrainGenerator::getBiomeRegionTile(const BiomeRegionGrid &grid,
+                                      const BiomeRegionTile &tile,
+                                      std::vector<BiomeType> &outBiomes,
+                                      BiomeRegionScratch *scratch,
+                                      const BiomeCancelCheck &shouldCancel,
+                                      BiomeRegionStats *outStats) const
+{
   outBiomes.clear();
 
   // Scratch owned by the caller when provided; otherwise a dedicated
@@ -1730,7 +1766,9 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
     ~ScratchTrimGuard() { target.trimOversizedCapacity(); }
   } trimGuard{bufs};
 
-  if (!grid.valid())
+  if (!grid.valid() || tile.x < 0 || tile.z < 0 ||
+      tile.width <= 0 || tile.height <= 0 ||
+      tile.x > grid.width - tile.width || tile.z > grid.height - tile.height)
     return false;
 
   BiomeRegionStats localStats;
@@ -1746,8 +1784,8 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
   // int math downstream (span differences, the + NOISE_OFFSET noise-domain
   // translation). One billion blocks is far beyond any reachable world.
   constexpr int64_t kColumnLimit = 1000000000;
-  const auto canonicalColumn = [&grid, kColumnLimit](int xi, int zi) {
-    const glm::ivec2 col = grid.columnAt(xi, zi);
+  const auto canonicalColumn = [&grid, &tile, kColumnLimit](int xi, int zi) {
+    const glm::ivec2 col = grid.columnAt(tile.x + xi, tile.z + zi);
     return glm::ivec2(
         static_cast<int>(std::clamp<int64_t>(col.x, -kColumnLimit, kColumnLimit)),
         static_cast<int>(std::clamp<int64_t>(col.y, -kColumnLimit, kColumnLimit)));
@@ -1793,7 +1831,7 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
         const glm::ivec2 col = canonicalColumn(xi, zi);
         const int denseX = col.x - denseStartX;
         const int denseZ = col.y - denseStartZ;
-        outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(grid.width) +
+        outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(tile.width) +
                   static_cast<size_t>(xi)] =
             evaluateBiomeAt(buffers, denseZ * denseW + denseX);
       }
@@ -1801,7 +1839,7 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
   };
 
   const glm::ivec2 minCol = canonicalColumn(0, 0);
-  const glm::ivec2 maxCol = canonicalColumn(grid.width - 1, grid.height - 1);
+  const glm::ivec2 maxCol = canonicalColumn(tile.width - 1, tile.height - 1);
   const int64_t minWorldX = std::min<int64_t>(minCol.x, maxCol.x);
   const int64_t maxWorldX = std::max<int64_t>(minCol.x, maxCol.x);
   const int64_t minWorldZ = std::min<int64_t>(minCol.y, maxCol.y);
@@ -1816,7 +1854,7 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
   const int64_t denseHeight = spanZ + 2 * HALO;
   const int64_t totalDensePoints = denseWidth * denseHeight;
 
-  const size_t outputCount = static_cast<size_t>(grid.width) * static_cast<size_t>(grid.height);
+  const size_t outputCount = static_cast<size_t>(tile.width) * static_cast<size_t>(tile.height);
 
   if (totalDensePoints <= static_cast<int64_t>(kMaxDenseDomainPoints))
   {
@@ -1853,7 +1891,7 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
 
     fillOutputFromDense(buffers, denseStartX, denseStartZ,
                         static_cast<int>(denseWidth),
-                        0, grid.width - 1, 0, grid.height - 1);
+                        0, tile.width - 1, 0, tile.height - 1);
     ++stats.denseTiles;
     updatePeak(totalDensePoints);
 
@@ -1875,18 +1913,18 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
   const float maxTileSpan = std::sqrt(static_cast<float>(kMaxTileDensePoints));
   const float tileDimF =
       std::floor((maxTileSpan - 1.0f - static_cast<float>(2 * HALO)) / grid.step) + 1.0f;
-  const int tileDim = std::clamp(static_cast<int>(tileDimF), 1, kMaxTileDim);
+  const int tileDim = static_cast<int>(std::clamp(tileDimF, 1.0f, static_cast<float>(kMaxTileDim)));
 
-  const int tilesX = (grid.width + tileDim - 1) / tileDim;
-  const int tilesZ = (grid.height + tileDim - 1) / tileDim;
+  const int tilesX = (tile.width + tileDim - 1) / tileDim;
+  const int tilesZ = (tile.height + tileDim - 1) / tileDim;
 
   outBiomes.resize(outputCount);
 
   // Tiles are processed sequentially in fixed order: the result depends only
   // on the grid and the seed, never on scheduling. TerrainGenerator does not
   // spawn threads and does not decide CPU policy; the caller chooses when and
-  // on which worker the whole call runs (the Engine runs the biome map as a
-  // single TaskPriority::Low job).
+  // on which worker the call runs. The Engine can schedule independent
+  // rectangles from buildBiomeRegionPlan() as TaskPriority::Low jobs.
   for (int tz = 0; tz < tilesZ; ++tz)
   {
     for (int tx = 0; tx < tilesX; ++tx)
@@ -1901,8 +1939,8 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
 
       const int x0 = tx * tileDim;
       const int z0 = tz * tileDim;
-      const int x1 = std::min(x0 + tileDim - 1, grid.width - 1);
-      const int z1 = std::min(z0 + tileDim - 1, grid.height - 1);
+      const int x1 = std::min(x0 + tileDim - 1, tile.width - 1);
+      const int z1 = std::min(z0 + tileDim - 1, tile.height - 1);
 
       const glm::ivec2 tMinCol = canonicalColumn(x0, z0);
       const glm::ivec2 tMaxCol = canonicalColumn(x1, z1);
@@ -1957,7 +1995,7 @@ bool TerrainGenerator::getBiomeRegion(const BiomeRegionGrid &grid,
           for (int xi = x0; xi <= x1; ++xi)
           {
             const glm::ivec2 col = canonicalColumn(xi, zi);
-            outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(grid.width) +
+            outBiomes[static_cast<size_t>(zi) * static_cast<size_t>(tile.width) +
                       static_cast<size_t>(xi)] = evaluateBiomeColumn(col.x, col.y);
           }
         }

--- a/src/Chunk/TerrainGenerator.hpp
+++ b/src/Chunk/TerrainGenerator.hpp
@@ -192,6 +192,23 @@ public:
     size_t peakScratchBytes{0};  // peakDensePoints * fields * sizeof(float)
   };
 
+  struct BiomeRegionTile
+  {
+    int x{0}, z{0}, width{0}, height{0};
+  };
+  // Independent output rectangles in the ORIGINAL grid. No recentering:
+  // float rounding and canonical column selection must match the full map.
+  // Planning and sampling are sequential; scheduling belongs to the caller.
+  static std::vector<BiomeRegionTile> buildBiomeRegionPlan(const BiomeRegionGrid &grid);
+  // Tile-local row-major output (tile.width stride). Invalid/out-of-grid
+  // rectangles and cancellation clear output. Scratch retention follows the
+  // same contract as getBiomeRegion(); concurrent callers need distinct scratch.
+  bool getBiomeRegionTile(const BiomeRegionGrid &grid, const BiomeRegionTile &tile,
+                         std::vector<BiomeType> &outBiomes,
+                         BiomeRegionScratch *scratch = nullptr,
+                         const BiomeCancelCheck &shouldCancel = {},
+                         BiomeRegionStats *outStats = nullptr) const;
+
   // Batch biome sampling for map visualization. `grid` is the single source
   // of truth for the pixel <-> world <-> voxel-column mapping (see
   // BiomeRegionGrid.hpp). Output is row-major, outBiomes[grid.width * z + x].
@@ -203,8 +220,7 @@ public:
   // (and clears outBiomes) when the grid is invalid or `shouldCancel`
   // returned true; partial results are never returned. On every exit —
   // success, cancellation, failure, or exception — the scratch is trimmed
-  // to the tiled-path bound, so oversized dense capacity is never retained
-  // across attempts. `outStats` is optional. `scratch` may be null, in
+  // to its configured retention bound. `outStats` is optional. `scratch` may be null, in
   // which case a dedicated internal thread-local scratch is used; pass a
   // caller-owned scratch to control memory retention (see
   // BiomeRegionScratch).

--- a/src/Engine/Benchmark.cpp
+++ b/src/Engine/Benchmark.cpp
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <fstream>
 #include <sstream>
+#include <cstring>
 
 #if defined(_WIN32)
 #include <direct.h>
@@ -15,6 +16,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #endif
+
+static constexpr const char *kBackgroundNames[] = {"TerrainQueue", "MeshQueue", "BiomeMap"};
 
 void Benchmark::requestStart()
 {
@@ -24,6 +27,7 @@ void Benchmark::requestStart()
 	m_elapsed = 0.f;
 	m_showReport = false;
 	m_report = {};
+	m_backgroundWork = {};
 	m_frameMs.clear();
 	m_sumStreaming = m_sumAcquire = m_sumRecord = m_sumImGui = m_sumPresent = 0;
 	m_sumVisibility = m_sumMeshUpload = 0;
@@ -148,6 +152,18 @@ void Benchmark::sampleFrame(float frameMs, float scopeStreaming, float scopeAcqu
 		++m_over33;
 }
 
+void Benchmark::sampleBackgroundWork(const char *name, uint64_t count, double totalMs)
+{
+	if (m_phase != BenchmarkPhase::Running)
+		return;
+	for (size_t i = 0; i < m_backgroundWork.size(); ++i)
+		if (std::strcmp(name, kBackgroundNames[i]) == 0)
+		{
+			m_backgroundWork[i].count += count;
+			m_backgroundWork[i].totalMs += totalMs;
+		}
+}
+
 float Benchmark::totalProgress() const
 {
 	const float total = m_config.warmupSec + m_config.durationSec;
@@ -267,6 +283,9 @@ void Benchmark::finalize()
 	r.avgVisibility = static_cast<float>(m_sumVisibility) * invN;
 	r.avgMeshUpload = static_cast<float>(m_sumMeshUpload) * invN;
 
+	r.backgroundWork = m_backgroundWork;
+	r.biomeMapZoom = m_config.biomeMapZoom;
+	r.biomeMapSequential = m_config.biomeMapSequential;
 	r.terrainGenJobs = m_terrainJobs;
 	r.terrainGenTotalMs = static_cast<float>(m_terrainMs);
 	r.terrainGenAvgMs = m_terrainJobs > 0 ? static_cast<float>(m_terrainMs / m_terrainJobs) : 0.f;
@@ -344,6 +363,16 @@ std::string Benchmark::formatReportText() const
 	  << "  totalMs=" << r.meshBuildTotalMs << "\n";
 	o << "  MeshLOD     n=" << r.meshLodJobs << "  avgMs=" << r.meshLodAvgMs
 	  << "  totalMs=" << r.meshLodTotalMs << "\n\n";
+	o << "Biome map: zoom=" << r.biomeMapZoom
+	  << " mode=" << (r.biomeMapSequential ? "sequential" : "scheduled")
+	  << " (fixed center when enabled)\n";
+	for (size_t i = 0; i < r.backgroundWork.size(); ++i)
+	{
+		const auto &work = r.backgroundWork[i];
+		o << "  " << kBackgroundNames[i] << " n=" << work.count
+		  << " avgMs=" << (work.count ? work.totalMs / work.count : 0.0)
+		  << " totalMs=" << work.totalMs << "\n";
+	}
 	o << "Peaks: chunks=" << r.peakChunks << " draw=" << r.peakDraw
 	  << " qLoad/Gen/Mesh=" << r.peakPendingLoad << "/" << r.peakPendingGen << "/"
 	  << r.peakPendingMesh << "\n\n";

--- a/src/Engine/Benchmark.hpp
+++ b/src/Engine/Benchmark.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <array>
 
 enum class BenchmarkPhase
 {
@@ -25,11 +26,22 @@ struct BenchmarkConfig
 	float pathRadius{160.f};
 	float pathHeight{48.f}; // above surface Y at center
 	bool forceVsyncOff{false};
+	float biomeMapZoom{0.f}; // >0 opens a fixed-center map during the benchmark
+	bool biomeMapSequential{false}; // control measurement of the previous path
+};
+
+struct BenchmarkWorkTiming
+{
+	uint64_t count{0};
+	double totalMs{0};
 };
 
 struct BenchmarkReport
 {
 	bool valid{false};
+	std::array<BenchmarkWorkTiming, 3> backgroundWork{};
+	float biomeMapZoom{0.f};
+	bool biomeMapSequential{false};
 
 	int seed{0};
 	float durationSec{0.f};
@@ -132,6 +144,8 @@ public:
 					 size_t pendingMesh, uint64_t terrainJobs, float terrainMs, uint64_t meshJobs,
 					 float meshMs, uint64_t lodJobs, float lodMs);
 
+	/// Queue waits and completed map latency from the frame's profiler snapshot.
+	void sampleBackgroundWork(const char *name, uint64_t count, double totalMs);
 	/// Progress 0–1 over warmup+duration total wall time for UI bar (full run).
 	float totalProgress() const;
 	/// Progress 0–1 of measurement only (warmup excluded).
@@ -184,6 +198,7 @@ public:
 	void clearVsyncRestore() { m_vsyncRestorePending = false; }
 
 private:
+	std::array<BenchmarkWorkTiming, 3> m_backgroundWork{};
 	std::vector<float> m_frameMs;
 	double m_sumStreaming{0}, m_sumAcquire{0}, m_sumRecord{0}, m_sumImGui{0}, m_sumPresent{0};
 	double m_sumVisibility{0}, m_sumMeshUpload{0};

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -732,6 +732,8 @@ void Engine::tickBenchmark(double dt)
 	if (m_benchmark.phase() == BenchmarkPhase::Reloading)
 	{
 		const BenchmarkConfig &cfg = m_benchmark.config();
+		if (cfg.biomeMapZoom > 0.0f)
+			gameUi->configureBenchmarkMap(cfg.biomeMapZoom);
 		if (cfg.forceVsyncOff && renderSettings.vsyncEnabled)
 		{
 			m_benchmark.markForceVsync(true);
@@ -784,6 +786,7 @@ void Engine::sampleBenchmarkFrame()
 	{
 		if (!ws[i].name)
 			continue;
+		m_benchmark.sampleBackgroundWork(ws[i].name, ws[i].count, ws[i].totalMs);
 		if (std::strcmp(ws[i].name, "TerrainGen") == 0)
 		{
 			tJobs = ws[i].count;
@@ -861,12 +864,19 @@ void Engine::drawUi()
 	if (threadPool)
 	{
 		f.submitBiomeMap = [this](BiomeMapRequest req) -> std::future<BiomeMapResult> {
+			if (!m_benchmark.config().biomeMapSequential)
+				return submitBiomeMap(*threadPool, std::move(req));
+			// Benchmark control: the previous one-Low-job map path.
 			auto promise = std::make_shared<std::promise<BiomeMapResult>>();
-			std::future<BiomeMapResult> fut = promise->get_future();
-			threadPool->enqueue(TaskPriority::Low, [promise, req]() mutable {
-				promise->set_value(generateBiomeMap(req));
+			auto future = promise->get_future();
+			const auto start = std::chrono::steady_clock::now();
+			threadPool->enqueue(TaskPriority::Low, [promise, req, start] {
+				BiomeMapResult result;
+				try { result = generateBiomeMap(req); } catch (...) {}
+				result.elapsedMs = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+				promise->set_value(std::move(result));
 			});
-			return fut;
+			return future;
 		};
 	}
 

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -1300,6 +1300,7 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 
 		if (isBiomeMapResultAcceptable(res, frame.worldGenerationId, frame.seed, m_mapRequestId))
 		{
+			GetProfiler().addWorkerSample("BiomeMap", static_cast<float>(res.elapsedMs));
 			paintBiomeMapPlayerDot(res.rgba, res.grid, playerXZ);
 			m_mapCenter = res.center;
 			ensureBiomeTexture(res.size);
@@ -1343,10 +1344,9 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 		m_mapJob.requestId = requestId;
 		m_mapJob.cancel = cancelToken;
 
-		// One scratch for the whole biome-map subsystem: dense capacity is
-		// retained across refreshes (no per-refresh reallocation churn),
-		// bounded in total by kMaxDenseDomainPoints and owned by GameUI so
-		// no pool worker keeps a private copy.
+		// Sequential/small-map scratch retains dense capacity across refreshes,
+		// bounded by kMaxDenseDomainPoints and owned by GameUI. Parallel tiles
+		// use separate thread-local scratch with only tiled-sized retention.
 		if (!m_mapScratch)
 		{
 			m_mapScratch = std::make_shared<TerrainGenerator::BiomeRegionScratch>();

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -119,6 +119,15 @@ public:
 	bool showHelp() const { return m_showHelp; }
 	bool showProfiler() const { return m_showProfiler; }
 
+	/// Reproducible streaming benchmark: map stays open at a fixed center.
+	void configureBenchmarkMap(float zoom)
+	{
+		m_showWorld = true;
+		m_mapZoom = zoom;
+		m_mapFollow = false;
+		invalidateBiomeMap();
+	}
+
 	void setShowHud(bool v) { m_showHud = v; }
 
 	/// Invalidate any active or in-flight biome map task and clear current texture.
@@ -212,8 +221,8 @@ private:
 
 	BiomeMapJob m_mapJob{};
 	BiomeMapUpload m_pendingUpload{};
-	// Single process-wide region scratch for the biome-map job (never one
-	// per pool worker): its retention cap allows dense-capacity reuse so
+	// Owner scratch for sequential/small maps. Parallel tiles use separate
+	// bounded thread-local scratch; this retention cap allows dense reuse so
 	// refreshes do not re-allocate the dense peak, while retention stays
 	// bounded by kMaxDenseDomainPoints per field (~10 MiB logical payload
 	// in total). The scratch holds only scratch floats - no seed- or

--- a/src/Engine/GameUIBiomeMap.cpp
+++ b/src/Engine/GameUIBiomeMap.cpp
@@ -2,6 +2,9 @@
 #include <Chunk/TerrainGenerator.hpp>
 
 #include <cmath>
+#include <algorithm>
+#include <Engine/ThreadPool.hpp>
+#include <chrono>
 
 void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
 							const BiomeRegionGrid &grid,
@@ -37,6 +40,52 @@ void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
 		for (int dx = -2; dx <= 2; ++dx)
 			if (dx * dx + dy * dy <= 4)
 				paint(dot.x + dx, dot.y + dy, 255, 255, 255);
+}
+
+static BiomeMapResult colorBiomeMap(const BiomeMapRequest &req,
+                                    const BiomeRegionGrid &grid,
+                                    const std::vector<BiomeType> &biomes)
+{
+	auto cancelled = [&]() {
+		return req.cancelToken && req.cancelToken->load(std::memory_order_relaxed);
+	};
+	// Checkpoint 3: before RGBA allocation
+	if (cancelled())
+		return {};
+
+	const size_t totalPixels = static_cast<size_t>(req.size) * static_cast<size_t>(req.size);
+	std::vector<unsigned char> rgba(totalPixels * 4);
+
+	// Checkpoint 4: conversion loop with periodic check every 1024 iterations
+	constexpr size_t kCheckInterval = 1024;
+	for (size_t i = 0; i < totalPixels; ++i)
+	{
+		if ((i % kCheckInterval) == 0 && cancelled())
+			return {};
+
+		const int b = static_cast<int>(biomes[i]);
+		const int bi = (b >= 0 && b < BIOME_COUNT) ? b : 0;
+		rgba[i * 4 + 0] = kBiomeColors[bi][0];
+		rgba[i * 4 + 1] = kBiomeColors[bi][1];
+		rgba[i * 4 + 2] = kBiomeColors[bi][2];
+		rgba[i * 4 + 3] = 255;
+	}
+
+	// Checkpoint 5: before publication
+	if (cancelled())
+		return {};
+
+	BiomeMapResult res;
+	res.requestId = req.requestId;
+	res.worldGenerationId = req.worldGenerationId;
+	res.seed = req.seed;
+	res.center = req.center;
+	res.zoom = req.zoom;
+	res.grid = grid;
+	res.size = req.size;
+	res.rgba = std::move(rgba);
+	res.valid = true;
+	return res;
 }
 
 BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
@@ -79,41 +128,152 @@ BiomeMapResult generateBiomeMap(const BiomeMapRequest &req)
 	if (!gen.getBiomeRegion(grid, biomes, scratch, [&] { return cancelled(); }))
 		return {};
 
-	// Checkpoint 3: before RGBA allocation
-	if (cancelled())
-		return {};
+	return colorBiomeMap(req, grid, biomes);
+}
 
-	const size_t totalPixels = static_cast<size_t>(req.size * req.size);
-	std::vector<unsigned char> rgba(totalPixels * 4);
+namespace
+{
+struct BiomeMapBuild : std::enable_shared_from_this<BiomeMapBuild>
+{
+	BiomeMapRequest request;
+	const std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
+	BiomeRegionGrid grid;
+	std::vector<BiomeType> biomes;
+	std::vector<TerrainGenerator::BiomeRegionTile> plan;
+	std::atomic<size_t> nextTile{0};
+	std::promise<BiomeMapResult> promise;
+	// Submission sentinel prevents publication while more work is enqueued.
+	std::atomic<size_t> remaining{1};
+	std::atomic<bool> failed{false};
 
-	// Checkpoint 4: conversion loop with periodic check every 1024 iterations
-	constexpr size_t kCheckInterval = 1024;
-	for (size_t i = 0; i < totalPixels; ++i)
+	bool cancelled() const
 	{
-		if ((i % kCheckInterval) == 0 && cancelled())
-			return {};
-
-		const int b = static_cast<int>(biomes[i]);
-		const int bi = (b >= 0 && b < BIOME_COUNT) ? b : 0;
-		rgba[i * 4 + 0] = kBiomeColors[bi][0];
-		rgba[i * 4 + 1] = kBiomeColors[bi][1];
-		rgba[i * 4 + 2] = kBiomeColors[bi][2];
-		rgba[i * 4 + 3] = 255;
+		return failed.load(std::memory_order_relaxed) ||
+			(request.cancelToken && request.cancelToken->load(std::memory_order_relaxed));
 	}
 
-	// Checkpoint 5: before publication
-	if (cancelled())
-		return {};
+	void publish(BiomeMapResult result)
+	{
+		result.elapsedMs = std::chrono::duration<double, std::milli>(
+			std::chrono::steady_clock::now() - start).count();
+		promise.set_value(std::move(result));
+	}
 
-	BiomeMapResult res;
-	res.requestId = req.requestId;
-	res.worldGenerationId = req.worldGenerationId;
-	res.seed = req.seed;
-	res.center = req.center;
-	res.zoom = req.zoom;
-	res.grid = grid;
-	res.size = req.size;
-	res.rgba = std::move(rgba);
-	res.valid = true;
-	return res;
+	void finish()
+	{
+		// The last tile acquires all disjoint writes before converting/publishing.
+		if (remaining.fetch_sub(1, std::memory_order_acq_rel) != 1)
+			return;
+		BiomeMapResult result;
+		try
+		{
+			if (!cancelled())
+				result = colorBiomeMap(request, grid, biomes);
+		}
+		catch (...) {} // Failed builds are invalid, never partially published.
+		publish(std::move(result));
+	}
+
+	void runTile(ThreadPool &pool, TerrainGenerator::BiomeRegionTile tile)
+	{
+		try
+		{
+			if (!cancelled())
+			{
+				auto &gen = TerrainGenerator::getThreadLocal(request.seed);
+				std::vector<BiomeType> pixels;
+				// Dedicated thread-local tile scratch, never the shared request
+				// scratch. Retention stays below ~0.7 MiB per worker.
+				if (!gen.getBiomeRegionTile(grid, tile, pixels, nullptr,
+					[&] { return cancelled(); }))
+					failed.store(true, std::memory_order_relaxed);
+				else
+					for (int z = 0; z < tile.height; ++z)
+						std::copy_n(pixels.begin() + static_cast<size_t>(z) * tile.width,
+							tile.width, biomes.begin() +
+							static_cast<size_t>(tile.z + z) * grid.width + tile.x);
+			}
+		}
+		catch (...) { failed.store(true, std::memory_order_relaxed); }
+		// Re-enqueue each next tile at Low priority: yield to streaming between
+		// tiles rather than running a whole lane as one non-preemptible job.
+		enqueueNext(pool);
+		finish();
+	}
+
+	void enqueueNext(ThreadPool &pool)
+	{
+		if (cancelled())
+			return;
+		const size_t index = nextTile.fetch_add(1, std::memory_order_relaxed);
+		if (index >= plan.size())
+			return;
+		remaining.fetch_add(1, std::memory_order_relaxed);
+		try
+		{
+			pool.enqueue(TaskPriority::Low, [build = shared_from_this(), &pool, index] {
+				build->runTile(pool, build->plan[index]);
+			});
+		}
+		catch (...)
+		{
+			failed.store(true, std::memory_order_relaxed);
+			finish(); // undo this unsubmitted tile; caller still holds one count
+		}
+	}
+
+	void enqueueTiles(ThreadPool &pool)
+	{
+		plan = TerrainGenerator::buildBiomeRegionPlan(grid);
+		biomes.resize(static_cast<size_t>(grid.width) * grid.height);
+		// Bound map pressure to eight lanes even on large machines. The map
+		// remains one single-flight build and adds no native worker threads.
+		const size_t lanes = std::min({size_t(8), pool.workerCount(), plan.size()});
+		for (size_t i = 0; i < lanes; ++i)
+			enqueueNext(pool);
+	}
+
+	void run(ThreadPool &pool)
+	{
+		try
+		{
+			grid = makeBiomeRegionGrid(request.center.x, request.center.y,
+				1.0f / request.zoom, request.size, request.size);
+			if (!grid.valid() || cancelled())
+				failed.store(true, std::memory_order_relaxed);
+			else if (static_cast<double>(request.size) * grid.step <= 128.0)
+			{
+				// Small maps stay a single Low job, reusing the owner's scratch.
+				publish(generateBiomeMap(request));
+				return;
+			}
+			else
+			{
+				if (request.onCheckpoint)
+					request.onCheckpoint();
+				if (!cancelled())
+					enqueueTiles(pool);
+			}
+		}
+		catch (...) { failed.store(true, std::memory_order_relaxed); }
+		finish(); // release submission sentinel; never wait for children
+	}
+};
+}
+
+std::future<BiomeMapResult> submitBiomeMap(ThreadPool &pool, BiomeMapRequest request)
+{
+	auto build = std::make_shared<BiomeMapBuild>();
+	build->request = std::move(request);
+	auto future = build->promise.get_future();
+	try
+	{
+		pool.enqueue(TaskPriority::Low, [build, &pool] { build->run(pool); });
+	}
+	catch (...)
+	{
+		build->failed.store(true, std::memory_order_relaxed);
+		build->finish();
+	}
+	return future;
 }

--- a/src/Engine/GameUIBiomeMap.hpp
+++ b/src/Engine/GameUIBiomeMap.hpp
@@ -59,7 +59,9 @@ struct BiomeMapRequest
 	std::shared_ptr<std::atomic<bool>> cancelToken;
 	/// Optional injectable test seam hook invoked before sampling.
 	std::function<void()> onCheckpoint;
-	/// Owner-controlled region scratch for the sampling job. When set, the
+	/// Owner-controlled scratch for the sequential/small-map path. Parallel
+	/// tiles never share it; each worker uses bounded thread-local scratch.
+	/// When set, the
 	/// job reuses it across refreshes (retention bounded by the scratch's
 	/// retainedPointsCap); when null, getBiomeRegion falls back to an
 	/// internal thread-local scratch. Shared ownership keeps the scratch
@@ -83,6 +85,7 @@ struct BiomeMapResult
 	int size{0};
 	std::vector<unsigned char> rgba;
 	bool valid{false};
+	double elapsedMs{0.0}; // scheduled request to completed CPU result, including queue time
 };
 
 /// Pending GPU upload request for streamed biome map data.
@@ -155,4 +158,10 @@ void paintBiomeMapPlayerDot(std::vector<unsigned char> &rgba,
 /// tiles), and after sampling — an interrupted build returns an invalid
 /// result and never publishes partial pixel data.
 BiomeMapResult generateBiomeMap(const BiomeMapRequest &req);
+
+class ThreadPool;
+/// Engine-owned Low-priority tile scheduling. No worker waits for children.
+/// Request data lives until every tile retires; the last tile publishes.
+/// The pool must outlive submission/execution. GameUI enforces single-flight.
+std::future<BiomeMapResult> submitBiomeMap(ThreadPool &pool, BiomeMapRequest req);
 

--- a/src/Engine/Profiler.cpp
+++ b/src/Engine/Profiler.cpp
@@ -12,6 +12,9 @@ Profiler::Profiler()
 	registerWorkerName("TerrainGen");
 	registerWorkerName("MeshBuild");
 	registerWorkerName("MeshLOD");
+	registerWorkerName("TerrainQueue");
+	registerWorkerName("MeshQueue");
+	registerWorkerName("BiomeMap");
 }
 
 Profiler &GetProfiler()

--- a/src/Engine/ThreadPool.hpp
+++ b/src/Engine/ThreadPool.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <atomic>
 #include <memory>
+#include <stdexcept>
 
 // Add above ThreadPool class
 enum class TaskPriority { High = 0, Normal = 1, Low = 2, Count = 3 };
@@ -22,8 +23,10 @@ class ThreadPool
 {
 public:
 	explicit ThreadPool(size_t numThreads)
-		: stop_(false), nextQueue_(0), numWorkers_(numThreads), taskCount_(0)
+		: numWorkers_(numThreads), stop_(false), nextQueue_(0), taskCount_(0)
 	{
+		if (numThreads == 0)
+			throw std::invalid_argument("ThreadPool requires at least one worker");
 		queues_.resize(numThreads);
 		for (size_t i = 0; i < numThreads; ++i)
 			queues_[i] = std::make_unique<LocalQueue>();
@@ -52,11 +55,15 @@ public:
 			std::lock_guard<std::mutex> lk(queues_[qi]->mx);
 			queues_[qi]->dq[static_cast<int>(priority)].emplace_front([task]
 										  { (*task)(); }); // LIFO push
+			taskCount_.fetch_add(1, std::memory_order_release);
 		}
-		taskCount_.fetch_add(1, std::memory_order_release);
+		// Synchronize notification with the sleeper predicate/wait transition.
+		{ std::lock_guard<std::mutex> lk(sleepMux_); }
 		cv_.notify_one();
 		return res;
 	}
+
+	size_t workerCount() const { return numWorkers_; }
 
 	// Overload for backward compatibility (defaults to Normal)
 	template <class F>
@@ -76,38 +83,24 @@ private:
 	// another worker's back (FIFO — oldest items first, minimises latency).
 	std::function<void()> tryGetTask(size_t id)
 	{
-		// Own queue
+		// Search EVERY queue for High before Normal, and Normal before Low.
+		// Local Low map tiles must not hide queued High/Normal chunk work.
+		for (int p = 0; p < static_cast<int>(TaskPriority::Count); ++p)
 		{
-			std::lock_guard<std::mutex> lk(queues_[id]->mx);
-			for (int p = 0; p < static_cast<int>(TaskPriority::Count); ++p)
+			for (size_t j = 0; j < numWorkers_; ++j)
 			{
-				if (!queues_[id]->dq[p].empty())
-				{
-					auto t = std::move(queues_[id]->dq[p].front());
-					queues_[id]->dq[p].pop_front();
-					taskCount_.fetch_sub(1, std::memory_order_relaxed);
-					return t;
-				}
-			}
-		}
-		// Steal from neighbours — use try_lock to skip busy victims rather than
-		// blocking, which avoids an O(N) lock-acquire chain under burst steal load.
-		for (size_t j = 1; j < numWorkers_; ++j)
-		{
-			size_t victim = (id + j) % numWorkers_;
-			std::unique_lock<std::mutex> lk(queues_[victim]->mx, std::try_to_lock);
-			if (!lk)
-				continue;
-			
-			for (int p = 0; p < static_cast<int>(TaskPriority::Count); ++p)
-			{
-				if (!queues_[victim]->dq[p].empty())
-				{
-					auto t = std::move(queues_[victim]->dq[p].back());
-					queues_[victim]->dq[p].pop_back();
-					taskCount_.fetch_sub(1, std::memory_order_relaxed);
-					return t;
-				}
+				const size_t victim = (id + j) % numWorkers_;
+				std::lock_guard<std::mutex> lk(queues_[victim]->mx);
+				auto &queue = queues_[victim]->dq[p];
+				if (queue.empty())
+					continue;
+				auto task = std::move(j == 0 ? queue.front() : queue.back());
+				if (j == 0)
+					queue.pop_front();
+				else
+					queue.pop_back();
+				taskCount_.fetch_sub(1, std::memory_order_relaxed);
+				return task;
 			}
 		}
 		return {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <Renderer/MinecraftTextures.hpp>
 #include <algorithm>
 #include <cstdlib>
+#include <cmath>
 #include <iostream>
 #include <optional>
 #include <string>
@@ -17,6 +18,8 @@ static void printUsage(const char *argv0)
 			  << "                              (defaults to ressources/default-resource-pack.zip)\n"
 			  << "  --vsync <on|off>            FIFO when on; strict IMMEDIATE and uncapped when off\n"
 			  << "  --benchmark <seconds>       Run a wide streaming benchmark, save report, exit\n"
+			  << "  --benchmark-map <zoom>      Open fixed-center biome map (zoom 0.1..8)\n"
+			  << "  --benchmark-map-sequential  Compare the previous one-job map path\n"
 			  << "  --help                      Show this help\n"
 			  << "\n"
 			  << "Env: FT_VOX_RESOURCE_PACK=<path>  used when --resource-pack is not set\n";
@@ -38,6 +41,8 @@ int main(int argc, char **argv)
 	std::string resourcePackCli;
 	std::optional<bool> vsyncOverride;
 	float benchmarkDuration = 0.0f;
+	float benchmarkMapZoom = 0.0f;
+	bool benchmarkMapSequential = false;
 
 	for (int i = 1; i < argc; ++i)
 	{
@@ -75,6 +80,28 @@ int main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 			resourcePackCli = argv[++i];
+			continue;
+		}
+		if (arg == "--benchmark-map-sequential")
+		{
+			benchmarkMapSequential = true;
+			continue;
+		}
+		if (arg == "--benchmark-map")
+		{
+			if (i + 1 >= argc)
+			{
+				std::cerr << "Error: --benchmark-map requires a zoom.\n";
+				return EXIT_FAILURE;
+			}
+			char *end = nullptr;
+			benchmarkMapZoom = std::strtof(argv[++i], &end);
+			if (end == argv[i] || *end || !std::isfinite(benchmarkMapZoom) ||
+				benchmarkMapZoom < 0.1f || benchmarkMapZoom > 8.0f)
+			{
+				std::cerr << "Error: --benchmark-map zoom must be between 0.1 and 8.\n";
+				return EXIT_FAILURE;
+			}
 			continue;
 		}
 		if (arg == "--benchmark")
@@ -119,6 +146,12 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	if ((benchmarkMapZoom > 0.0f && benchmarkDuration == 0.0f) ||
+		(benchmarkMapSequential && benchmarkMapZoom == 0.0f))
+	{
+		std::cerr << "Error: map benchmark options require --benchmark and --benchmark-map.\n";
+		return EXIT_FAILURE;
+	}
 	const std::string resourcePack = resolveResourcePackRoot(resourcePackCli);
 
 	try
@@ -132,6 +165,8 @@ int main(int argc, char **argv)
 			BenchmarkConfig &config = engine.benchmark().config();
 			config.seed = seed_to_use > 0 ? static_cast<int>(seed_to_use) : 42;
 			config.durationSec = benchmarkDuration;
+			config.biomeMapZoom = benchmarkMapZoom;
+			config.biomeMapSequential = benchmarkMapSequential;
 			config.warmupSec = std::min(2.0f, benchmarkDuration * 0.2f);
 			config.pathOrbits = 2;
 			config.pathRadius = 512.0f;

--- a/tests/test_biome_map.cpp
+++ b/tests/test_biome_map.cpp
@@ -1,5 +1,9 @@
 // Biome map generation lifetime, concurrency safety, cancellation, and stale/superseded rejection tests.
 #include <Engine/GameUIBiomeMap.hpp>
+#include <Engine/ThreadPool.hpp>
+#include <chrono>
+#include <algorithm>
+#include <cstring>
 #include <Chunk/TerrainGenerator.hpp>
 
 #include <atomic>
@@ -694,8 +698,169 @@ static void test_request_scratch_reuse()
 		  "returning to dense zoom must reuse the retained capacity without churn");
 }
 
-int main()
+
+
+static void test_region_tile_plan()
 {
+	for (int seed : {42, 4242})
+	{
+		TerrainGenerator gen(seed);
+		for (float step : {0.125f, 1.0f, 10.0f, 1.0e20f})
+		{
+			const auto grid = makeBiomeRegionGrid(-16.01f, 123.6f, step, 67, 35);
+			std::vector<BiomeType> expected, assembled(67 * 35);
+			std::vector<int> visits(67 * 35);
+			CHECK(gen.getBiomeRegion(grid, expected), "sequential region succeeds");
+			auto plan = TerrainGenerator::buildBiomeRegionPlan(grid);
+			std::reverse(plan.begin(), plan.end());
+			TerrainGenerator::BiomeRegionScratch scratch;
+			for (auto tile : plan)
+			{
+				std::vector<BiomeType> pixels;
+				CHECK(gen.getBiomeRegionTile(grid, tile, pixels, &scratch), "independent tile succeeds");
+				for (int z = 0; z < tile.height; ++z)
+					for (int x = 0; x < tile.width; ++x)
+					{
+						const size_t i = static_cast<size_t>(tile.z + z) * grid.width + tile.x + x;
+						assembled[i] = pixels[static_cast<size_t>(z) * tile.width + x];
+						++visits[i];
+					}
+				CHECK(scratch.temperature.capacity() <= TerrainGenerator::kMaxTileDensePoints,
+					  "tile scratch retention stays bounded");
+			}
+			CHECK(assembled == expected, "reverse tile order preserves every biome");
+			CHECK(std::all_of(visits.begin(), visits.end(), [](int n) { return n == 1; }),
+				  "plan partitions output without gaps or overlap");
+			CHECK(!gen.getBiomeRegionTile(grid, {-1, 0, 1, 1}, assembled), "invalid rectangle rejected");
+			CHECK(assembled.empty(), "invalid rectangle never returns partial data");
+			int checks = 0;
+			CHECK(!gen.getBiomeRegionTile(grid, plan.front(), assembled, &scratch,
+				[&] { return ++checks == 2; }), "late tile cancellation rejected");
+			CHECK(assembled.empty(), "cancelled tile output cleared");
+		}
+	}
+}
+
+static void test_parallel_maps()
+{
+	for (size_t workers : {size_t(1), size_t(4)})
+	{
+		ThreadPool pool(workers);
+		for (float zoom : {0.1f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f})
+		{
+			BiomeMapRequest req;
+			req.seed = 1337;
+			req.requestId = 8;
+			req.worldGenerationId = 3;
+			req.size = 65; // odd dimensions, partial edge tiles
+			req.center = {-123.6f, 432.1f};
+			req.zoom = zoom;
+			const auto expected = generateBiomeMap(req);
+			auto future = submitBiomeMap(pool, req);
+			CHECK(future.wait_for(std::chrono::seconds(10)) == std::future_status::ready,
+				  "parallel map completes even with one worker (no nested waits)");
+			const auto actual = future.get();
+			CHECK(actual.valid && actual.rgba == expected.rgba, "scheduled map matches sequential RGBA exactly");
+			CHECK(isBiomeMapResultAcceptable(actual, 3, 1337, 8), "scheduled result preserves identity/grid");
+		}
+	}
+
+	ThreadPool pool(1);
+	BiomeMapRequest req;
+	req.size = 65;
+	req.zoom = 0.1f;
+	req.cancelToken = std::make_shared<std::atomic<bool>>(true);
+	CHECK(!submitBiomeMap(pool, req).get().valid, "pre-cancelled scheduled map rejected");
+	req.cancelToken->store(false);
+	// Parent enqueues tiles, then a queued High task cancels before they run.
+	req.onCheckpoint = [&] {
+		pool.enqueue(TaskPriority::High, [token = req.cancelToken] { token->store(true); });
+	};
+	const auto cancelled = submitBiomeMap(pool, req).get();
+	CHECK(!cancelled.valid && cancelled.rgba.empty(), "queued tiles drain cancellation without partial publication");
+	req.cancelToken->store(false);
+	req.onCheckpoint = [] { throw std::runtime_error("test failure"); };
+	CHECK(!submitBiomeMap(pool, req).get().valid, "job failure resolves future with invalid result");
+	req.onCheckpoint = {};
+	std::future<BiomeMapResult> future;
+	{
+		ThreadPool draining(2);
+		future = submitBiomeMap(draining, req);
+	} // pool shutdown must drain parent and all children without dangling state
+	CHECK(future.get().valid, "shutdown drains scheduled map");
+}
+
+static void test_global_priority()
+{
+	ThreadPool pool(2);
+	std::promise<void> enteredA, enteredB, releaseA, releaseB;
+	auto gateA = releaseA.get_future().share();
+	auto gateB = releaseB.get_future().share();
+	auto a = pool.enqueue(TaskPriority::High, [&] { enteredA.set_value(); gateA.wait(); });
+	enteredA.get_future().wait();
+	auto b = pool.enqueue(TaskPriority::High, [&] { enteredB.set_value(); gateB.wait(); });
+	enteredB.get_future().wait();
+	// Only one worker is released. Every priority has work in both queues,
+	// so local-first scheduling would select local Normal before remote High.
+	std::vector<int> order;
+	std::vector<std::future<void>> tasks;
+	for (auto priority : {TaskPriority::Low, TaskPriority::Normal, TaskPriority::High})
+		for (int i = 0; i < 2; ++i)
+			tasks.push_back(pool.enqueue(priority, [&, priority] { order.push_back(static_cast<int>(priority)); }));
+	releaseA.set_value();
+	for (auto &task : tasks)
+		task.get();
+	CHECK(order == std::vector<int>({0, 0, 1, 1, 2, 2}), "High/Normal across all queues precede local Low tiles");
+	releaseB.set_value();
+	a.get(); b.get();
+}
+
+static int benchmark_maps()
+{
+	using Clock = std::chrono::steady_clock;
+	const size_t workers = std::min(size_t(8), std::max(size_t(1), size_t(std::thread::hardware_concurrency())));
+	ThreadPool pool(workers);
+	BiomeMapRequest req;
+	req.seed = 1337;
+	req.size = 256;
+	req.center = {-123.6f, 432.1f};
+	req.scratch = std::make_shared<TerrainGenerator::BiomeRegionScratch>();
+	req.scratch->retainedPointsCap = TerrainGenerator::kMaxDenseDomainPoints;
+	std::cout << "[Biome map latency] workers=" << workers << " size=256 seed=1337 (3 runs, alternating order)\n";
+	for (float zoom : {0.1f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f})
+	{
+		req.zoom = zoom;
+		generateBiomeMap(req);
+		submitBiomeMap(pool, req).get();
+		double sequential = 0, parallel = 0;
+		for (int run = 0; run < 3; ++run)
+		{
+			BiomeMapResult reference, scheduled;
+			for (int phase = 0; phase < 2; ++phase)
+			{
+				const bool usePool = ((run + phase) % 2) != 0;
+				const auto start = Clock::now();
+				auto result = usePool ? submitBiomeMap(pool, req).get() : generateBiomeMap(req);
+				const double ms = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+				(usePool ? parallel : sequential) += ms;
+				(usePool ? scheduled : reference) = std::move(result);
+			}
+			CHECK(reference.valid && scheduled.valid && reference.rgba == scheduled.rgba,
+				  "benchmark outputs must match exactly");
+		}
+		std::cout << "zoom=" << zoom << " sequential_ms=" << sequential / 3
+				  << " scheduled_ms=" << parallel / 3 << '\n';
+	}
+	return g_fails ? 1 : 0;
+}
+
+int main(int argc, char **argv)
+{
+	if (argc > 1 && std::strcmp(argv[1], "--map-perf") == 0)
+		return benchmark_maps();
+	test_region_tile_plan();
+	test_global_priority();
+	test_parallel_maps();
 	std::cout << "[test_biome_map] Running tests...\n";
 	test_biome_map_result_validity();
 	test_deterministic_stale_generation_rejection();


### PR DESCRIPTION
A zoomed-out 256x256 biome map spent about 617 ms sampling canonical terrain columns in one Low-priority worker job. Distribute independent tiles through the existing Engine pool while keeping TerrainGenerator sequential and preserving chunk streaming priorities.

Implementation:
- Add buildBiomeRegionPlan() and getBiomeRegionTile() to describe and sample independent rectangles in the original grid. Preserve canonical coordinate rounding, erosion halos, and tile-local row-major output.
- Add Engine-owned submitBiomeMap() with at most eight Low-priority tile lanes. Each tile queues its successor separately so High/Normal work can run between tiles; no extra native threads are created.
- Use a submission sentinel and atomic remaining-work count. The last task assembles the result and resolves the future without any worker waiting for children. Cancellation and failures drain submitted work and never publish partial pixels.
- Preserve GameUI single-flight, stale-result, and upload checks. Small maps retain the single-job path and reuse UI-owned scratch; parallel tiles use separate bounded thread-local scratch, never shared scratch.
- Search every ThreadPool queue at each priority before considering a lower priority, preventing local Low work from hiding remote High or Normal tasks. Synchronize task-count publication with queue visibility and notifications with the sleeper predicate/wait transition.

Tests and measurements:
- Cover reverse-order tile assembly, exact output partitioning, negative and fractional coordinates, odd dimensions, partial edge tiles, extreme steps, invalid rectangles, cancellation, and scratch bounds.
- Compare scheduled maps against sequential RGBA with one and four workers; verify queued cancellation, exception completion, and pool shutdown draining. Add a gated cross-queue priority regression.
- Add --map-perf to test_biome_map and --benchmark-map <zoom> with a --benchmark-map-sequential control to the streaming benchmark.
- Record map completion latency and terrain/mesh enqueue-to-start waits through registered profiler buckets and benchmark reports.
- Document scheduling, memory retention, reproducible commands, raw streaming reports, and the limits of the measurements.

Validation:
- Full Windows/MSVC Release build passes.
- CTest passes 10/10 in 41.41 s, including VulkanResourceSmoke, TerrainGeneration, BiomeMapGeneration, and ProfilerWorkerConsistency.
- git diff --check passes; invalid map zoom and missing benchmark options are rejected by the CLI.
- Standalone 256x256 map, seed 1337, eight workers, three alternating measurements per zoom: 0.1 improves 617.361 -> 84.2733 ms; 0.25 improves 109.146 -> 16.8534 ms; 0.5 improves 28.3086 -> 4.7153 ms; 1 improves 8.25587 -> 1.73337 ms. Every measured RGBA output matches exactly.
- With the map open at zoom 0.1 during a 15-second streaming benchmark, mean map latency improves 664.308 -> 93.0621 ms. TerrainGen execution is 1.57173 -> 1.56174 ms and MeshBuild is 2.9515 -> 2.94787 ms.
- Mean terrain queue wait is 0.00999458 -> 0.00920847 ms; mean mesh queue wait is 0.00969865 -> 0.00955753 ms. Both control and scheduled runs use the same binary, instrumentation, and scheduler. Different task counts and single-run sampling prevent throughput or tail-latency guarantees.
- Linux/macOS, sanitizers, allocator counters, and queue percentiles were not tested or collected locally.

Close #88