### PR TITLE
fix(profiler): reset completed capture state and retire old worker epochs

### DIFF
--- a/docs/benchmarks/bench_20260904_103355_b6e774db1246__s42_sc9996.txt
+++ b/docs/benchmarks/bench_20260904_103355_b6e774db1246__s42_sc9996.txt
@@ -1,0 +1,34 @@
+ft_vox Benchmark Report
+=======================
+Score: 9996 / 10000  Grade: S
+Revision: b6e774db1246* (dirty tree at build)
+  git b6e774db1246  branch fix/80-profiler-capture-reset  describe b6e774d-dirty
+  build UTC 2026-09-04T10:33:46Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00107s  Frames: 976
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 5.01713  min 4.9539  max 16.7046
+  p50 4.9916  p95 4.9974  p99 5.1148
+  avg FPS 199.317  1% low FPS 195.511
+  frames >16.7ms: 1  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.465891  Visibility 0.00646168
+  Acquire 0.0322865  Record 0.156647  MeshUpload 0.0274875
+  ImGui 0.0634878  Present 4.28754
+
+Worker jobs
+  TerrainGen  n=2385  avgMs=1.53003  totalMs=3649.11
+  MeshBuild   n=1771  avgMs=2.87837  totalMs=5097.59
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+Biome map: zoom=0.1 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2385 avgMs=0.0279065 totalMs=66.557
+  MeshQueue n=1771 avgMs=0.0270486 totalMs=47.903
+  BiomeMap n=5 avgMs=94.7874 totalMs=473.937
+Peaks: chunks=491 draw=125 qLoad/Gen/Mesh=3304/13/8
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue-80-profiler-reset.md
+++ b/docs/benchmarks/issue-80-profiler-reset.md
@@ -1,0 +1,63 @@
+# Issue #80: complete profiler capture reset
+
+`clearHistory()` now resets all completed capture state immediately: frame
+time, scope hierarchy, graph, averages, percentile, spikes, displayed worker
+snapshot, and old pending worker aggregates. Capture enabled/paused state and
+registered worker names are retained. The UI reads profiler metrics directly
+instead of substituting stale Engine frame/FPS values after a reset.
+
+Reset advances an atomic capture epoch. Each bucket checks the sample epoch
+under its existing count/time mutex. A writer that reaches a bucket before
+the reset sweep can retire old data and install the new epoch; the sweep
+preserves that new data. Old-epoch submissions are rejected. Terrain, mesh,
+queue-wait, and biome-map measurements carry the epoch from job submission,
+so late completion cannot relabel pre-reset work as a new sample.
+
+An open frame keeps its instrumentation stack intact, but its completed
+capture is discarded. The next full frame starts the fresh history. Engine
+benchmark sampling skips the discarded frame, including with zero warmup.
+Reset, snapshot, frame operations, and UI reads belong to the capture thread;
+worker submissions may run concurrently.
+
+## Regression coverage
+
+`test_profiler` covers:
+
+- idle reset with populated history, scopes, spikes, displayed worker data,
+  and additional pending data; repeated reset while capture is paused;
+- reset within nested scopes, preserving the live stack and parent links,
+  discarding the interrupted frame, and publishing a fresh hierarchy next;
+- rejection of both pending and late old-epoch samples before the first
+  new frame, modeling reload with zero warmup;
+- four gated workers straddling reset: exactly four new samples survive;
+- 1,000 resets racing stale/new worker submissions, retaining only valid
+  count/time pairs from the current epoch;
+- existing concurrent snapshot and registration tests (240,000 worker
+  samples drained with exact counts/times and zero split violations).
+
+Windows/MSVC Release builds of `ft_vox` and `test_profiler` pass. The full
+ten-suite CTest run includes terrain, Vulkan resources, biome maps, and the
+profiler. No sanitizer or Linux/macOS run was performed.
+
+## Zero-warmup runtime check
+
+The new optional `--benchmark-warmup` argument allows this case to be
+reproduced without changing source code; the default warmup is unchanged.
+
+```powershell
+./build/Release/ft_vox.exe --seed 42 --benchmark 5 --benchmark-warmup 0 --benchmark-map 0.1
+```
+
+2026-09-04, base revision `b6e774db1246` plus this change, RTX 4070 Ti,
+1920x1080, view distance 512, IMMEDIATE presentation:
+
+- report confirms warmup **0 s**, measured **5.00107 s**, **976 frames**;
+- **2,385** TerrainGen jobs, **1,771** MeshBuild jobs, **5** completed maps;
+- mean frame **5.01713 ms**, minimum **4.9539 ms** (no zero-duration reset
+  frame included).
+
+This runtime smoke exercises reload/reset and subsequent worker capture.
+The deterministic tests, rather than aggregate runtime timings, establish
+the old-epoch rejection contract.
+
+[Raw runtime report](bench_20260904_103355_b6e774db1246__s42_sc9996.txt)

--- a/docs/engine-architecture.md
+++ b/docs/engine-architecture.md
@@ -101,6 +101,26 @@ Bootstrap: `generateInitialArea` fills a small radius around spawn synchronously
 
 Controls summary lives in root `README.md` (WASD, break/place, borders, etc.).
 
+### Profiler capture reset
+
+Profiler capture reset (`Profiler::clearHistory`, also used after world reload)
+clears the displayed frame/scopes, history, averages, spikes, worker snapshot,
+and pending samples from the previous capture epoch. Registered worker names
+and the capture enabled/paused setting are preserved. Reset and snapshot calls
+belong to the capture/main thread; worker submission may run concurrently.
+
+Each asynchronous job captures `captureEpoch()` at submission and supplies it
+to `addWorkerSample(name, ms, epoch)`. A result from an old epoch is rejected
+even if its job finishes after reset. Bucket mutexes protect count/time pairs;
+new-epoch samples arriving during reset are retained. The two-argument overload
+uses the epoch at the time of submission and is intended for immediate samples.
+
+When clearing inside an open frame, its instrumentation stack remains valid
+until scopes close, but that entire frame is discarded. History resumes at the
+next full completed frame. Benchmark sampling skips the discarded frame, so a
+zero-warmup reload cannot measure its pre-reset scopes or worker samples.
+Reproduce that path with `ft_vox --seed 42 --benchmark 5 --benchmark-warmup 0`.
+
 ---
 
 ## 4. World constants (`utils.hpp`)

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -236,17 +236,18 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 		const TaskPriority prio = calculateTaskPriority(queue[i].distSq, lodThreshSq);
 		chunk->setInTransit(true);
 		m_pendingGenJobsCount.fetch_add(1);
+		const auto captureEpoch = GetProfiler().captureEpoch();
 		const auto queuedAt = std::chrono::steady_clock::now();
-		m_threadPool->enqueue(prio, [chunk, seed, this, queuedAt]() {
+		m_threadPool->enqueue(prio, [chunk, seed, this, queuedAt, captureEpoch]() {
 			const auto t0 = std::chrono::steady_clock::now();
 			GetProfiler().addWorkerSample("TerrainQueue",
-				std::chrono::duration<float, std::milli>(t0 - queuedAt).count());
+				std::chrono::duration<float, std::milli>(t0 - queuedAt).count(), captureEpoch);
 			TerrainGenerator &localGen = TerrainGenerator::getThreadLocal(seed);
 			chunk->generateTerrain(localGen);
 			const float ms = std::chrono::duration<float, std::milli>(
 								 std::chrono::steady_clock::now() - t0)
 								 .count();
-			GetProfiler().addWorkerSample("TerrainGen", ms);
+			GetProfiler().addWorkerSample("TerrainGen", ms, captureEpoch);
 
 			{
 				std::lock_guard<std::mutex> lk(m_completedJobsMutex);
@@ -321,16 +322,17 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 		if (distSq > lodThreshSq)
 		{
 			m_pendingMeshJobsCount.fetch_add(1);
+			const auto captureEpoch = GetProfiler().captureEpoch();
 			const auto queuedAt = std::chrono::steady_clock::now();
-			m_threadPool->enqueue(prio, [chunk, this, queuedAt]() {
+			m_threadPool->enqueue(prio, [chunk, this, queuedAt, captureEpoch]() {
 				const auto t0 = std::chrono::steady_clock::now();
 				GetProfiler().addWorkerSample("MeshQueue",
-					std::chrono::duration<float, std::milli>(t0 - queuedAt).count());
+					std::chrono::duration<float, std::milli>(t0 - queuedAt).count(), captureEpoch);
 				chunk->generateLODMesh();
 				const float ms = std::chrono::duration<float, std::milli>(
 									 std::chrono::steady_clock::now() - t0)
 									 .count();
-				GetProfiler().addWorkerSample("MeshLOD", ms);
+				GetProfiler().addWorkerSample("MeshLOD", ms, captureEpoch);
 
 				{
 					std::lock_guard<std::mutex> lk(m_completedJobsMutex);
@@ -343,16 +345,17 @@ void ChunkManager::meshPendingChunks(const Camera &camera, const RenderSettings 
 		{
 			ensureShellPopulated(chunk, ci);
 			m_pendingMeshJobsCount.fetch_add(1);
+			const auto captureEpoch = GetProfiler().captureEpoch();
 			const auto queuedAt = std::chrono::steady_clock::now();
-			m_threadPool->enqueue(prio, [chunk, this, queuedAt]() {
+			m_threadPool->enqueue(prio, [chunk, this, queuedAt, captureEpoch]() {
 				const auto t0 = std::chrono::steady_clock::now();
 				GetProfiler().addWorkerSample("MeshQueue",
-					std::chrono::duration<float, std::milli>(t0 - queuedAt).count());
+					std::chrono::duration<float, std::milli>(t0 - queuedAt).count(), captureEpoch);
 				chunk->generateMesh();
 				const float ms = std::chrono::duration<float, std::milli>(
 									 std::chrono::steady_clock::now() - t0)
 									 .count();
-				GetProfiler().addWorkerSample("MeshBuild", ms);
+				GetProfiler().addWorkerSample("MeshBuild", ms, captureEpoch);
 
 				{
 					std::lock_guard<std::mutex> lk(m_completedJobsMutex);

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -778,6 +778,9 @@ void Engine::sampleBenchmarkFrame()
 		return;
 
 	Profiler &prof = GetProfiler();
+	// A reset during reload discards the interrupted frame, even at zero warmup.
+	if (prof.historyCount() == 0)
+		return;
 	uint64_t tJobs = 0, mJobs = 0, lJobs = 0;
 	float tMs = 0.f, mMs = 0.f, lMs = 0.f;
 	const int wc = prof.workerSnapshotCount();

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -618,7 +618,7 @@ void GameUI::drawStreaming(GameUIFrame &frame)
 			row("Streaming", prof.lastScopeMs("Streaming"));
 			row("Acquire (fence)", prof.lastScopeMs("Acquire"));
 			row("Record", prof.lastScopeMs("Record"));
-			row("Frame total", prof.lastFrameMs() > 0.f ? prof.lastFrameMs() : frame.frameMs);
+			row("Frame total", prof.lastFrameMs());
 			ImGui::EndTable();
 		}
 		ImGui::TextDisabled("Full hierarchy + graph: Profiler (F7)");
@@ -657,9 +657,9 @@ void GameUI::drawProfiler(GameUIFrame &frame)
 	ImGui::SameLine();
 	ImGui::TextDisabled("CPU scopes · previous frame");
 
-	const float frameMs = prof.lastFrameMs() > 0.f ? prof.lastFrameMs() : frame.frameMs;
-	const float avgMs = prof.avgFrameMs() > 0.f ? prof.avgFrameMs() : frameMs;
-	const float fpsEst = prof.fpsEstimate() > 0.f ? prof.fpsEstimate() : frame.fps;
+	const float frameMs = prof.lastFrameMs();
+	const float avgMs = prof.avgFrameMs();
+	const float fpsEst = prof.fpsEstimate();
 	const float p1 = prof.onePercentLowMs();
 
 	ImGui::SeparatorText("Frame");
@@ -1300,7 +1300,7 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 
 		if (isBiomeMapResultAcceptable(res, frame.worldGenerationId, frame.seed, m_mapRequestId))
 		{
-			GetProfiler().addWorkerSample("BiomeMap", static_cast<float>(res.elapsedMs));
+			GetProfiler().addWorkerSample("BiomeMap", static_cast<float>(res.elapsedMs), m_mapCaptureEpoch);
 			paintBiomeMapPlayerDot(res.rgba, res.grid, playerXZ);
 			m_mapCenter = res.center;
 			ensureBiomeTexture(res.size);
@@ -1341,6 +1341,7 @@ void GameUI::tickBiomeMap(GameUIFrame &frame)
 
 		const uint64_t requestId = m_mapRequestId;
 		auto cancelToken = std::make_shared<std::atomic<bool>>(false);
+		m_mapCaptureEpoch = GetProfiler().captureEpoch();
 		m_mapJob.requestId = requestId;
 		m_mapJob.cancel = cancelToken;
 

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -220,6 +220,7 @@ private:
 	uint64_t m_mapRequestId{0};
 
 	BiomeMapJob m_mapJob{};
+	uint64_t m_mapCaptureEpoch{0};
 	BiomeMapUpload m_pendingUpload{};
 	// Owner scratch for sequential/small maps. Parallel tiles use separate
 	// bounded thread-local scratch; this retention cap allows dense reuse so

--- a/src/Engine/Profiler.cpp
+++ b/src/Engine/Profiler.cpp
@@ -52,6 +52,7 @@ void Profiler::beginFrame()
 	m_entryCount = 0;
 	m_stackDepth = 0;
 	m_inFrame = true;
+	m_discardFrame = false;
 }
 
 void Profiler::endFrame()
@@ -63,8 +64,8 @@ void Profiler::endFrame()
 	while (m_stackDepth > 0)
 		closeScope();
 
-	const float frameMs = nowMs();
-	finalizeFrame(frameMs);
+	if (!m_discardFrame)
+		finalizeFrame(nowMs());
 	m_inFrame = false;
 }
 
@@ -113,6 +114,11 @@ void Profiler::closeScope()
 
 void Profiler::addWorkerSample(const char *name, float ms)
 {
+	addWorkerSample(name, ms, captureEpoch());
+}
+
+void Profiler::addWorkerSample(const char *name, float ms, CaptureEpoch epoch)
+{
 	if (!name || !enabled())
 		return;
 
@@ -129,6 +135,15 @@ void Profiler::addWorkerSample(const char *name, float ms)
 		if (bn == name || (bn && std::strcmp(bn, name) == 0))
 		{
 			std::lock_guard<std::mutex> lock(b.mutex);
+			if (epoch != captureEpoch())
+				return;
+			// A new-epoch writer may reach this bucket before clearHistory's
+			// sweep. Retire the old pair atomically without dropping new work.
+			if (b.epoch != epoch)
+			{
+				b.count = b.totalUs = 0;
+				b.epoch = epoch;
+			}
 			b.count += 1;
 			b.totalUs += us;
 			return;
@@ -139,6 +154,28 @@ void Profiler::addWorkerSample(const char *name, float ms)
 
 void Profiler::clearHistory()
 {
+	// Linearization point for the capture reset. Writers carry their epoch
+	// into the bucket lock; an old writer either precedes this reset and is
+	// drained below, or observes the new epoch and is rejected.
+	const auto epoch = m_captureEpoch.fetch_add(1, std::memory_order_acq_rel) + 1;
+	const int n = m_workerBucketCount.load(std::memory_order_acquire);
+	for (int i = 0; i < n; ++i)
+	{
+		auto &bucket = m_workers[static_cast<size_t>(i)];
+		std::lock_guard<std::mutex> lock(bucket.mutex);
+		if (bucket.epoch != epoch)
+		{
+			bucket.count = bucket.totalUs = 0;
+			bucket.epoch = epoch;
+		}
+	}
+	m_lastFrameMs = 0.f;
+	m_lastEntryCount = 0;
+	m_lastEntries = {};
+	m_workerSnapCount = 0;
+	m_workerSnaps = {};
+	// Do not touch live entries or the stack: existing RAII scopes still pop.
+	m_discardFrame = m_inFrame;
 	m_history.fill(0.f);
 	m_historyWrite = 0;
 	m_historyCount = 0;
@@ -177,8 +214,13 @@ void Profiler::snapshotWorkers()
 		uint64_t us = 0;
 		{
 			std::lock_guard<std::mutex> lock(b.mutex);
-			c = b.count;
-			us = b.totalUs;
+			const auto epoch = captureEpoch();
+			if (b.epoch == epoch)
+			{
+				c = b.count;
+				us = b.totalUs;
+			}
+			b.epoch = epoch;
 			b.count = 0;
 			b.totalUs = 0;
 		}

--- a/src/Engine/Profiler.hpp
+++ b/src/Engine/Profiler.hpp
@@ -38,6 +38,7 @@ struct WorkerBucket
 	const char *name{nullptr};
 	mutable std::mutex mutex;
 	uint64_t count{0};
+	uint64_t epoch{0};
 	uint64_t totalUs{0}; // microseconds for sub-millisecond precision
 
 	WorkerBucket() = default;
@@ -45,6 +46,7 @@ struct WorkerBucket
 	{
 		std::lock_guard<std::mutex> lock(o.mutex);
 		name = o.name;
+		epoch = o.epoch;
 		count = o.count;
 		totalUs = o.totalUs;
 	}
@@ -54,6 +56,7 @@ struct WorkerBucket
 		{
 			std::scoped_lock lock(mutex, o.mutex);
 			name = o.name;
+			epoch = o.epoch;
 			count = o.count;
 			totalUs = o.totalUs;
 		}
@@ -103,15 +106,24 @@ public:
 	void push(const char *name);
 	void pop();
 
+	using CaptureEpoch = uint64_t;
+	/// Capture at job submission to reject work spanning a capture reset.
+	CaptureEpoch captureEpoch() const { return m_captureEpoch.load(std::memory_order_acquire); }
+
 	/// Thread-safe aggregate samples from worker threads.
 	void addWorkerSample(const char *name, float ms);
+	void addWorkerSample(const char *name, float ms, CaptureEpoch epoch);
 
 	/// Ensure a worker name slot exists before workers sample it.
 	void registerWorkerName(const char *name);
 
-	/// Frame-consistent snapshot of worker thread aggregates.
+	/// Capture-thread only; may run concurrently with worker submissions.
 	void snapshotWorkers();
 
+	/// Capture-thread only. Clear all published state and advance the worker
+	/// epoch, discarding pending/late old samples. Preserve registrations and
+	/// enabled state. If a frame is open, keep its stack valid but discard that
+	/// entire frame at endFrame(); collection resumes with the next full frame.
 	void clearHistory();
 
 	// --- UI accessors (read last completed frame) ---
@@ -138,6 +150,7 @@ public:
 	float lastScopeMs(const char *name) const;
 
 private:
+	friend struct ProfilerStateProbe;
 	using Clock = std::chrono::steady_clock;
 
 	float nowMs() const
@@ -153,6 +166,8 @@ private:
 
 	std::atomic<bool> m_enabled{true};
 	bool m_inFrame{false};
+	bool m_discardFrame{false};
+	std::atomic<CaptureEpoch> m_captureEpoch{0};
 
 	Clock::time_point m_frameStart{};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@ static void printUsage(const char *argv0)
 			  << "                              (defaults to ressources/default-resource-pack.zip)\n"
 			  << "  --vsync <on|off>            FIFO when on; strict IMMEDIATE and uncapped when off\n"
 			  << "  --benchmark <seconds>       Run a wide streaming benchmark, save report, exit\n"
+			  << "  --benchmark-warmup <secs>   Override warmup (0 disables it)\n"
 			  << "  --benchmark-map <zoom>      Open fixed-center biome map (zoom 0.1..8)\n"
 			  << "  --benchmark-map-sequential  Compare the previous one-job map path\n"
 			  << "  --help                      Show this help\n"
@@ -41,6 +42,7 @@ int main(int argc, char **argv)
 	std::string resourcePackCli;
 	std::optional<bool> vsyncOverride;
 	float benchmarkDuration = 0.0f;
+	std::optional<float> benchmarkWarmup;
 	float benchmarkMapZoom = 0.0f;
 	bool benchmarkMapSequential = false;
 
@@ -104,6 +106,23 @@ int main(int argc, char **argv)
 			}
 			continue;
 		}
+		if (arg == "--benchmark-warmup")
+		{
+			if (i + 1 >= argc)
+			{
+				std::cerr << "Error: --benchmark-warmup requires seconds.\n";
+				return EXIT_FAILURE;
+			}
+			char *end = nullptr;
+			const float seconds = std::strtof(argv[++i], &end);
+			if (end == argv[i] || *end || !std::isfinite(seconds) || seconds < 0.f || seconds > 300.f)
+			{
+				std::cerr << "Error: benchmark warmup must be between 0 and 300 seconds.\n";
+				return EXIT_FAILURE;
+			}
+			benchmarkWarmup = seconds;
+			continue;
+		}
 		if (arg == "--benchmark")
 		{
 			if (i + 1 >= argc)
@@ -146,6 +165,11 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	if (benchmarkWarmup && (benchmarkDuration == 0.f || *benchmarkWarmup > benchmarkDuration))
+	{
+		std::cerr << "Error: --benchmark-warmup requires --benchmark and cannot exceed its duration.\n";
+		return EXIT_FAILURE;
+	}
 	if ((benchmarkMapZoom > 0.0f && benchmarkDuration == 0.0f) ||
 		(benchmarkMapSequential && benchmarkMapZoom == 0.0f))
 	{
@@ -167,7 +191,7 @@ int main(int argc, char **argv)
 			config.durationSec = benchmarkDuration;
 			config.biomeMapZoom = benchmarkMapZoom;
 			config.biomeMapSequential = benchmarkMapSequential;
-			config.warmupSec = std::min(2.0f, benchmarkDuration * 0.2f);
+			config.warmupSec = benchmarkWarmup.value_or(std::min(2.0f, benchmarkDuration * 0.2f));
 			config.pathOrbits = 2;
 			config.pathRadius = 512.0f;
 			config.pathHeight = 72.0f;

--- a/tests/test_profiler.cpp
+++ b/tests/test_profiler.cpp
@@ -5,6 +5,8 @@
 #include <chrono>
 #include <cmath>
 #include <iostream>
+#include <future>
+#include <algorithm>
 #include <thread>
 #include <vector>
 
@@ -18,6 +20,12 @@
 			std::abort();                                                              \
 		}                                                                              \
 	} while (0)
+
+struct ProfilerStateProbe
+{
+	static int stackDepth(const Profiler &prof) { return prof.m_stackDepth; }
+	static const ProfileEntry &entry(const Profiler &prof, int i) { return prof.m_entries[i]; }
+};
 
 namespace
 {
@@ -350,11 +358,157 @@ void test_profiler_overhead_benchmark()
 	std::cout << "  -> Passed!" << std::endl;
 }
 
+
+void check_empty_capture(const Profiler &prof)
+{
+	TEST_CHECK(prof.lastFrameMs() == 0.f);
+	TEST_CHECK(prof.lastEntryCount() == 0);
+	TEST_CHECK(prof.avgFrameMs() == 0.f);
+	TEST_CHECK(prof.fpsEstimate() == 0.f);
+	TEST_CHECK(prof.onePercentLowMs() == 0.f);
+	TEST_CHECK(prof.historyCount() == 0);
+	TEST_CHECK(prof.historyWriteIndex() == 0);
+	TEST_CHECK(prof.spikeCount() == 0);
+	TEST_CHECK(prof.workerSnapshotCount() == 0);
+	for (int i = 0; i < Profiler::kHistorySize; ++i)
+		TEST_CHECK(prof.frameHistory()[i] == 0.f);
+	for (int i = 0; i < Profiler::kMaxEntries; ++i)
+		TEST_CHECK(prof.lastEntries()[i].name == nullptr);
+	for (int i = 0; i < Profiler::kMaxWorkerBuckets; ++i)
+		TEST_CHECK(prof.workerSnapshots()[i].count == 0);
+}
+
+void test_capture_reset_idle()
+{
+	Profiler prof;
+	prof.beginFrame();
+	prof.push("old");
+	std::this_thread::sleep_for(std::chrono::milliseconds(25));
+	prof.pop();
+	prof.addWorkerSample("TerrainGen", 3.f);
+	prof.endFrame();
+	TEST_CHECK(prof.lastFrameMs() > 0.f && prof.historyCount() == 1);
+	TEST_CHECK(prof.lastEntryCount() == 1 && prof.spikeCount() == 1);
+	TEST_CHECK(prof.workerSnapshotCount() > 0);
+	prof.addWorkerSample("TerrainGen", 7.f); // pending, not yet drained
+	const auto oldEpoch = prof.captureEpoch();
+	prof.setEnabled(false);
+	prof.clearHistory();
+	check_empty_capture(prof);
+	TEST_CHECK(!prof.enabled());
+	TEST_CHECK(prof.captureEpoch() != oldEpoch);
+	TEST_CHECK(prof.lastScopeMs("old") == 0.f);
+	prof.snapshotWorkers();
+	for (int i = 0; i < prof.workerSnapshotCount(); ++i)
+		TEST_CHECK(prof.workerSnapshots()[i].count == 0);
+	prof.clearHistory(); // repeated reset while paused is safe
+	check_empty_capture(prof);
+	prof.setEnabled(true);
+	prof.addWorkerSample("TerrainGen", 2.f);
+	prof.snapshotWorkers();
+	TEST_CHECK(prof.workerSnapshots()[0].count == 1); // registration retained
+	TEST_CHECK(prof.workerSnapshots()[0].totalUs == 2000);
+}
+
+void test_capture_reset_open_frame()
+{
+	Profiler prof;
+	prof.beginFrame();
+	prof.push("before-reset-root");
+	prof.push("Clear button");
+	const auto oldEpoch = prof.captureEpoch();
+	prof.addWorkerSample("TerrainGen", 8.f, oldEpoch);
+	prof.clearHistory(); // same placement as UI/reloadWorld during an open frame
+	check_empty_capture(prof);
+	TEST_CHECK(ProfilerStateProbe::stackDepth(prof) == 2);
+	TEST_CHECK(std::strcmp(ProfilerStateProbe::entry(prof, 0).name, "before-reset-root") == 0);
+	prof.push("after-button");
+	TEST_CHECK(ProfilerStateProbe::entry(prof, 2).parent == 1);
+	TEST_CHECK(ProfilerStateProbe::stackDepth(prof) == 3);
+	prof.pop();
+	prof.pop(); // Clear button
+	prof.pop(); // root opened before clear
+	TEST_CHECK(ProfilerStateProbe::stackDepth(prof) == 0);
+	prof.addWorkerSample("TerrainGen", 9.f, oldEpoch); // late pre-reload job
+	prof.addWorkerSample("TerrainGen", 2.f, prof.captureEpoch());
+	prof.endFrame();
+	// Even with zero warmup the interrupted pre-reload frame is not measured.
+	check_empty_capture(prof);
+	prof.beginFrame();
+	prof.push("fresh-root");
+	prof.push("fresh-child");
+	prof.pop();
+	prof.pop();
+	prof.endFrame();
+	TEST_CHECK(prof.historyCount() == 1 && prof.lastEntryCount() == 2);
+	TEST_CHECK(prof.lastEntries()[0].parent == -1 && prof.lastEntries()[0].depth == 0);
+	TEST_CHECK(prof.lastEntries()[1].parent == 0 && prof.lastEntries()[1].depth == 1);
+	TEST_CHECK(std::strcmp(prof.lastEntries()[0].name, "fresh-root") == 0);
+	TEST_CHECK(prof.workerSnapshots()[0].count == 1);
+	TEST_CHECK(prof.workerSnapshots()[0].totalUs == 2000);
+}
+
+void test_capture_reset_inflight_workers()
+{
+	Profiler prof;
+	const auto oldEpoch = prof.captureEpoch();
+	std::promise<void> release;
+	auto gate = release.get_future().share();
+	std::atomic<int> ready{0};
+	std::vector<std::thread> workers;
+	for (int i = 0; i < 4; ++i)
+		workers.emplace_back([&] {
+			prof.addWorkerSample("TerrainGen", 1.f, oldEpoch);
+			ready.fetch_add(1, std::memory_order_release);
+			gate.wait();
+			prof.addWorkerSample("TerrainGen", 1.f, oldEpoch); // reject late completion
+			prof.addWorkerSample("TerrainGen", 2.5f, prof.captureEpoch());
+		});
+	while (ready.load(std::memory_order_acquire) != 4)
+		std::this_thread::yield();
+	prof.clearHistory();
+	check_empty_capture(prof);
+	release.set_value();
+	for (auto &worker : workers)
+		worker.join();
+	prof.snapshotWorkers();
+	TEST_CHECK(prof.workerSnapshots()[0].count == 4);
+	TEST_CHECK(prof.workerSnapshots()[0].totalUs == 10000);
+
+	// Race reset sweeps with both stale-epoch and fresh submissions. Every
+	// retained pair must consist solely of 2.5ms samples, never old 1ms work.
+	std::atomic<bool> stop{false};
+	workers.clear();
+	for (int i = 0; i < 4; ++i)
+		workers.emplace_back([&] {
+			while (!stop.load(std::memory_order_relaxed))
+			{
+				prof.addWorkerSample("TerrainGen", 1.f, oldEpoch);
+				prof.addWorkerSample("TerrainGen", 2.5f, prof.captureEpoch());
+			}
+		});
+	for (int i = 0; i < 1000; ++i)
+	{
+		prof.clearHistory();
+		prof.snapshotWorkers();
+		const auto &snapshot = prof.workerSnapshots()[0];
+		TEST_CHECK(snapshot.totalUs == snapshot.count * 2500);
+	}
+	stop.store(true, std::memory_order_relaxed);
+	for (auto &worker : workers)
+		worker.join();
+	prof.snapshotWorkers();
+	TEST_CHECK(prof.workerSnapshots()[0].totalUs == prof.workerSnapshots()[0].count * 2500);
+}
+
 } // namespace
 
 int main()
 {
 	std::cout << "=== Running Profiler Worker Consistency Tests ===" << std::endl;
+	test_capture_reset_idle();
+	test_capture_reset_open_frame();
+	test_capture_reset_inflight_workers();
 	test_basic_worker_snapshot();
 	test_concurrent_worker_snapshot_consistency();
 	test_concurrent_registration_and_sampling();


### PR DESCRIPTION
Clear history only reset the frame history, averages, and spike records. The UI could still display the previous frame, scope hierarchy, and worker snapshot, while pending worker aggregates could enter the next capture. World reload uses the same reset before benchmark measurements, making that stale data especially problematic when warmup is zero.

Implementation:
- Define clearHistory() as a complete capture reset: clear last-frame metrics and entries, history, averages, spikes, worker snapshots, and pending aggregates from the retired epoch. Preserve capture enabled state and registered worker names.
- Advance an atomic capture epoch and validate samples under each bucket's existing count/time mutex. Reject old-epoch submissions and retain new samples arriving before the reset sweep reaches a bucket.
- Capture the epoch when terrain, mesh, queue-wait, and biome-map jobs are submitted, so late completion cannot relabel old work as new data.
- Preserve the instrumentation stack when resetting inside an open frame, but discard that entire frame at endFrame(). Resume history collection with the next full completed frame and skip the discarded benchmark frame even when warmup is zero.
- Remove UI fallbacks to stale Engine frame/FPS metrics after clearing.
- Add --benchmark-warmup <seconds> for reproducible zero-warmup checks, keeping the default warmup unchanged and validating explicit values.
- Document capture-thread ownership, worker epoch semantics, interrupted frame behavior, and the runtime validation report.

Tests and measurements:
- Cover idle reset with populated history, hierarchy, spikes, displayed worker samples, and pending samples; verify repeated reset while paused preserves capture state and worker registration.
- Reset within nested scopes and verify the live stack, parent links, discarded frame, and fresh next-frame hierarchy.
- Verify pending and late old-epoch samples cannot reach the first new frame, modeling benchmark reload without warmup.
- Gate four workers across reset and assert exactly four fresh samples survive; race 1,000 resets against stale and current-epoch submissions while checking count/time consistency.
- Retain the existing concurrent snapshot and registration tests, which drain 240,000 samples with exact totals and zero split violations.

Validation:
- Windows/MSVC Release builds pass for ft_vox and test_profiler.
- CTest passes 10/10 in 41.57 s, including Vulkan resources, terrain, biome maps, and profiler consistency. The final targeted profiler run also passes after adding explicit live-stack assertions.
- git diff --check passes. NaN warmup and warmup without --benchmark are rejected by the CLI.
- Runtime: --seed 42 --benchmark 5 --benchmark-warmup 0 --benchmark-map 0.1 completes with reported warmup 0 s, measured 5.00107 s, and 976 frames. It records 2,385 TerrainGen jobs, 1,771 MeshBuild jobs, and five maps; minimum frame time is 4.9539 ms with no zero-duration reset frame.
- The runtime run exercises reload and subsequent capture; deterministic regression tests establish old-epoch rejection, not aggregate timings.
- Linux/macOS and sanitizers were not run locally.

Close #80