### PR TITLE
feat(profiler): measure Vulkan GPU frame and render-pass execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(FT_VOX_VULKAN_SOURCES
     ${CMAKE_SOURCE_DIR}/src/Vulkan/VkContext.cpp
     ${CMAKE_SOURCE_DIR}/src/Vulkan/VkSwapchain.cpp
     ${CMAKE_SOURCE_DIR}/src/Vulkan/VkFrame.cpp
+    ${CMAKE_SOURCE_DIR}/src/Vulkan/VkGpuProfiler.cpp
     ${CMAKE_SOURCE_DIR}/src/Vulkan/VkAllocator.cpp
     ${CMAKE_SOURCE_DIR}/src/Vulkan/VkBuffer.cpp
     ${CMAKE_SOURCE_DIR}/src/Vulkan/VkImage.cpp

--- a/docs/benchmarks/bench_20260904_105948_098ceae27860__s42_sc10000.txt
+++ b/docs/benchmarks/bench_20260904_105948_098ceae27860__s42_sc10000.txt
@@ -1,0 +1,46 @@
+ft_vox Benchmark Report
+=======================
+Score: 10000 / 10000  Grade: S
+Revision: 098ceae27860* (dirty tree at build)
+  git 098ceae27860  branch feat/82-gpu-timestamp-profiler  describe 098ceae-dirty
+  build UTC 2026-09-04T10:58:35Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00107s  Frames: 980
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 4.99302  min 4.987  max 5.1271
+  p50 4.9922  p95 4.9966  p99 4.9981
+  avg FPS 200.28  1% low FPS 200.076
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.394543  Visibility 0.00387327
+  Acquire 0.0653359  Record 1.02228  MeshUpload 0.0546257
+  ImGui 0.0432418  Present 3.45818
+
+Worker jobs
+  TerrainGen  n=2385  avgMs=1.32654  totalMs=3163.79
+  MeshBuild   n=1767  avgMs=2.35665  totalMs=4164.2
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+GPU timestamp queries: available
+  samples=979 avgMs=0.903612
+  p95Ms=1.26669 p99Ms=1.49373
+  Uploads avgMs=0.013787
+  Shadow avgMs=0.0498908
+  Opaque avgMs=0.0966587
+  Overlays avgMs=0.000121332
+  Water avgMs=0.0691718
+  Sky avgMs=0.393768
+  Post avgMs=0.268501
+  ImGui avgMs=0.0115579
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2385 avgMs=0.0161312 totalMs=38.473
+  MeshQueue n=1767 avgMs=0.0136084 totalMs=24.046
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=490 draw=124 qLoad/Gen/Mesh=3304/1/4
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/bench_20260904_110048_098ceae27860__s42_sc9983.txt
+++ b/docs/benchmarks/bench_20260904_110048_098ceae27860__s42_sc9983.txt
@@ -1,0 +1,35 @@
+ft_vox Benchmark Report
+=======================
+Score: 9983 / 10000  Grade: S
+Revision: 098ceae27860* (dirty tree at build)
+  git 098ceae27860  branch feat/82-gpu-timestamp-profiler  describe 098ceae-dirty
+  build UTC 2026-09-04T10:59:59Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00002s  Frames: 803
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: on  PresentMode: FIFO
+
+Frame times (ms)
+  avg 6.07361  min 4.9915  max 24.2611
+  p50 6.0482  p95 6.3257  p99 6.6247
+  avg FPS 164.647  1% low FPS 150.95
+  frames >16.7ms: 1  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.402445  Visibility 0.00392267
+  Acquire 4.49213  Record 0.979295  MeshUpload 0.0636631
+  ImGui 0.0434011  Present 0.146726
+
+Worker jobs
+  TerrainGen  n=2366  avgMs=1.32995  totalMs=3146.65
+  MeshBuild   n=1757  avgMs=2.50077  totalMs=4393.85
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+GPU timestamp queries: unavailable
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2366 avgMs=0.0175507 totalMs=41.525
+  MeshQueue n=1757 avgMs=0.0181121 totalMs=31.823
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=492 draw=124 qLoad/Gen/Mesh=3314/2/5
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/bench_20260904_110108_098ceae27860__s42_sc9879.txt
+++ b/docs/benchmarks/bench_20260904_110108_098ceae27860__s42_sc9879.txt
@@ -1,0 +1,46 @@
+ft_vox Benchmark Report
+=======================
+Score: 9879 / 10000  Grade: S
+Revision: 098ceae27860* (dirty tree at build)
+  git 098ceae27860  branch feat/82-gpu-timestamp-profiler  describe 098ceae-dirty
+  build UTC 2026-09-04T10:59:59Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00102s  Frames: 800
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: on  PresentMode: FIFO
+
+Frame times (ms)
+  avg 6.09042  min 4.931  max 30.2992
+  p50 4.993  p95 8.3115  p99 9.0215
+  avg FPS 164.192  1% low FPS 110.846
+  frames >16.7ms: 8  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.410553  Visibility 0.00403125
+  Acquire 2.25146  Record 1.0375  MeshUpload 0.0634186
+  ImGui 0.0432429  Present 2.33772
+
+Worker jobs
+  TerrainGen  n=2364  avgMs=1.33705  totalMs=3160.78
+  MeshBuild   n=1755  avgMs=2.48048  totalMs=4353.24
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+GPU timestamp queries: available
+  samples=799 avgMs=1.03013
+  p95Ms=1.48646 p99Ms=1.80678
+  Uploads avgMs=0.0166833
+  Shadow avgMs=0.0512956
+  Opaque avgMs=0.105049
+  Overlays avgMs=0.000140976
+  Water avgMs=0.0741496
+  Sky avgMs=0.434608
+  Post avgMs=0.327766
+  ImGui avgMs=0.0202826
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2364 avgMs=0.0151464 totalMs=35.806
+  MeshQueue n=1755 avgMs=0.028196 totalMs=49.484
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=491 draw=124 qLoad/Gen/Mesh=3318/0/2
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue98-validation/README.md
+++ b/docs/benchmarks/issue98-validation/README.md
@@ -1,0 +1,83 @@
+# PR #98 review validation — 2026-09-04
+
+The capability gate now depends on the **selected graphics queue**:
+`timestampValidBits` in 1–64 and finite positive `timestampPeriod`.
+The device-wide `timestampComputeAndGraphics` guarantee is not required.
+The query lifecycle, timestamp stages and nonblocking read flags are unchanged.
+
+## Controlled base comparison
+
+Base: `098ceae278607d3330d1d9e9a797ec94d9a170a9`, clean checkout.
+PR: `b999bd881a02aff3d462fb93bc5415e258741908` plus the capability/diagnostics
+and regression-test corrections documented here (dirty build identity in logs).
+The existing build directory was rebuilt from each source version; the base
+checkout has no GPU timestamp code. All runs used the same compiler, packages,
+driver, validation configuration, resource pack, viewport and present mode.
+
+```powershell
+$env:FT_VOX_VALIDATION = '1'
+$env:FT_VOX_GPU_PROFILING = '1' # ignored by base
+.\build\Release\ft_vox.exe --seed 42 --benchmark 5 --benchmark-warmup 0 --vsync off
+# Repeat PR run with FT_VOX_GPU_PROFILING=0.
+```
+
+| Full output | imageFormat-01778 | usage-02275 | Other VUIDs |
+| --- | ---: | ---: | ---: |
+| [Base](base-validation.txt) | 8 | 6 | 0 |
+| [PR enabled](pr-validation.txt) | 8 | 6 | 0 |
+| [PR disabled](pr-disabled.txt) | 8 | 6 | 0 |
+
+The IDs are `VUID-VkSwapchainCreateInfoKHR-imageFormat-01778` and
+`VUID-VkImageViewCreateInfo-usage-02275`. The same errors occur with profiling
+code absent, so they are preexisting and tracked in
+[#99](https://github.com/gkehren/ft_vox/issues/99). There are no timestamp/query
+VUIDs. This does **not** claim the entire renderer has clean validation.
+The engine asks for COLOR_ATTACHMENT | TRANSFER_DST; validation sees extra
+STORAGE/TRANSFER_SRC usage. Its origin remains unknown. Matching counts and
+messages establish reproduction, not the underlying cause.
+
+## Environment
+
+- Windows; NVIDIA GeForce RTX 4070 Ti, driver 616.56, device API 1.4.351.
+- MSVC 19.50.35724.0; Visual Studio 18 2026; Release; same CMake build directory.
+- Vulkan SDK shader tools 1.3.290.0 and Khronos validation layer API 1.3.290;
+  compile-time Vulkan headers 1.4.350 from vcpkg. `vulkaninfoSDK` reports loader
+  instance version 1.4.341 (the SDK tool's process).
+- 1920×1080, view distance 512, seed 42, warmup 0, 5 seconds,
+  VSync off / IMMEDIATE. Bundled `ressources/default-resource-pack.zip`, SHA256
+  `00847414CB6AE5EF97FAE236EDCB9C01449A1865B3D38F907F902278A58477EC`.
+- No implicit-layer disable filter for this comparison. Installed implicit
+  layers include AMD switchable graphics, NVIDIA Optimus/present and Nsight
+  2025.2, OBS, GOG Galaxy, EOS, Steam overlay/fossilize and RTSS. Installation
+  does not establish which hooks were active; the active chain is unconfirmed.
+  Earlier profiling runs with implicit layers disabled still showed the errors.
+
+## Tests and runtime checks
+
+- Full Release build passed. CTest **11/11**, 41.16 s; [output](ctest.txt).
+- `GpuProfile`: support for 36/40/48/56/64 bits, invalid widths and nonfinite,
+  zero or negative periods; existing 8/64-bit wrap tests retained. The global
+  guarantee is no longer an input to the tested capability helper.
+- `VulkanResourceSmoke`: zero-slot graceful failure, two query pools, repeated
+  reuse after fence completion, partial availability, clear/reset, disable and
+  resume. A completed but unread sample is explicitly left pending across
+  OFF → ON, rejected afterwards, and replaced by exactly one fresh sample.
+- Smoke diagnostics: graphics family 0, 64 valid bits, period 1 ns,
+  `timestampComputeAndGraphics=true`, selected queue supported. A physical
+  device exposing false for the global guarantee was not tested.
+- Enabled benchmark: **980 GPU samples, mean 0.923 ms**, Shadow 0.049 ms,
+  Opaque 0.096 ms, Post 0.278 ms, ImGui 0.010 ms. Disabled benchmark completes
+  and reports `GPU timestamp queries: unavailable` with no GPU measurements.
+- [Ten-second run with two-second warmup](pr-warmup.txt) also completes with
+  GPU timings. Deterministic tests, rather than aggregate timing counts, prove
+  exclusion of warmup samples arriving before/after measurement starts and
+  old tags across successive benchmarks in one Benchmark instance.
+- CPU clear semantics remain covered by ProfilerWorkerConsistency; GPU clear
+  and toggles are exercised through the same profiler methods the UI calls.
+  Manual F7 button interaction and two full Engine benchmark runs without
+  restarting the process were not performed.
+- `git diff --check` passed. No query read/wait/reset ordering changes.
+
+Resolution/shadow/overdraw sweeps, RenderDoc/Nsight comparison, Linux and macOS
+builds remain unperformed optional checks. These short runs establish
+functionality and classify the VUIDs; they are not an overhead benchmark.

--- a/docs/benchmarks/issue98-validation/base-validation.txt
+++ b/docs/benchmarks/issue98-validation/base-validation.txt
@@ -1,0 +1,83 @@
+[Vulkan] Layer name GalaxyOverlayVkLayer does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_VERBOSE does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_DEBUG does not conform to naming standard (Policy #LLP_LAYER_3)
+Vulkan device: NVIDIA GeForce RTX 4070 Ti
+Vulkan API: 1.4.351
+  validation=yes dynamicRendering=yes timelineSemaphores=yes portabilitySubset=no
+  VMA allocator: ready
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, with following params: format: VK_FORMAT_B8G8R8A8_SRGB, imageType: VK_IMAGE_TYPE_2D, tiling: VK_IMAGE_TILING_OPTIMAL, usage: VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, flags: VkImageCreateFlags(0). The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageArrayLayers 1, but Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is 0 for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 1920, height = 1080), which is bigger than max extent (width = 0, height = 0, depth = 0)returned by vkGetPhysicalDeviceImageFormatProperties(): for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+Swapchain present mode: FIFO (VSync on)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xf56c9b0000000004, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xe7f79a0000000005, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xf443490000000006, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+Resource pack: ./ressources/default-resource-pack.zip
+Texture array: 101 layers (16x16)
+WorldRenderer ready (Shadow/Opaque/Water/Sky + post)
+ChunkPool: pre-allocated 8894 chunks
+SDL version: 3004012
+ft_vox: Vulkan — streaming procedural world
+  WASD fly · mouse look · LMB/RMB edit · T block · B borders
+  C free mouse · F1–F7 panels · F10 VSync · Esc quit
+  ThreadPool workers: 16
+Bootstrap: 25 chunks around spawn
+World seed: 42 chunks=25 view=512
+[stream] chunks=26 draw=9 shadow=25 q=3350/1/0
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, with following params: format: VK_FORMAT_B8G8R8A8_SRGB, imageType: VK_IMAGE_TYPE_2D, tiling: VK_IMAGE_TILING_OPTIMAL, usage: VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, flags: VkImageCreateFlags(0). The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageArrayLayers 1, but Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is 0 for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 1920, height = 1080), which is bigger than max extent (width = 0, height = 0, depth = 0)returned by vkGetPhysicalDeviceImageFormatProperties(): for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+Swapchain present mode: IMMEDIATE (VSync off, uncapped)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x76f3e50000000194, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x4a581c0000000195, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x6b3d270000000196, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+Bootstrap: 25 chunks around spawn
+[bench] World reloaded seed=42 chunks=25
+[stream] chunks=487 draw=115 shadow=49 q=3029/2/2
+[stream] chunks=489 draw=116 shadow=48 q=3032/3/2
+[stream] chunks=487 draw=123 shadow=47 q=3016/2/2
+[stream] chunks=486 draw=114 shadow=48 q=3026/2/2
+
+ft_vox Benchmark Report
+=======================
+Score: 10000 / 10000  Grade: S
+Revision: 098ceae27860
+  git 098ceae27860  branch HEAD  describe 098ceae
+  build UTC 2026-09-04T11:16:45Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00007s  Frames: 980
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 4.99245  min 4.9117  max 5.1396
+  p50 4.9919  p95 4.9968  p99 4.9995
+  avg FPS 200.302  1% low FPS 200.02
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.420464  Visibility 0.00547133
+  Acquire 0.0588974  Record 1.17162  MeshUpload 0.0587913
+  ImGui 0.041942  Present 3.28885
+
+Worker jobs
+  TerrainGen  n=2384  avgMs=1.54332  totalMs=3679.28
+  MeshBuild   n=1769  avgMs=2.81616  totalMs=4981.79
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2384 avgMs=0.0185688 totalMs=44.268
+  MeshQueue n=1769 avgMs=0.0137982 totalMs=24.409
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=490 draw=125 qLoad/Gen/Mesh=3307/3/5
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.
+Benchmark saved: docs/benchmarks/bench_20260904_111704_098ceae27860_s42_sc10000.txt

--- a/docs/benchmarks/issue98-validation/ctest.txt
+++ b/docs/benchmarks/issue98-validation/ctest.txt
@@ -1,0 +1,27 @@
+Test project D:/Projects/ft_vox/build
+      Start  1: NetworkIntegrationTest
+ 1/11 Test  #1: NetworkIntegrationTest ...........   Passed    1.20 sec
+      Start  2: VulkanResourceSmoke
+ 2/11 Test  #2: VulkanResourceSmoke ..............   Passed    0.79 sec
+      Start  3: VisualLookDefaults
+ 3/11 Test  #3: VisualLookDefaults ...............   Passed    0.01 sec
+      Start  4: RenderHelpers
+ 4/11 Test  #4: RenderHelpers ....................   Passed    0.02 sec
+      Start  5: StreamOptHelpers
+ 5/11 Test  #5: StreamOptHelpers .................   Passed    0.02 sec
+      Start  6: TerrainGeneration
+ 6/11 Test  #6: TerrainGeneration ................   Passed   37.87 sec
+      Start  7: BiomeMapGeneration
+ 7/11 Test  #7: BiomeMapGeneration ...............   Passed    1.07 sec
+      Start  8: InputRouting
+ 8/11 Test  #8: InputRouting .....................   Passed    0.01 sec
+      Start  9: ChunkLifecycle
+ 9/11 Test  #9: ChunkLifecycle ...................   Passed    0.05 sec
+      Start 10: ProfilerWorkerConsistency
+10/11 Test #10: ProfilerWorkerConsistency ........   Passed    0.08 sec
+      Start 11: GpuProfile
+11/11 Test #11: GpuProfile .......................   Passed    0.02 sec
+
+100% tests passed out of 11
+
+Total Test time (real) =  41.16 sec

--- a/docs/benchmarks/issue98-validation/pr-disabled.txt
+++ b/docs/benchmarks/issue98-validation/pr-disabled.txt
@@ -1,0 +1,85 @@
+[Vulkan] Layer name GalaxyOverlayVkLayer does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_VERBOSE does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_DEBUG does not conform to naming standard (Policy #LLP_LAYER_3)
+Vulkan device: NVIDIA GeForce RTX 4070 Ti
+Vulkan API: 1.4.351
+  validation=yes dynamicRendering=yes timelineSemaphores=yes portabilitySubset=no
+  VMA allocator: ready
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, with following params: format: VK_FORMAT_B8G8R8A8_SRGB, imageType: VK_IMAGE_TYPE_2D, tiling: VK_IMAGE_TILING_OPTIMAL, usage: VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, flags: VkImageCreateFlags(0). The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageArrayLayers 1, but Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is 0 for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 1920, height = 1080), which is bigger than max extent (width = 0, height = 0, depth = 0)returned by vkGetPhysicalDeviceImageFormatProperties(): for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+Swapchain present mode: FIFO (VSync on)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xf56c9b0000000004, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xe7f79a0000000005, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xf443490000000006, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+Resource pack: ./ressources/default-resource-pack.zip
+Texture array: 101 layers (16x16)
+WorldRenderer ready (Shadow/Opaque/Water/Sky + post)
+ChunkPool: pre-allocated 8894 chunks
+SDL version: 3004012
+ft_vox: Vulkan — streaming procedural world
+  WASD fly · mouse look · LMB/RMB edit · T block · B borders
+  C free mouse · F1–F7 panels · F10 VSync · Esc quit
+  ThreadPool workers: 16
+Bootstrap: 25 chunks around spawn
+World seed: 42 chunks=25 view=512
+[stream] chunks=26 draw=9 shadow=25 q=3350/1/0
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, with following params: format: VK_FORMAT_B8G8R8A8_SRGB, imageType: VK_IMAGE_TYPE_2D, tiling: VK_IMAGE_TILING_OPTIMAL, usage: VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, flags: VkImageCreateFlags(0). The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageArrayLayers 1, but Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is 0 for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 1920, height = 1080), which is bigger than max extent (width = 0, height = 0, depth = 0)returned by vkGetPhysicalDeviceImageFormatProperties(): for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+Swapchain present mode: IMMEDIATE (VSync off, uncapped)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x6b3d270000000196, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x6d91ce0000000197, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x4046a90000000198, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+Bootstrap: 25 chunks around spawn
+[bench] World reloaded seed=42 chunks=25
+[stream] chunks=486 draw=116 shadow=49 q=3029/2/2
+[stream] chunks=488 draw=113 shadow=48 q=3029/3/2
+[stream] chunks=486 draw=121 shadow=47 q=3024/3/2
+[stream] chunks=487 draw=113 shadow=48 q=3030/3/2
+[stream] chunks=486 draw=124 shadow=48 q=3023/2/1
+
+ft_vox Benchmark Report
+=======================
+Score: 10000 / 10000  Grade: S
+Revision: b999bd881a02* (dirty tree at build)
+  git b999bd881a02  branch feat/82-gpu-timestamp-profiler  describe b999bd8-dirty
+  build UTC 2026-09-04T11:18:54Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00407s  Frames: 981
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 4.99254  min 4.9003  max 5.0878
+  p50 4.9918  p95 4.9966  p99 5.0026
+  avg FPS 200.299  1% low FPS 199.896
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.41633  Visibility 0.00528501
+  Acquire 0.060958  Record 1.18896  MeshUpload 0.0608034
+  ImGui 0.0430216  Present 3.27233
+
+Worker jobs
+  TerrainGen  n=2386  avgMs=1.54689  totalMs=3690.88
+  MeshBuild   n=1771  avgMs=2.81603  totalMs=4987.2
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+GPU timestamp queries: unavailable
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2386 avgMs=0.0192385 totalMs=45.903
+  MeshQueue n=1771 avgMs=0.017332 totalMs=30.695
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=491 draw=125 qLoad/Gen/Mesh=3306/4/7
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.
+Benchmark saved: docs/benchmarks/bench_20260904_111921_b999bd881a02__s42_sc10000.txt

--- a/docs/benchmarks/issue98-validation/pr-validation.txt
+++ b/docs/benchmarks/issue98-validation/pr-validation.txt
@@ -1,0 +1,95 @@
+[Vulkan] Layer name GalaxyOverlayVkLayer does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_VERBOSE does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_DEBUG does not conform to naming standard (Policy #LLP_LAYER_3)
+Vulkan device: NVIDIA GeForce RTX 4070 Ti
+Vulkan API: 1.4.351
+  validation=yes dynamicRendering=yes timelineSemaphores=yes portabilitySubset=no
+  VMA allocator: ready
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, with following params: format: VK_FORMAT_B8G8R8A8_SRGB, imageType: VK_IMAGE_TYPE_2D, tiling: VK_IMAGE_TILING_OPTIMAL, usage: VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, flags: VkImageCreateFlags(0). The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageArrayLayers 1, but Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is 0 for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 1920, height = 1080), which is bigger than max extent (width = 0, height = 0, depth = 0)returned by vkGetPhysicalDeviceImageFormatProperties(): for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+Swapchain present mode: FIFO (VSync on)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xf56c9b0000000004, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xe7f79a0000000005, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xf443490000000006, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+Resource pack: ./ressources/default-resource-pack.zip
+Texture array: 101 layers (16x16)
+WorldRenderer ready (Shadow/Opaque/Water/Sky + post)
+ChunkPool: pre-allocated 8894 chunks
+SDL version: 3004012
+ft_vox: Vulkan — streaming procedural world
+  WASD fly · mouse look · LMB/RMB edit · T block · B borders
+  C free mouse · F1–F7 panels · F10 VSync · Esc quit
+  ThreadPool workers: 16
+Bootstrap: 25 chunks around spawn
+World seed: 42 chunks=25 view=512
+[stream] chunks=26 draw=9 shadow=25 q=3350/1/0
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, with following params: format: VK_FORMAT_B8G8R8A8_SRGB, imageType: VK_IMAGE_TYPE_2D, tiling: VK_IMAGE_TILING_OPTIMAL, usage: VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, flags: VkImageCreateFlags(0). The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageArrayLayers 1, but Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is 0 for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 1920, height = 1080), which is bigger than max extent (width = 0, height = 0, depth = 0)returned by vkGetPhysicalDeviceImageFormatProperties(): for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+Swapchain present mode: IMMEDIATE (VSync off, uncapped)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x6b3d270000000196, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x6d91ce0000000197, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x4046a90000000198, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+Bootstrap: 25 chunks around spawn
+[bench] World reloaded seed=42 chunks=25
+[stream] chunks=487 draw=116 shadow=47 q=3031/2/2
+[stream] chunks=488 draw=115 shadow=51 q=3027/3/1
+[stream] chunks=487 draw=122 shadow=49 q=3019/2/2
+[stream] chunks=486 draw=113 shadow=48 q=3020/2/2
+
+ft_vox Benchmark Report
+=======================
+Score: 10000 / 10000  Grade: S
+Revision: b999bd881a02* (dirty tree at build)
+  git b999bd881a02  branch feat/82-gpu-timestamp-profiler  describe b999bd8-dirty
+  build UTC 2026-09-04T11:18:54Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00307s  Frames: 981
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 4.99261  min 4.8423  max 5.5268
+  p50 4.9916  p95 4.9965  p99 4.9982
+  avg FPS 200.296  1% low FPS 200.072
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.422963  Visibility 0.00545821
+  Acquire 0.0703279  Record 1.19595  MeshUpload 0.0613467
+  ImGui 0.0436211  Present 3.24742
+
+Worker jobs
+  TerrainGen  n=2386  avgMs=1.53922  totalMs=3672.57
+  MeshBuild   n=1772  avgMs=2.73551  totalMs=4847.33
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+GPU timestamp queries: available
+  samples=980 avgMs=0.923035
+  p95Ms=1.46662 p99Ms=1.8248
+  Uploads avgMs=0.0138031
+  Shadow avgMs=0.0486859
+  Opaque avgMs=0.0955705
+  Overlays avgMs=0.000118073
+  Water avgMs=0.0663907
+  Sky avgMs=0.410413
+  Post avgMs=0.278293
+  ImGui avgMs=0.00959634
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2386 avgMs=0.0253726 totalMs=60.539
+  MeshQueue n=1772 avgMs=0.0182799 totalMs=32.392
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=491 draw=126 qLoad/Gen/Mesh=3303/9/6
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.
+Benchmark saved: docs/benchmarks/bench_20260904_111914_b999bd881a02__s42_sc10000.txt

--- a/docs/benchmarks/issue98-validation/pr-warmup.txt
+++ b/docs/benchmarks/issue98-validation/pr-warmup.txt
@@ -1,0 +1,102 @@
+[Vulkan] Layer name GalaxyOverlayVkLayer does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_VERBOSE does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_DEBUG does not conform to naming standard (Policy #LLP_LAYER_3)
+Vulkan device: NVIDIA GeForce RTX 4070 Ti
+Vulkan API: 1.4.351
+  validation=yes dynamicRendering=yes timelineSemaphores=yes portabilitySubset=no
+  VMA allocator: ready
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, with following params: format: VK_FORMAT_B8G8R8A8_SRGB, imageType: VK_IMAGE_TYPE_2D, tiling: VK_IMAGE_TILING_OPTIMAL, usage: VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, flags: VkImageCreateFlags(0). The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageArrayLayers 1, but Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is 0 for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 1920, height = 1080), which is bigger than max extent (width = 0, height = 0, depth = 0)returned by vkGetPhysicalDeviceImageFormatProperties(): for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+Swapchain present mode: FIFO (VSync on)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xf56c9b0000000004, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xe7f79a0000000005, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0xf443490000000006, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+Resource pack: ./ressources/default-resource-pack.zip
+Texture array: 101 layers (16x16)
+WorldRenderer ready (Shadow/Opaque/Water/Sky + post)
+ChunkPool: pre-allocated 8894 chunks
+SDL version: 3004012
+ft_vox: Vulkan — streaming procedural world
+  WASD fly · mouse look · LMB/RMB edit · T block · B borders
+  C free mouse · F1–F7 panels · F10 VSync · Esc quit
+  ThreadPool workers: 16
+Bootstrap: 25 chunks around spawn
+World seed: 42 chunks=25 view=512
+[stream] chunks=26 draw=9 shadow=25 q=3350/1/0
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL does not support usage that includes VK_IMAGE_USAGE_STORAGE_BIT. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo vkGetPhysicalDeviceImageFormatProperties() unexpectedly failed, with following params: format: VK_FORMAT_B8G8R8A8_SRGB, imageType: VK_IMAGE_TYPE_2D, tiling: VK_IMAGE_TILING_OPTIMAL, usage: VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_STORAGE_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, flags: VkImageCreateFlags(0). The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageArrayLayers 1, but Maximum value returned by vkGetPhysicalDeviceImageFormatProperties() is 0 for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+[Vulkan] Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 ] | MessageID = 0xc036022f | vkCreateSwapchainKHR(): pCreateInfo->imageExtent (width = 1920, height = 1080), which is bigger than max extent (width = 0, height = 0, depth = 0)returned by vkGetPhysicalDeviceImageFormatProperties(): for imageFormat VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL. The Vulkan spec states: The implied image creation parameters of the swapchain must be supported as reported by vkGetPhysicalDeviceImageFormatProperties (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageFormat-01778)
+Swapchain present mode: IMMEDIATE (VSync off, uncapped)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x6b3d270000000196, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x6d91ce0000000197, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+[Vulkan] Validation Error: [ VUID-VkImageViewCreateInfo-usage-02275 ] Object 0: handle = 0x4046a90000000198, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x618ab1e7 | vkCreateImageView(): pCreateInfo->format VK_FORMAT_B8G8R8A8_SRGB with tiling VK_IMAGE_TILING_OPTIMAL doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT.
+(supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT|VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_BLIT_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT|Unhandled VkFormatFeatureFlagBits2). The Vulkan spec states: If usage contains VK_IMAGE_USAGE_STORAGE_BIT, then the image view's format features must contain VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT (https://vulkan.lunarg.com/doc/view/1.3.290.0/windows/1.3-extensions/vkspec.html#VUID-VkImageViewCreateInfo-usage-02275)
+Bootstrap: 25 chunks around spawn
+[bench] World reloaded seed=42 chunks=25
+[stream] chunks=636 draw=106 shadow=139 q=2732/2/2
+[stream] chunks=1143 draw=285 shadow=142 q=2503/3/1
+[stream] chunks=1231 draw=298 shadow=143 q=2483/3/2
+[stream] chunks=1238 draw=292 shadow=145 q=2476/2/1
+[stream] chunks=1242 draw=287 shadow=142 q=2478/3/2
+[stream] chunks=1244 draw=301 shadow=144 q=2476/2/1
+[stream] chunks=1242 draw=299 shadow=143 q=2471/3/2
+[stream] chunks=1244 draw=290 shadow=142 q=2482/2/1
+[stream] chunks=1243 draw=298 shadow=144 q=2480/3/2
+[stream] chunks=1239 draw=293 shadow=144 q=2478/2/2
+[stream] chunks=1245 draw=289 shadow=143 q=2474/3/1
+
+ft_vox Benchmark Report
+=======================
+Score: 9999 / 10000  Grade: S
+Revision: b999bd881a02* (dirty tree at build)
+  git b999bd881a02  branch feat/82-gpu-timestamp-profiler  describe b999bd8-dirty
+  build UTC 2026-09-04T11:18:54Z
+Seed: 42  Duration: 10s  Warmup: 2s  Measured: 10.0002s  Frames: 1999
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 4.99297  min 4.9583  max 6.0725
+  p50 4.9917  p95 4.9926  p99 5.0096
+  avg FPS 200.282  1% low FPS 199.617
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.391458  Visibility 0.0176529
+  Acquire 0.0962726  Record 2.61116  MeshUpload 0.0680489
+  ImGui 0.0441504  Present 1.83847
+
+Worker jobs
+  TerrainGen  n=4799  avgMs=1.62321  totalMs=7789.79
+  MeshBuild   n=3599  avgMs=2.97605  totalMs=10710.8
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+GPU timestamp queries: available
+  samples=1997 avgMs=1.3281
+  p95Ms=1.8056 p99Ms=1.9728
+  Uploads avgMs=0.0137836
+  Shadow avgMs=0.137059
+  Opaque avgMs=0.34203
+  Overlays avgMs=0.00018511
+  Water avgMs=0.0838542
+  Sky avgMs=0.416509
+  Post avgMs=0.319555
+  ImGui avgMs=0.0149667
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=4799 avgMs=0.00847656 totalMs=40.679
+  MeshQueue n=3599 avgMs=0.00863101 totalMs=31.063
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=1247 draw=305 qLoad/Gen/Mesh=2506/0/1
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.
+Benchmark saved: docs/benchmarks/bench_20260904_112052_b999bd881a02__s42_sc9999.txt

--- a/docs/gpu-profiling.md
+++ b/docs/gpu-profiling.md
@@ -8,9 +8,13 @@ use 64-bit values plus availability, never `VK_QUERY_RESULT_WAIT_BIT`.
 Recording resets the pool on the GPU outside rendering. There is no added
 per-frame fence wait, queue idle or device idle for profiling.
 
-`VkGpuProfiler` requires `timestampComputeAndGraphics`, a graphics queue with
-1–64 timestamp valid bits, and a finite positive `timestampPeriod`. Allocation
-failure or unsupported timestamps leave rendering functional. Nanoseconds are
+`VkGpuProfiler` requires the selected graphics queue family to expose
+1–64 `timestampValidBits`, and a finite positive `timestampPeriod`.
+`timestampComputeAndGraphics` is a blanket guarantee across graphics/compute
+queues, not a requirement when the selected queue itself has valid timestamps.
+Allocation failure or unsupported timestamps leave rendering functional. The
+status distinguishes missing/invalid queue bits, invalid period, invalid queue
+family, zero frame slots and pool allocation failure. Nanoseconds are
 converted to milliseconds after unsigned counter subtraction and valid-bit
 masking (including the 64-bit case and one counter wrap).
 
@@ -54,14 +58,18 @@ IMMEDIATE GPU p95/p99 were 1.267/1.494 ms. Shadow averaged 0.050 ms,
 Opaque 0.097 ms, Sky 0.394 ms and Post 0.269 ms. These short runs are functional
 checks, not an overhead comparison or a performance claim.
 
-No timestamp/query validation errors were observed. Full application validation
-is **not clean** on this setup: enabled and disabled runs both report
+No timestamp/query validation errors were observed. The controlled follow-up
+comparison reproduces the same two VUIDs on base main
+`098ceae278607d3330d1d9e9a797ec94d9a170a9`, with profiling code absent, and on
+the corrected PR with profiling enabled and disabled:
 `VUID-VkSwapchainCreateInfoKHR-imageFormat-01778` and
 `VUID-VkImageViewCreateInfo-usage-02275` concerning STORAGE usage on SRGB
-swapchain images. The engine requests only COLOR_ATTACHMENT and TRANSFER_DST;
-disabling implicit layers did not remove the errors. The source of the added
-usage is not established. This issue is recorded rather than hidden by changing
-swapchain formats or disabling validation.
+swapchain images (8 and 6 occurrences respectively in each run).
+Full application validation is **not clean**, but this is preexisting rather
+than introduced by the timestamp profiler. The root cause remains unresolved
+and is tracked in [#99](https://github.com/gkehren/ft_vox/issues/99).
+See the [review validation report](benchmarks/issue98-validation/README.md)
+for full logs, environment, tests and limits of the comparison.
 
 Resolution/shadow-distance/overdraw sweeps and external RenderDoc/Nsight
 comparison remain manual validation: use the Graphics/Streaming controls with

--- a/docs/gpu-profiling.md
+++ b/docs/gpu-profiling.md
@@ -1,0 +1,73 @@
+# GPU timestamp profiling
+
+F7 separates CPU frame/recording scopes, GPU frame/passes, worker CPU jobs and
+the pipeline snapshot. `VkFrameContext` owns one timestamp query pool per
+frame-in-flight slot. It resolves the previous submission immediately after
+that slot's existing fence signals, before command-buffer reuse. Query results
+use 64-bit values plus availability, never `VK_QUERY_RESULT_WAIT_BIT`.
+Recording resets the pool on the GPU outside rendering. There is no added
+per-frame fence wait, queue idle or device idle for profiling.
+
+`VkGpuProfiler` requires `timestampComputeAndGraphics`, a graphics queue with
+1–64 timestamp valid bits, and a finite positive `timestampPeriod`. Allocation
+failure or unsupported timestamps leave rendering functional. Nanoseconds are
+converted to milliseconds after unsigned counter subtraction and valid-bit
+masking (including the 64-bit case and one counter wrap).
+
+The frame interval encloses uploads, Shadow, Opaque, Overlays, Water, Sky, Post,
+ImGui and the final present-layout transition. TOP_OF_PIPE/BOTTOM_OF_PIPE
+timestamps measure elapsed graphics-queue intervals, including dependencies;
+they are not shader-only utilization measurements. Pass intervals can overlap
+and must not be summed. CPU `Record`, `Acquire` and `Present` remain CPU wall
+times. GPU measurements neither include the CPU call to present nor display
+scanout, though queue/semaphore backpressure can affect execution intervals.
+
+The GPU checkbox is independent of CPU capture. `FT_VOX_GPU_PROFILING=0`
+disables query reset/write/read work at startup; the checkbox can re-enable it.
+Disabled pools retain their small allocation. Clear/reload and GPU toggles
+clear the 240-sample history and discard pending results from old captures.
+
+Benchmark reports and the report UI include availability, sample count, GPU
+frame average, p95/p99 (at least 100 samples), and per-pass averages. Submission
+tags exclude warmup and previous-run results; serial numbers avoid counting
+the same delayed result twice. Finalization does not drain the GPU: the final
+in-flight samples may be omitted, so GPU and CPU sample counts can differ.
+Unavailable timings are explicitly labelled and never replaced with CPU data.
+
+## Validation (Windows, RTX 4070 Ti, 2026-09-04)
+
+Release build and all 11 CTest tests passed. `GpuProfile` exercises capability
+gates, unit conversion, 8/64-bit wrap, duplicate exclusion, per-pass aggregation,
+percentiles and capture isolation. `VulkanResourceSmoke` exercises two pools,
+repeated reuse after a fence, unused query availability, capture reset and
+disable/re-enable on a real device.
+
+Five-second seed-42 runs at 1920×1080, zero warmup, validation enabled:
+
+| Profiling / present | GPU samples | GPU avg ms | CPU Acquire ms | CPU Present ms |
+| --- | ---: | ---: | ---: | ---: |
+| Enabled / IMMEDIATE | 979 | 0.904 | 0.065 | 3.458 |
+| Enabled / FIFO | 799 | 1.030 | 2.251 | 2.338 |
+| Disabled / FIFO | 0 (unavailable) | unavailable | 4.492 | 0.147 |
+
+IMMEDIATE GPU p95/p99 were 1.267/1.494 ms. Shadow averaged 0.050 ms,
+Opaque 0.097 ms, Sky 0.394 ms and Post 0.269 ms. These short runs are functional
+checks, not an overhead comparison or a performance claim.
+
+No timestamp/query validation errors were observed. Full application validation
+is **not clean** on this setup: enabled and disabled runs both report
+`VUID-VkSwapchainCreateInfoKHR-imageFormat-01778` and
+`VUID-VkImageViewCreateInfo-usage-02275` concerning STORAGE usage on SRGB
+swapchain images. The engine requests only COLOR_ATTACHMENT and TRANSFER_DST;
+disabling implicit layers did not remove the errors. The source of the added
+usage is not established. This issue is recorded rather than hidden by changing
+swapchain formats or disabling validation.
+
+Resolution/shadow-distance/overdraw sweeps and external RenderDoc/Nsight
+comparison remain manual validation: use the Graphics/Streaming controls with
+a fixed world/camera, compare the GPU pass history, and repeat with VSync on/off.
+Unsupported-device behavior has unit coverage; no unsupported physical GPU was
+available for an end-to-end run.
+
+References: [Khronos timestamp sample](https://docs.vulkan.org/samples/latest/samples/api/timestamp_queries/README.html)
+and [Vulkan queries specification](https://docs.vulkan.org/spec/latest/chapters/queries.html).

--- a/docs/vulkan-graphics.md
+++ b/docs/vulkan-graphics.md
@@ -327,6 +327,8 @@ Do not treat this section as “already shipped.” For historical feature discu
 
 ## 11. Related docs
 
+- [`gpu-profiling.md`](gpu-profiling.md) — GPU timestamp lifecycle, UI, benchmark metrics and validation
+
 - [`engine-architecture.md`](engine-architecture.md) — Engine loop, chunks, streaming, terrain generation  
 - Root [`README.md`](../README.md) — build, deps, controls  
 - [`Agents.md`](../Agents.md) — contributor-oriented project context  

--- a/src/Engine/Benchmark.cpp
+++ b/src/Engine/Benchmark.cpp
@@ -27,6 +27,10 @@ void Benchmark::requestStart()
 	m_elapsed = 0.f;
 	m_showReport = false;
 	m_report = {};
+	++m_gpuTag;
+	m_lastGpuSerial = 0;
+	m_gpuFrames.clear();
+	m_gpuPasses = {};
 	m_backgroundWork = {};
 	m_frameMs.clear();
 	m_sumStreaming = m_sumAcquire = m_sumRecord = m_sumImGui = m_sumPresent = 0;
@@ -152,6 +156,21 @@ void Benchmark::sampleFrame(float frameMs, float scopeStreaming, float scopeAcqu
 		++m_over33;
 }
 
+void Benchmark::sampleGpu(const GpuFrameSample &sample)
+{
+	if (m_phase != BenchmarkPhase::Running || !sample.serial ||
+		sample.serial == m_lastGpuSerial || sample.benchmarkTag != m_gpuTag || !sample.present[0])
+		return;
+	m_lastGpuSerial = sample.serial;
+	m_gpuFrames.push_back(sample.ms[0]);
+	for (size_t i = 0; i < kGpuPassCount; ++i)
+		if (sample.present[i])
+		{
+			++m_gpuPasses[i].count;
+			m_gpuPasses[i].totalMs += sample.ms[i];
+		}
+}
+
 void Benchmark::sampleBackgroundWork(const char *name, uint64_t count, double totalMs)
 {
 	if (m_phase != BenchmarkPhase::Running)
@@ -250,6 +269,21 @@ void Benchmark::finalize()
 	r.warmupSec = m_config.warmupSec;
 	r.measuredSec = std::max(0.f, m_elapsed - m_config.warmupSec);
 	r.frames = static_cast<int>(m_frameMs.size());
+	r.gpuSamples = m_gpuFrames.size();
+	r.gpuAvailable = r.gpuSamples > 0;
+	r.gpuPasses = m_gpuPasses;
+	if (r.gpuAvailable)
+	{
+		r.gpuAvgMs = static_cast<float>(m_gpuPasses[0].totalMs / r.gpuSamples);
+		r.gpuPercentilesAvailable = r.gpuSamples >= 100;
+		if (r.gpuPercentilesAvailable)
+		{
+			auto sorted = m_gpuFrames;
+			std::sort(sorted.begin(), sorted.end());
+			r.gpuP95Ms = percentileSorted(sorted, 0.95f);
+			r.gpuP99Ms = percentileSorted(sorted, 0.99f);
+		}
+	}
 
 	if (!m_frameMs.empty())
 	{
@@ -363,6 +397,20 @@ std::string Benchmark::formatReportText() const
 	  << "  totalMs=" << r.meshBuildTotalMs << "\n";
 	o << "  MeshLOD     n=" << r.meshLodJobs << "  avgMs=" << r.meshLodAvgMs
 	  << "  totalMs=" << r.meshLodTotalMs << "\n\n";
+	o << "GPU timestamp queries: " << (r.gpuAvailable ? "available" : "unavailable") << "\n";
+	if (r.gpuAvailable)
+	{
+		o << "  samples=" << r.gpuSamples << " avgMs=" << r.gpuAvgMs << "\n";
+		if (r.gpuPercentilesAvailable)
+			o << "  p95Ms=" << r.gpuP95Ms << " p99Ms=" << r.gpuP99Ms << "\n";
+		else
+			o << "  p95/p99 unavailable (fewer than 100 GPU samples)\n";
+		for (size_t i = 1; i < kGpuPassCount; ++i)
+			if (r.gpuPasses[i].count)
+				o << "  " << kGpuPassNames[i] << " avgMs="
+				  << r.gpuPasses[i].totalMs / r.gpuPasses[i].count << "\n";
+		o << "  Delayed graphics-queue intervals; overlapping passes are not additive.\n";
+	}
 	o << "Biome map: zoom=" << r.biomeMapZoom
 	  << " mode=" << (r.biomeMapSequential ? "sequential" : "scheduled")
 	  << " (fixed center when enabled)\n";

--- a/src/Engine/Benchmark.hpp
+++ b/src/Engine/Benchmark.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Camera/Camera.hpp>
+#include <Engine/GpuProfile.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -39,6 +40,10 @@ struct BenchmarkWorkTiming
 struct BenchmarkReport
 {
 	bool valid{false};
+	bool gpuAvailable{false}, gpuPercentilesAvailable{false};
+	uint64_t gpuSamples{0};
+	float gpuAvgMs{0.f}, gpuP95Ms{0.f}, gpuP99Ms{0.f};
+	std::array<BenchmarkWorkTiming, kGpuPassCount> gpuPasses{};
 	std::array<BenchmarkWorkTiming, 3> backgroundWork{};
 	float biomeMapZoom{0.f};
 	bool biomeMapSequential{false};
@@ -146,6 +151,9 @@ public:
 
 	/// Queue waits and completed map latency from the frame's profiler snapshot.
 	void sampleBackgroundWork(const char *name, uint64_t count, double totalMs);
+	/// Zero outside measurement; tags exclude delayed warmup/previous-run results.
+	uint64_t gpuCaptureTag() const { return m_phase == BenchmarkPhase::Running ? m_gpuTag : 0; }
+	void sampleGpu(const GpuFrameSample &sample);
 	/// Progress 0–1 over warmup+duration total wall time for UI bar (full run).
 	float totalProgress() const;
 	/// Progress 0–1 of measurement only (warmup excluded).
@@ -199,6 +207,9 @@ public:
 
 private:
 	std::array<BenchmarkWorkTiming, 3> m_backgroundWork{};
+	uint64_t m_gpuTag{0}, m_lastGpuSerial{0};
+	std::vector<float> m_gpuFrames;
+	std::array<BenchmarkWorkTiming, kGpuPassCount> m_gpuPasses{};
 	std::vector<float> m_frameMs;
 	double m_sumStreaming{0}, m_sumAcquire{0}, m_sumRecord{0}, m_sumImGui{0}, m_sumPresent{0};
 	double m_sumVisibility{0}, m_sumMeshUpload{0};

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -783,6 +783,7 @@ void Engine::sampleBenchmarkFrame()
 		return;
 	uint64_t tJobs = 0, mJobs = 0, lJobs = 0;
 	float tMs = 0.f, mMs = 0.f, lMs = 0.f;
+	m_benchmark.sampleGpu(frameCtx->gpuProfiler().latest());
 	const int wc = prof.workerSnapshotCount();
 	const WorkerSnapshot *ws = prof.workerSnapshots();
 	for (int i = 0; i < wc; ++i)
@@ -831,6 +832,7 @@ void Engine::drawUi()
 	f.generator = terrainGenerator.get();
 	f.worldRenderer = worldRenderer.get();
 	f.vk = vkContext.get();
+	f.gpu = &frameCtx->gpuProfiler();
 	f.imm = immediate.get();
 	f.shader = &shaderParams;
 	f.render = &renderSettings;
@@ -965,6 +967,7 @@ void Engine::run()
 		recreateSwapchainIfNeeded(static_cast<uint32_t>(pixelW),
 								  static_cast<uint32_t>(pixelH));
 
+		frameCtx->gpuProfiler().syncCapture(GetProfiler().captureEpoch());
 		uint32_t imageIndex = 0;
 		{
 			PROFILE_SCOPE("Acquire");
@@ -1015,6 +1018,7 @@ void Engine::run()
 									renderSettings.shadowCascadeFar, underwater);
 		}
 
+		frameCtx->gpuProfiler().syncCapture(GetProfiler().captureEpoch());
 		const int uploadBudget = uploadBudgetThisFrame;
 		{
 			PROFILE_SCOPE("Record");
@@ -1048,7 +1052,7 @@ void Engine::run()
 				[&](VkCommandBuffer cmd) {
 					if (imgui)
 						imgui->recordDraw(cmd);
-				});
+				}, &frameCtx->gpuProfiler(), m_benchmark.gpuCaptureTag());
 		}
 
 		{

--- a/src/Engine/GameUI.cpp
+++ b/src/Engine/GameUI.cpp
@@ -653,7 +653,10 @@ void GameUI::drawProfiler(GameUIFrame &frame)
 		prof.setEnabled(capturing);
 	ImGui::SameLine();
 	if (ImGui::Button("Clear history"))
+	{
 		prof.clearHistory();
+		if (frame.gpu) frame.gpu->syncCapture(prof.captureEpoch());
+	}
 	ImGui::SameLine();
 	ImGui::TextDisabled("CPU scopes · previous frame");
 
@@ -662,7 +665,7 @@ void GameUI::drawProfiler(GameUIFrame &frame)
 	const float fpsEst = prof.fpsEstimate();
 	const float p1 = prof.onePercentLowMs();
 
-	ImGui::SeparatorText("Frame");
+	ImGui::SeparatorText("CPU frame");
 	ImGui::Text("%.1f FPS  |  %.2f ms  |  avg %.2f ms", fpsEst, frameMs, avgMs);
 	if (p1 > 0.f)
 		ImGui::Text("1%% low (slow frames): %.2f ms  (~%.0f FPS)", p1, p1 > 1e-4f ? 1000.f / p1 : 0.f);
@@ -697,7 +700,7 @@ void GameUI::drawProfiler(GameUIFrame &frame)
 	}
 
 	// Hierarchy
-	ImGui::SeparatorText("Hierarchy (last frame)");
+	ImGui::SeparatorText("CPU hierarchy (command recording, not GPU execution)");
 	const float denom = frameMs > 1e-4f ? frameMs : 1.f;
 	if (ImGui::BeginTable("scopes", 4,
 						  ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY,
@@ -748,6 +751,28 @@ void GameUI::drawProfiler(GameUIFrame &frame)
 			ImGui::TextDisabled("No samples yet — wait a frame or enable Capture");
 		}
 		ImGui::EndTable();
+	}
+
+	ImGui::SeparatorText("GPU frame / passes");
+	if (frame.gpu)
+	{
+		auto &gpu = *frame.gpu;
+		bool enabled = gpu.enabled();
+		if (ImGui::Checkbox("GPU timestamps", &enabled)) gpu.setEnabled(enabled);
+		ImGui::TextDisabled("%s", gpu.status());
+		if (gpu.latest().serial)
+		{
+			for (size_t i = 0; i < kGpuPassCount; ++i)
+				if (gpu.latest().present[i])
+					ImGui::Text("%s: %.3f ms", kGpuPassNames[i], gpu.latest().ms[i]);
+			ImGui::TextDisabled("Pass intervals may overlap; do not sum them. Present wait is CPU-side.");
+			std::vector<float> ordered;
+			const int n = gpu.historyCount();
+			const int start = n < VkGpuProfiler::kHistorySize ? 0 : gpu.historyWrite();
+			for (int i = 0; i < n; ++i)
+				ordered.push_back(gpu.history()[(start + i) % VkGpuProfiler::kHistorySize]);
+			ImGui::PlotLines("##gpu", ordered.data(), n, 0, nullptr, 0.f, FLT_MAX, ImVec2(-1.f, 80.f));
+		}
 	}
 
 	// Worker jobs
@@ -921,6 +946,20 @@ void GameUI::drawBenchmarkReport(GameUIFrame &frame)
 		ImGui::EndTable();
 	}
 
+	ImGui::SeparatorText("GPU timestamps");
+	if (!r.gpuAvailable)
+		ImGui::TextDisabled("Unavailable: no completed GPU samples");
+	else
+	{
+		ImGui::Text("%llu samples | average %.3f ms", static_cast<unsigned long long>(r.gpuSamples), r.gpuAvgMs);
+		if (r.gpuPercentilesAvailable)
+			ImGui::Text("p95 %.3f ms | p99 %.3f ms", r.gpuP95Ms, r.gpuP99Ms);
+		else
+			ImGui::TextDisabled("p95/p99 unavailable (fewer than 100 samples)");
+		for (size_t i = 1; i < kGpuPassCount; ++i)
+			if (r.gpuPasses[i].count)
+				ImGui::Text("%s: %.3f ms", kGpuPassNames[i], r.gpuPasses[i].totalMs / r.gpuPasses[i].count);
+	}
 	ImGui::SeparatorText("CPU scopes (avg ms)");
 	if (ImGui::BeginTable("bm_sc", 2, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))
 	{

--- a/src/Engine/GameUI.hpp
+++ b/src/Engine/GameUI.hpp
@@ -33,6 +33,7 @@ struct GameUIFrame
 	TerrainGenerator *generator{nullptr};
 	WorldRenderer *worldRenderer{nullptr};
 	VkContext *vk{nullptr};
+	VkGpuProfiler *gpu{nullptr};
 	ImmediateCommands *imm{nullptr};
 
 	ShaderParameters *shader{nullptr};

--- a/src/Engine/GpuProfile.hpp
+++ b/src/Engine/GpuProfile.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+enum class GpuPass : uint32_t { Frame, Upload, Shadow, Opaque, Overlays, Water, Sky, Post, ImGui, Count };
+inline constexpr size_t kGpuPassCount = static_cast<size_t>(GpuPass::Count);
+inline constexpr std::array<const char *, kGpuPassCount> kGpuPassNames = {
+    "GPU Frame", "Uploads", "Shadow", "Opaque", "Overlays", "Water", "Sky", "Post", "ImGui"};
+
+struct GpuFrameSample
+{
+    uint64_t serial{0};
+    uint64_t benchmarkTag{0};
+    std::array<float, kGpuPassCount> ms{};
+    std::array<bool, kGpuPassCount> present{};
+};
+
+inline bool gpuTimestampSupported(bool graphicsAndCompute, uint32_t validBits, float period)
+{
+    return graphicsAndCompute && validBits > 0 && validBits <= 64 &&
+           std::isfinite(period) && period > 0.f;
+}
+
+// Unsigned subtraction plus masking handles one counter wrap without ever
+// shifting by 64. Multiple wraps cannot be recovered from two timestamps.
+inline double gpuTimestampMilliseconds(uint64_t begin, uint64_t end, uint32_t bits, float period)
+{
+    if (bits == 0 || bits > 64 || !std::isfinite(period) || period <= 0.f)
+        return 0.0;
+    const uint64_t mask = bits == 64 ? std::numeric_limits<uint64_t>::max() : (uint64_t{1} << bits) - 1;
+    return static_cast<double>((end - begin) & mask) * static_cast<double>(period) / 1000000.0;
+}

--- a/src/Engine/GpuProfile.hpp
+++ b/src/Engine/GpuProfile.hpp
@@ -19,9 +19,12 @@ struct GpuFrameSample
     std::array<bool, kGpuPassCount> present{};
 };
 
-inline bool gpuTimestampSupported(bool graphicsAndCompute, uint32_t validBits, float period)
+// timestampComputeAndGraphics guarantees support across graphics/compute queues.
+// For queries on the selected graphics queue, that queue's valid bits are
+// authoritative even when the device-wide guarantee is false.
+inline bool gpuTimestampSupported(uint32_t validBits, float period)
 {
-    return graphicsAndCompute && validBits > 0 && validBits <= 64 &&
+    return validBits > 0 && validBits <= 64 &&
            std::isfinite(period) && period > 0.f;
 }
 

--- a/src/Renderer/OpaquePass.cpp
+++ b/src/Renderer/OpaquePass.cpp
@@ -67,8 +67,9 @@ void OpaquePass::destroyPipeline()
 void OpaquePass::record(VkCommandBuffer cmd, VkExtent2D extent, VkDescriptorSet set0, VkDescriptorSet set1,
 						VkPipelineLayout layout, AllocatedImage &hdr, AllocatedImage &depth,
 						const std::vector<Chunk *> &chunks, OverlayRenderer &overlays,
-						const VkClearColorValue &clearColor)
+						const VkClearColorValue &clearColor, VkGpuProfiler *gpu)
 {
+	if (gpu) gpu->beginPass(cmd, GpuPass::Opaque);
 	const auto beginRendering = beginR();
 	const auto endRendering = endR();
 
@@ -116,6 +117,9 @@ void OpaquePass::record(VkCommandBuffer cmd, VkExtent2D extent, VkDescriptorSet 
 		if (chunk)
 			chunk->draw(cmd);
 	}
+	if (gpu) gpu->endPass(cmd, GpuPass::Opaque);
+	if (gpu) gpu->beginPass(cmd, GpuPass::Overlays);
 	overlays.record(cmd, set0, chunks);
+	if (gpu) gpu->endPass(cmd, GpuPass::Overlays);
 	endRendering(cmd);
 }

--- a/src/Renderer/OpaquePass.hpp
+++ b/src/Renderer/OpaquePass.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Vulkan/VkContext.hpp"
+#include "Vulkan/VkGpuProfiler.hpp"
 #include "Vulkan/VkImage.hpp"
 #include "Chunk/Chunk.hpp"
 #include "Renderer/OverlayRenderer.hpp"
@@ -23,7 +24,7 @@ public:
 	void record(VkCommandBuffer cmd, VkExtent2D extent, VkDescriptorSet set0, VkDescriptorSet set1,
 				VkPipelineLayout layout, AllocatedImage &hdr, AllocatedImage &depth,
 				const std::vector<Chunk *> &chunks, OverlayRenderer &overlays,
-				const VkClearColorValue &clearColor);
+				const VkClearColorValue &clearColor, VkGpuProfiler *gpu = nullptr);
 
 private:
 	VkContext *m_context{nullptr};

--- a/src/Renderer/WorldRenderer.cpp
+++ b/src/Renderer/WorldRenderer.cpp
@@ -361,7 +361,8 @@ void WorldRenderer::recordFrame(VkCommandBuffer cmd, uint32_t frameIndex, uint32
 								  VkSwapchain &swapchain, const std::vector<Chunk *> &chunks,
 								  const std::vector<Chunk *> &shadowChunks, const VkClearColorValue &clearColor,
 								  const std::function<void(VkCommandBuffer)> &preRecord,
-								  const std::function<void(VkCommandBuffer)> &imguiDraw)
+								  const std::function<void(VkCommandBuffer)> &imguiDraw,
+                                  VkGpuProfiler *gpu, uint64_t benchmarkTag)
 {
 	const VkExtent2D extent = swapchain.getExtent();
 	const auto beginRendering = beginR();
@@ -373,28 +374,37 @@ void WorldRenderer::recordFrame(VkCommandBuffer cmd, uint32_t frameIndex, uint32
 	if (vkBeginCommandBuffer(cmd, &beginInfo) != VK_SUCCESS)
 		throw std::runtime_error("Failed to begin terrain command buffer");
 
+	if (gpu) gpu->beginRecording(cmd, frameIndex, benchmarkTag);
+	if (gpu) gpu->beginPass(cmd, GpuPass::Upload);
 	if (preRecord)
 		preRecord(cmd);
+	if (gpu) gpu->endPass(cmd, GpuPass::Upload);
 
 	const VkDescriptorSet set0 = m_frameUbos[frameIndex].descriptorSet0;
 
 	{
 		PROFILE_SCOPE("Shadow");
+		if (gpu) gpu->beginPass(cmd, GpuPass::Shadow);
 		m_shadow.record(cmd, shadowChunks, m_cascadeMatrices, m_time);
+		if (gpu) gpu->endPass(cmd, GpuPass::Shadow);
 	}
 	{
 		PROFILE_SCOPE("Scene");
 		m_opaque.record(cmd, extent, set0, m_set1, m_pipelineLayout, m_post.hdrColor(), m_post.sceneDepth(), chunks,
-						m_overlays, clearColor);
+						m_overlays, clearColor, gpu);
 	}
 	{
 		const auto *ubo = static_cast<const FrameUBO *>(m_frameUbos[frameIndex].uboMapped);
+		if (gpu) gpu->beginPass(cmd, GpuPass::Water);
 		m_water.record(cmd, extent, set0, m_set1, m_set2Water, m_waterPipelineLayout, m_post.hdrColor(),
 					   m_post.sceneDepth(), chunks, glm::vec3(ubo->viewPos));
+		if (gpu) gpu->endPass(cmd, GpuPass::Water);
 	}
 	{
 		PROFILE_SCOPE("Sky");
+		if (gpu) gpu->beginPass(cmd, GpuPass::Sky);
 		m_sky.record(cmd, set0, extent, m_post.hdrColor(), m_post.godSource(), m_post.sceneDepth());
+		if (gpu) gpu->endPass(cmd, GpuPass::Sky);
 	}
 	{
 		PROFILE_SCOPE("Post");
@@ -412,15 +422,18 @@ void WorldRenderer::recordFrame(VkCommandBuffer cmd, uint32_t frameIndex, uint32
 				sunVisibility = 0.f;
 		}
 		m_postSettings.underwater = ubo->lightingParams.w > 0.5f;
+		if (gpu) gpu->beginPass(cmd, GpuPass::Post);
 		m_post.recordPost(cmd, swapchain.getImages()[imageIndex],
 						  swapchain.getImageViews()[imageIndex], extent,
 						  frameIndex, set0, m_postSettings, sunScreen,
 						  sunVisibility, m_time, ubo->projection);
+		if (gpu) gpu->endPass(cmd, GpuPass::Post);
 	}
 
 	if (imguiDraw)
 	{
 		PROFILE_SCOPE("ImGuiDraw");
+		if (gpu) gpu->beginPass(cmd, GpuPass::ImGui);
 		VkRenderingAttachmentInfo colorAtt{VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO};
 		colorAtt.imageView = swapchain.getImageViews()[imageIndex];
 		colorAtt.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -438,12 +451,14 @@ void WorldRenderer::recordFrame(VkCommandBuffer cmd, uint32_t frameIndex, uint32
 		vkCmdSetScissor(cmd, 0, 1, &sc);
 		imguiDraw(cmd);
 		endRendering(cmd);
+		if (gpu) gpu->endPass(cmd, GpuPass::ImGui);
 	}
 
 	vkbar::cmdTransitionColor(cmd, swapchain.getImages()[imageIndex], VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
 							  VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, 0,
 							  VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 
+	if (gpu) gpu->endRecording(cmd);
 	if (vkEndCommandBuffer(cmd) != VK_SUCCESS)
 		throw std::runtime_error("Failed to end terrain command buffer");
 }

--- a/src/Renderer/WorldRenderer.hpp
+++ b/src/Renderer/WorldRenderer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Vulkan/VkContext.hpp"
+#include "Vulkan/VkGpuProfiler.hpp"
 #include "Vulkan/VkSwapchain.hpp"
 #include "Vulkan/VkBuffer.hpp"
 #include "Vulkan/VkImage.hpp"
@@ -57,7 +58,8 @@ public:
 					 const std::vector<Chunk *> &chunks, const std::vector<Chunk *> &shadowChunks,
 					 const VkClearColorValue &clearColor,
 					 const std::function<void(VkCommandBuffer)> &preRecord = {},
-					 const std::function<void(VkCommandBuffer)> &imguiDraw = {});
+					 const std::function<void(VkCommandBuffer)> &imguiDraw = {},
+                     VkGpuProfiler *gpu = nullptr, uint64_t benchmarkTag = 0);
 
 	PostProcessSettings &postSettings() { return m_postSettings; }
 	OverlayRenderer &overlays() { return m_overlays; }

--- a/src/Vulkan/VkFrame.cpp
+++ b/src/Vulkan/VkFrame.cpp
@@ -11,6 +11,7 @@ void VkFrameContext::init(VkContext &context)
 {
 	m_context = &context;
 	VkDevice device = m_context->getDevice();
+	m_gpuProfiler.init(context, kMaxFramesInFlight);
 
 	for (uint32_t i = 0; i < kMaxFramesInFlight; ++i)
 	{
@@ -52,6 +53,7 @@ void VkFrameContext::shutdown()
 	}
 
 	m_context->waitIdle();
+	m_gpuProfiler.shutdown();
 	VkDevice device = m_context->getDevice();
 
 	for (auto &frame : m_frames)
@@ -113,6 +115,7 @@ bool VkFrameContext::beginFrame(VkSwapchain &swapchain, uint32_t &outImageIndex)
 	FrameData &frame = m_frames[m_currentFrame];
 
 	vkWaitForFences(device, 1, &frame.inFlight, VK_TRUE, UINT64_MAX);
+	m_gpuProfiler.onSlotReady(m_currentFrame);
 
 	VkResult result = vkAcquireNextImageKHR(device, swapchain.getSwapchain(), UINT64_MAX, frame.imageAvailable,
 											VK_NULL_HANDLE, &outImageIndex);
@@ -154,6 +157,7 @@ bool VkFrameContext::submitAndPresent(VkSwapchain &swapchain, uint32_t imageInde
 	if (vkQueueSubmit(m_context->getGraphicsQueue(), 1, &submit, frame.inFlight) != VK_SUCCESS)
 		throw std::runtime_error("Failed to submit frame command buffer");
 
+	m_gpuProfiler.markSubmitted(m_currentFrame);
 	VkPresentInfoKHR present{};
 	present.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
 	present.waitSemaphoreCount = 1;

--- a/src/Vulkan/VkFrame.hpp
+++ b/src/Vulkan/VkFrame.hpp
@@ -2,6 +2,7 @@
 
 #include "Vulkan/VkContext.hpp"
 #include "Vulkan/VkSwapchain.hpp"
+#include "Vulkan/VkGpuProfiler.hpp"
 
 #include <array>
 #include <cstdint>
@@ -36,6 +37,8 @@ public:
 	/// Legacy clear-only path (tests / smoke). Prefer record + submitAndPresent for the game.
 	bool endFrameClearAndPresent(VkSwapchain &swapchain, uint32_t imageIndex, const VkClearColorValue &clearColor);
 
+	VkGpuProfiler &gpuProfiler() { return m_gpuProfiler; }
+
 	uint32_t frameIndex() const { return m_currentFrame; }
 	uint32_t currentFrameIndex() const { return m_currentFrame; }
 	VkCommandBuffer commandBuffer() const { return m_frames[m_currentFrame].commandBuffer; }
@@ -55,6 +58,7 @@ private:
 	void recordClearCommands(VkCommandBuffer cmd, VkSwapchain &swapchain, uint32_t imageIndex,
 							 const VkClearColorValue &clearColor);
 
+	VkGpuProfiler m_gpuProfiler;
 	VkContext *m_context{nullptr};
 	std::array<FrameData, kMaxFramesInFlight> m_frames{};
 	std::vector<VkFence> m_imagesInFlight;

--- a/src/Vulkan/VkGpuProfiler.cpp
+++ b/src/Vulkan/VkGpuProfiler.cpp
@@ -1,0 +1,164 @@
+#include <Vulkan/VkGpuProfiler.hpp>
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+
+void VkGpuProfiler::init(VkContext &context, uint32_t slots)
+{
+    m_device = context.getDevice();
+    const auto &limits = context.getDeviceProperties().limits;
+    uint32_t count = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(context.getPhysicalDevice(), &count, nullptr);
+    std::vector<VkQueueFamilyProperties> families(count);
+    vkGetPhysicalDeviceQueueFamilyProperties(context.getPhysicalDevice(), &count, families.data());
+    m_period = limits.timestampPeriod;
+    m_validBits = families.at(context.getGraphicsQueueFamily()).timestampValidBits;
+    m_supported = gpuTimestampSupported(limits.timestampComputeAndGraphics == VK_TRUE, m_validBits, m_period);
+    if (const char *env = std::getenv("FT_VOX_GPU_PROFILING"))
+        m_enabled = std::strcmp(env, "0") != 0;
+    if (!m_supported)
+        return;
+    m_slots.resize(slots);
+    VkQueryPoolCreateInfo info{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
+    info.queryType = VK_QUERY_TYPE_TIMESTAMP;
+    info.queryCount = kQueries;
+    for (auto &slot : m_slots)
+        if (vkCreateQueryPool(m_device, &info, nullptr, &slot.pool) != VK_SUCCESS)
+        {
+            // Optional instrumentation must not prevent rendering.
+            shutdown();
+            return;
+        }
+}
+
+void VkGpuProfiler::shutdown()
+{
+    for (auto &slot : m_slots)
+        if (slot.pool != VK_NULL_HANDLE)
+            vkDestroyQueryPool(m_device, slot.pool, nullptr);
+    m_slots.clear();
+    m_recording = nullptr;
+    m_supported = false;
+    m_device = VK_NULL_HANDLE;
+    clear();
+}
+
+void VkGpuProfiler::clear()
+{
+    ++m_generation;
+    m_latest = {};
+    m_history.fill(0.f);
+    m_historyCount = m_historyWrite = 0;
+}
+
+void VkGpuProfiler::syncCapture(uint64_t epoch)
+{
+    if (epoch != m_epoch)
+    {
+        m_epoch = epoch;
+        clear();
+    }
+}
+
+void VkGpuProfiler::setEnabled(bool enabled)
+{
+    if (m_enabled != enabled)
+    {
+        m_enabled = enabled;
+        clear();
+    }
+}
+
+const char *VkGpuProfiler::status() const
+{
+    if (!m_supported) return "GPU timestamps unavailable (device/queue or query-pool allocation)";
+    if (!m_enabled) return "GPU timestamps disabled";
+    if (!m_latest.serial) return "Waiting for a completed GPU frame";
+    return "GPU timestamp queries (delayed, graphics queue)";
+}
+
+void VkGpuProfiler::onSlotReady(uint32_t index)
+{
+    if (!m_supported) return;
+    auto &slot = m_slots.at(index);
+    if (!slot.pending) return;
+    slot.pending = false;
+    if (!m_enabled || slot.generation != m_generation) return;
+    struct Query { uint64_t value, available; };
+    std::array<Query, kQueries> queries{};
+    // The existing frame fence has signalled. Never use WAIT_BIT or add a wait.
+    const VkResult result = vkGetQueryPoolResults(m_device, slot.pool, 0, kQueries,
+        sizeof(queries), queries.data(), sizeof(Query),
+        VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WITH_AVAILABILITY_BIT);
+    if (result != VK_SUCCESS && result != VK_NOT_READY) return;
+    GpuFrameSample sample;
+    sample.benchmarkTag = slot.benchmarkTag;
+    for (uint32_t i = 0; i < kGpuPassCount; ++i)
+    {
+        const uint32_t bit = uint32_t{1} << i;
+        if (!(slot.ended & bit)) continue;
+        if (!queries[i * 2].available || !queries[i * 2 + 1].available) return;
+        sample.ms[i] = static_cast<float>(gpuTimestampMilliseconds(
+            queries[i * 2].value, queries[i * 2 + 1].value, m_validBits, m_period));
+        sample.present[i] = true;
+    }
+    if (!sample.present[static_cast<size_t>(GpuPass::Frame)]) return;
+    sample.serial = ++m_serial;
+    m_latest = sample;
+    m_history[m_historyWrite] = sample.ms[0];
+    m_historyWrite = (m_historyWrite + 1) % kHistorySize;
+    m_historyCount = std::min(m_historyCount + 1, kHistorySize);
+}
+
+void VkGpuProfiler::beginRecording(VkCommandBuffer cmd, uint32_t index, uint64_t benchmarkTag)
+{
+    m_recording = nullptr;
+    if (!m_supported) return;
+    auto &slot = m_slots.at(index);
+    slot.recorded = false;
+    if (!m_enabled) return;
+    slot.started = slot.ended = 0;
+    slot.generation = m_generation;
+    slot.benchmarkTag = benchmarkTag;
+    m_recording = &slot;
+    vkCmdResetQueryPool(cmd, slot.pool, 0, kQueries);
+    beginPass(cmd, GpuPass::Frame);
+}
+
+void VkGpuProfiler::beginPass(VkCommandBuffer cmd, GpuPass pass)
+{
+    if (!m_recording) return;
+    const auto i = static_cast<uint32_t>(pass);
+    const uint32_t bit = uint32_t{1} << i;
+    if (m_recording->started & bit) return;
+    m_recording->started |= bit;
+    vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, m_recording->pool, i * 2);
+}
+
+void VkGpuProfiler::endPass(VkCommandBuffer cmd, GpuPass pass)
+{
+    if (!m_recording) return;
+    const auto i = static_cast<uint32_t>(pass);
+    const uint32_t bit = uint32_t{1} << i;
+    if (!(m_recording->started & bit) || (m_recording->ended & bit)) return;
+    m_recording->ended |= bit;
+    vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_recording->pool, i * 2 + 1);
+}
+
+void VkGpuProfiler::endRecording(VkCommandBuffer cmd)
+{
+    if (!m_recording) return;
+    endPass(cmd, GpuPass::Frame);
+    m_recording->recorded = true;
+    m_recording = nullptr;
+}
+
+void VkGpuProfiler::markSubmitted(uint32_t index)
+{
+    if (m_supported)
+    {
+        auto &slot = m_slots.at(index);
+        slot.pending = slot.recorded;
+        slot.recorded = false;
+    }
+}

--- a/src/Vulkan/VkGpuProfiler.cpp
+++ b/src/Vulkan/VkGpuProfiler.cpp
@@ -5,6 +5,12 @@
 
 void VkGpuProfiler::init(VkContext &context, uint32_t slots)
 {
+    if (slots == 0)
+    {
+        m_supported = false;
+        m_unavailableReason = UnavailableReason::NoSlots;
+        return;
+    }
     m_device = context.getDevice();
     const auto &limits = context.getDeviceProperties().limits;
     uint32_t count = 0;
@@ -12,12 +18,24 @@ void VkGpuProfiler::init(VkContext &context, uint32_t slots)
     std::vector<VkQueueFamilyProperties> families(count);
     vkGetPhysicalDeviceQueueFamilyProperties(context.getPhysicalDevice(), &count, families.data());
     m_period = limits.timestampPeriod;
-    m_validBits = families.at(context.getGraphicsQueueFamily()).timestampValidBits;
-    m_supported = gpuTimestampSupported(limits.timestampComputeAndGraphics == VK_TRUE, m_validBits, m_period);
+    const uint32_t family = context.getGraphicsQueueFamily();
+    if (family >= count || family >= families.size())
+    {
+        m_supported = false;
+        m_unavailableReason = UnavailableReason::InvalidQueueFamily;
+        return;
+    }
+    m_validBits = families[family].timestampValidBits;
+    m_supported = gpuTimestampSupported(m_validBits, m_period);
     if (const char *env = std::getenv("FT_VOX_GPU_PROFILING"))
         m_enabled = std::strcmp(env, "0") != 0;
     if (!m_supported)
+    {
+        m_unavailableReason = m_validBits == 0 ? UnavailableReason::NoTimestampBits :
+            m_validBits > 64 ? UnavailableReason::InvalidTimestampBits :
+            UnavailableReason::InvalidTimestampPeriod;
         return;
+    }
     m_slots.resize(slots);
     VkQueryPoolCreateInfo info{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
     info.queryType = VK_QUERY_TYPE_TIMESTAMP;
@@ -27,6 +45,7 @@ void VkGpuProfiler::init(VkContext &context, uint32_t slots)
         {
             // Optional instrumentation must not prevent rendering.
             shutdown();
+            m_unavailableReason = UnavailableReason::QueryPoolAllocationFailed;
             return;
         }
 }
@@ -39,6 +58,7 @@ void VkGpuProfiler::shutdown()
     m_slots.clear();
     m_recording = nullptr;
     m_supported = false;
+    m_unavailableReason = UnavailableReason::NotInitialized;
     m_device = VK_NULL_HANDLE;
     clear();
 }
@@ -71,7 +91,19 @@ void VkGpuProfiler::setEnabled(bool enabled)
 
 const char *VkGpuProfiler::status() const
 {
-    if (!m_supported) return "GPU timestamps unavailable (device/queue or query-pool allocation)";
+    if (!m_supported)
+    {
+        switch (m_unavailableReason)
+        {
+        case UnavailableReason::NoSlots: return "GPU timestamps unavailable: no frame slots";
+        case UnavailableReason::InvalidQueueFamily: return "GPU timestamps unavailable: invalid graphics queue family";
+        case UnavailableReason::NoTimestampBits: return "GPU timestamps unavailable: graphics queue has timestampValidBits=0";
+        case UnavailableReason::InvalidTimestampBits: return "GPU timestamps unavailable: invalid timestampValidBits";
+        case UnavailableReason::InvalidTimestampPeriod: return "GPU timestamps unavailable: invalid timestampPeriod";
+        case UnavailableReason::QueryPoolAllocationFailed: return "GPU timestamps unavailable: query pool allocation failed";
+        default: return "GPU timestamps unavailable: not initialized";
+        }
+    }
     if (!m_enabled) return "GPU timestamps disabled";
     if (!m_latest.serial) return "Waiting for a completed GPU frame";
     return "GPU timestamp queries (delayed, graphics queue)";

--- a/src/Vulkan/VkGpuProfiler.hpp
+++ b/src/Vulkan/VkGpuProfiler.hpp
@@ -31,6 +31,12 @@ public:
     int historyWrite() const { return m_historyWrite; }
     static constexpr int kHistorySize = 240;
 private:
+    enum class UnavailableReason
+    {
+        NotInitialized, NoSlots, InvalidQueueFamily, NoTimestampBits,
+        InvalidTimestampBits, InvalidTimestampPeriod, QueryPoolAllocationFailed
+    };
+    UnavailableReason m_unavailableReason{UnavailableReason::NotInitialized};
     static constexpr uint32_t kQueries = static_cast<uint32_t>(kGpuPassCount * 2);
     struct Slot
     {

--- a/src/Vulkan/VkGpuProfiler.hpp
+++ b/src/Vulkan/VkGpuProfiler.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <Engine/GpuProfile.hpp>
+#include <Vulkan/VkContext.hpp>
+#include <vector>
+
+/// Query storage belongs to the frame-slot owner. onSlotReady() must only be
+/// called after that slot's existing fence, before resetting/re-recording it.
+class VkGpuProfiler
+{
+public:
+    VkGpuProfiler() = default;
+    VkGpuProfiler(const VkGpuProfiler &) = delete;
+    VkGpuProfiler &operator=(const VkGpuProfiler &) = delete;
+    void init(VkContext &context, uint32_t slots);
+    void shutdown(); // owner has waited for the device
+    void onSlotReady(uint32_t slot);
+    void beginRecording(VkCommandBuffer cmd, uint32_t slot, uint64_t benchmarkTag);
+    void beginPass(VkCommandBuffer cmd, GpuPass pass);
+    void endPass(VkCommandBuffer cmd, GpuPass pass);
+    void endRecording(VkCommandBuffer cmd);
+    void markSubmitted(uint32_t slot);
+    void syncCapture(uint64_t epoch);
+    void setEnabled(bool enabled);
+    bool enabled() const { return m_enabled; }
+    bool supported() const { return m_supported; }
+    const char *status() const;
+    const GpuFrameSample &latest() const { return m_latest; }
+    const float *history() const { return m_history.data(); }
+    int historyCount() const { return m_historyCount; }
+    int historyWrite() const { return m_historyWrite; }
+    static constexpr int kHistorySize = 240;
+private:
+    static constexpr uint32_t kQueries = static_cast<uint32_t>(kGpuPassCount * 2);
+    struct Slot
+    {
+        VkQueryPool pool{VK_NULL_HANDLE};
+        uint64_t generation{0}, benchmarkTag{0};
+        uint32_t started{0}, ended{0};
+        bool recorded{false}, pending{false};
+    };
+    void clear();
+    VkDevice m_device{VK_NULL_HANDLE};
+    std::vector<Slot> m_slots;
+    Slot *m_recording{nullptr};
+    bool m_supported{false}, m_enabled{true};
+    float m_period{0.f};
+    uint32_t m_validBits{0};
+    uint64_t m_epoch{0}, m_generation{0}, m_serial{0};
+    GpuFrameSample m_latest{};
+    std::array<float, kHistorySize> m_history{};
+    int m_historyCount{0}, m_historyWrite{0};
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -309,3 +309,14 @@ target_link_libraries(test_profiler PRIVATE
 )
 
 add_test(NAME ProfilerWorkerConsistency COMMAND test_profiler)
+
+add_executable(test_gpu_profile
+    test_gpu_profile.cpp
+    ${CMAKE_SOURCE_DIR}/src/Engine/Benchmark.cpp
+    ${CMAKE_SOURCE_DIR}/src/Engine/BuildInfo.cpp
+    ${CMAKE_SOURCE_DIR}/src/Camera/Camera.cpp
+)
+add_dependencies(test_gpu_profile ft_vox_build_info)
+target_include_directories(test_gpu_profile PRIVATE ${CMAKE_SOURCE_DIR}/src ${FT_VOX_GENERATED_DIR})
+target_link_libraries(test_gpu_profile PRIVATE glm SDL3::SDL3)
+add_test(NAME GpuProfile COMMAND test_gpu_profile)

--- a/tests/test_gpu_profile.cpp
+++ b/tests/test_gpu_profile.cpp
@@ -1,0 +1,80 @@
+#include <Engine/Benchmark.hpp>
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+static void require(bool condition, const char *message)
+{
+    if (!condition) throw std::runtime_error(message);
+}
+
+int main()
+{
+    try
+    {
+        require(gpuTimestampSupported(true, 64, 1.f), "64-bit support");
+        require(!gpuTimestampSupported(false, 64, 1.f), "device capability gate");
+        require(!gpuTimestampSupported(true, 0, 1.f), "queue capability gate");
+        require(!gpuTimestampSupported(true, 65, 1.f), "invalid bit count");
+        require(!gpuTimestampSupported(true, 64, NAN), "invalid period");
+        require(!gpuTimestampSupported(true, 64, 0.f), "zero period");
+        require(std::abs(gpuTimestampMilliseconds(250, 10, 8, 1000.f) - .016) < 1e-9, "8-bit wrap");
+        require(std::abs(gpuTimestampMilliseconds(UINT64_MAX - 9, 10, 64, 1000.f) - .020) < 1e-9, "64-bit wrap");
+        require(gpuTimestampMilliseconds(0, 2000000, 64, .5f) == 1., "nanoseconds to milliseconds");
+
+        Camera camera;
+        Benchmark benchmark;
+        benchmark.config().warmupSec = 0.f;
+        benchmark.config().durationSec = 5.f;
+        benchmark.requestStart();
+        benchmark.onWorldReady(glm::vec3(0.f));
+        benchmark.tick(.001, camera);
+        const auto tag = benchmark.gpuCaptureTag();
+        require(tag != 0, "running capture tag");
+        GpuFrameSample sample;
+        sample.present[0] = sample.present[2] = true;
+        sample.benchmarkTag = tag;
+        for (uint64_t i = 1; i <= 100; ++i)
+        {
+            sample.serial = i;
+            sample.ms[0] = static_cast<float>(i);
+            sample.ms[2] = 2.f;
+            benchmark.sampleGpu(sample);
+            benchmark.sampleGpu(sample); // A delayed result must never be counted twice.
+        }
+        sample.serial = 101;
+        sample.benchmarkTag = 0; // Warmup result arriving during measurement.
+        benchmark.sampleGpu(sample);
+        benchmark.tick(6., camera);
+        const auto &report = benchmark.report();
+        require(report.gpuSamples == 100, "deduplication and warmup exclusion");
+        require(report.gpuAvgMs == 50.5f, "GPU average");
+        require(report.gpuPercentilesAvailable && report.gpuP95Ms >= 94.f && report.gpuP99Ms >= 98.f, "GPU percentiles");
+        require(report.gpuPasses[2].count == 100 && report.gpuPasses[2].totalMs == 200., "per-pass aggregation");
+        require(report.gpuPasses[3].count == 0, "absent pass stays absent");
+
+        benchmark.requestStart();
+        benchmark.onWorldReady(glm::vec3(0.f));
+        benchmark.tick(.001, camera);
+        sample.benchmarkTag = tag; // Previous run's in-flight result.
+        benchmark.sampleGpu(sample);
+        benchmark.tick(6., camera);
+        require(!benchmark.report().gpuAvailable && benchmark.report().gpuSamples == 0, "new run excludes old GPU results");
+        require(benchmark.formatReportText().find("unavailable") != std::string::npos, "unavailable report");
+        benchmark.requestStart();
+        benchmark.onWorldReady(glm::vec3(0.f));
+        benchmark.tick(.001, camera);
+        sample.benchmarkTag = benchmark.gpuCaptureTag();
+        benchmark.sampleGpu(sample);
+        benchmark.tick(6., camera);
+        require(benchmark.report().gpuAvailable && !benchmark.report().gpuPercentilesAvailable,
+                "short capture keeps average but suppresses percentiles");
+        std::cout << "PASS: GPU conversion and benchmark capture isolation\n";
+        return 0;
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "FAIL: " << e.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/test_gpu_profile.cpp
+++ b/tests/test_gpu_profile.cpp
@@ -12,12 +12,16 @@ int main()
 {
     try
     {
-        require(gpuTimestampSupported(true, 64, 1.f), "64-bit support");
-        require(!gpuTimestampSupported(false, 64, 1.f), "device capability gate");
-        require(!gpuTimestampSupported(true, 0, 1.f), "queue capability gate");
-        require(!gpuTimestampSupported(true, 65, 1.f), "invalid bit count");
-        require(!gpuTimestampSupported(true, 64, NAN), "invalid period");
-        require(!gpuTimestampSupported(true, 64, 0.f), "zero period");
+        // The device-wide timestampComputeAndGraphics flag is deliberately not
+        // an input: a selected queue with valid timestamps is sufficient.
+        for (uint32_t bits : {36u, 40u, 48u, 56u, 64u})
+            require(gpuTimestampSupported(bits, 1.f), "valid graphics timestamp width");
+        require(!gpuTimestampSupported(0, 1.f), "queue without timestamps");
+        require(!gpuTimestampSupported(65, 1.f), "invalid bit count");
+        require(!gpuTimestampSupported(64, NAN), "invalid timestamp period");
+        require(!gpuTimestampSupported(64, INFINITY), "infinite timestamp period");
+        require(!gpuTimestampSupported(64, -1.f), "negative timestamp period");
+        require(!gpuTimestampSupported(64, 0.f), "zero timestamp period");
         require(std::abs(gpuTimestampMilliseconds(250, 10, 8, 1000.f) - .016) < 1e-9, "8-bit wrap");
         require(std::abs(gpuTimestampMilliseconds(UINT64_MAX - 9, 10, 64, 1000.f) - .020) < 1e-9, "64-bit wrap");
         require(gpuTimestampMilliseconds(0, 2000000, 64, .5f) == 1., "nanoseconds to milliseconds");
@@ -69,6 +73,23 @@ int main()
         benchmark.tick(6., camera);
         require(benchmark.report().gpuAvailable && !benchmark.report().gpuPercentilesAvailable,
                 "short capture keeps average but suppresses percentiles");
+        benchmark.config().warmupSec = 2.f;
+        benchmark.requestStart();
+        benchmark.onWorldReady(glm::vec3(0.f));
+        benchmark.tick(1., camera);
+        require(benchmark.gpuCaptureTag() == 0, "warmup has no measurement tag");
+        sample.benchmarkTag = 0;
+        benchmark.sampleGpu(sample);
+        benchmark.tick(1.1, camera);
+        require(benchmark.gpuCaptureTag() != 0, "measurement tag after warmup");
+        benchmark.sampleGpu(sample); // Late result from warmup.
+        ++sample.serial;
+        sample.benchmarkTag = benchmark.gpuCaptureTag();
+        sample.ms[0] = 3.f;
+        benchmark.sampleGpu(sample);
+        benchmark.tick(6., camera);
+        require(benchmark.report().gpuSamples == 1 && benchmark.report().gpuAvgMs == 3.f,
+                "warmup samples excluded before and after measurement starts");
         std::cout << "PASS: GPU conversion and benchmark capture isolation\n";
         return 0;
     }

--- a/tests/test_vulkan_resources.cpp
+++ b/tests/test_vulkan_resources.cpp
@@ -8,6 +8,8 @@
 #include <Vulkan/VkLoadLibrary.hpp>
 #include <Vulkan/VkResourceSmoke.hpp>
 #include <Vulkan/VkSwapchain.hpp>
+#include <Vulkan/VkGpuProfiler.hpp>
+#include <Vulkan/VkCommands.hpp>
 
 #include <algorithm>
 #include <cstdio>
@@ -140,6 +142,48 @@ int main()
 					  << " disabling VSync instead of falling back\n";
 		}
 		swapchain.shutdown();
+
+		VkGpuProfiler gpu;
+		gpu.init(context, 2);
+		if (gpu.supported())
+		{
+			gpu.setEnabled(true);
+			ImmediateCommands commands;
+			commands.init(context);
+			const auto record = [&](uint32_t slot) {
+				commands.submitAndWait([&](VkCommandBuffer cmd) {
+					gpu.beginRecording(cmd, slot, 42);
+					gpu.beginPass(cmd, GpuPass::Shadow);
+					gpu.endPass(cmd, GpuPass::Shadow);
+					gpu.endRecording(cmd);
+				}); // Test fence; production reuses VkFrameContext's existing fence.
+				gpu.markSubmitted(slot);
+			};
+			for (uint32_t i = 0; i < 6; ++i)
+			{
+				record(i % 2);
+				gpu.onSlotReady(i % 2);
+				if (gpu.latest().serial != i + 1 || !gpu.latest().present[2] ||
+					gpu.latest().present[3] || gpu.latest().benchmarkTag != 42)
+					throw std::runtime_error("GPU slot recycling or absent-pass availability failed");
+			}
+			record(0);
+			gpu.syncCapture(1);
+			gpu.onSlotReady(0);
+			if (gpu.latest().serial || gpu.historyCount())
+				throw std::runtime_error("old GPU capture survived reset");
+			gpu.setEnabled(false);
+			record(1);
+			gpu.onSlotReady(1);
+			if (gpu.latest().serial) throw std::runtime_error("disabled GPU profiler collected samples");
+			gpu.setEnabled(true);
+			record(0);
+			gpu.onSlotReady(0);
+			if (!gpu.latest().serial) throw std::runtime_error("GPU profiler failed to resume");
+			std::cout << "PASS: GPU timestamp recycling, partial queries, reset and toggle\n";
+		}
+		else std::cout << "SKIP: GPU timestamps unsupported\n";
+		gpu.shutdown();
 
 		const std::string vert = resolveSpv("smoke.vert.spv");
 		const std::string frag = resolveSpv("smoke.frag.spv");

--- a/tests/test_vulkan_resources.cpp
+++ b/tests/test_vulkan_resources.cpp
@@ -144,7 +144,22 @@ int main()
 		swapchain.shutdown();
 
 		VkGpuProfiler gpu;
+		gpu.init(context, 0);
+		if (gpu.supported() || std::string(gpu.status()).find("no frame slots") == std::string::npos)
+			throw std::runtime_error("zero-slot profiler should be unavailable with a diagnostic");
+		gpu.shutdown();
 		gpu.init(context, 2);
+		uint32_t familyCount = 0;
+		vkGetPhysicalDeviceQueueFamilyProperties(context.getPhysicalDevice(), &familyCount, nullptr);
+		std::vector<VkQueueFamilyProperties> families(familyCount);
+		vkGetPhysicalDeviceQueueFamilyProperties(context.getPhysicalDevice(), &familyCount, families.data());
+		const auto &limits = context.getDeviceProperties().limits;
+		std::cout << "GPU timestamp capability:\n  graphics family: " << context.getGraphicsQueueFamily()
+			<< "\n  valid bits: " << families.at(context.getGraphicsQueueFamily()).timestampValidBits
+			<< "\n  period: " << limits.timestampPeriod << " ns"
+			<< "\n  timestampComputeAndGraphics: " << (limits.timestampComputeAndGraphics ? "true" : "false")
+			<< "\n  selected queue supported: " << (gpu.supported() ? "yes" : "no")
+			<< "\n  status: " << gpu.status() << '\n';
 		if (gpu.supported())
 		{
 			gpu.setEnabled(true);
@@ -180,6 +195,18 @@ int main()
 			record(0);
 			gpu.onSlotReady(0);
 			if (!gpu.latest().serial) throw std::runtime_error("GPU profiler failed to resume");
+			record(1); // Result completed but not yet consumed when capture is toggled.
+			gpu.setEnabled(false);
+			if (gpu.latest().serial || gpu.historyCount())
+				throw std::runtime_error("GPU toggle did not immediately clear displayed data");
+			gpu.setEnabled(true);
+			gpu.onSlotReady(1);
+			if (gpu.latest().serial || gpu.historyCount())
+				throw std::runtime_error("pending GPU sample survived OFF/ON");
+			record(0);
+			gpu.onSlotReady(0);
+			if (!gpu.latest().serial || gpu.historyCount() != 1)
+				throw std::runtime_error("fresh capture did not resume after OFF/ON");
 			std::cout << "PASS: GPU timestamp recycling, partial queries, reset and toggle\n";
 		}
 		else std::cout << "SKIP: GPU timestamps unsupported\n";


### PR DESCRIPTION
CPU scopes around Vulkan recording cannot attribute GPU work to render passes. This adds delayed GPU timestamp measurements while keeping CPU recording, worker, acquire and present timings separate.

Implementation:
- Own one query pool per frame-in-flight slot. Resolve results after its existing fence, before command-buffer reuse; reset queries in the next recording. No additional per-frame GPU wait and no VK_QUERY_RESULT_WAIT_BIT.
- Use the selected graphics queue family's timestampValidBits as the effective timestamp capability, with a finite positive timestampPeriod. timestampComputeAndGraphics is only a blanket guarantee and is not required. Invalid queue/slot configuration, unsupported timestamps and pool allocation failure have explicit unavailable diagnostics.
- Handle valid-bit masking and unsigned counter wrap, including 64 bits. Record GPU Frame, Uploads, Shadow, Opaque, Overlays, Water, Sky, Post and ImGui with availability checks for recorded passes.
- Show separate CPU/GPU sections and a 240-sample GPU history. The GPU toggle and FT_VOX_GPU_PROFILING=0 disable query work; clear/reset and toggles reject old pending results.
- Add benchmark GPU availability, sample counts, average frame/pass timings and p95/p99 for at least 100 samples. Tags exclude warmup and previous runs; serials deduplicate delayed results. Finalization does not wait for the last in-flight samples.
- Document that graphics-queue intervals include dependencies, can overlap and must not be summed; CPU Present remains CPU wall time.

GPU profiler correctness:
- Full Windows/MSVC Release build passes; CTest 11/11 in 41.16 s, including GpuProfile, VulkanResourceSmoke and ProfilerWorkerConsistency.
- Capability tests cover 36/40/48/56/64-bit queues without a global-flag input, invalid widths and invalid periods; 8/64-bit wrap coverage is retained.
- Device smoke covers two query pools, repeated reuse after a fence, partial queries, zero slots, reset, disable/resume and an unread old sample rejected across OFF/ON before exactly one fresh sample resumes history.
- Benchmark tests cover duplicate rejection, per-pass aggregation, percentiles, short/unavailable captures, two-second warmup transitions and successive-run isolation.
- Enabled seed-42, five-second benchmark at 1920x1080: 980 GPU samples, 0.923 ms mean; Shadow 0.049 ms, Opaque 0.096 ms, Post 0.278 ms, ImGui 0.010 ms. Disabled run completes and reports unavailable. Ten seconds with two seconds warmup records 1,997 GPU samples. These are functional checks, not overhead claims.
- git diff --check passes. Query lifecycle and read flags are unchanged by the capability correction.

Validation environment:
- No timestamp/query VUIDs. Full application validation is not clean, but a controlled clean-base comparison classifies the SRGB/STORAGE messages as preexisting.
- Base 098ceae278607d3330d1d9e9a797ec94d9a170a9 (no profiling code), corrected PR enabled, and corrected PR disabled each produce eight VUID-VkSwapchainCreateInfoKHR-imageFormat-01778 and six VUID-VkImageViewCreateInfo-usage-02275 occurrences, with no other VUIDs. Investigation is tracked separately in #99; the extra STORAGE usage's source is unresolved.
- All comparison runs use the same MSVC 19.50 Release build directory, RTX 4070 Ti / driver 616.56, SDK validation layer 1.3.290, resource pack, 1920x1080 viewport and IMMEDIATE mode.
- [Detailed report and full logs](https://github.com/gkehren/ft_vox/tree/feat/82-gpu-timestamp-profiler/docs/benchmarks/issue98-validation).

Validation not performed:
- Linux/macOS builds, a physical GPU with timestampComputeAndGraphics=false, resolution/shadow/overdraw sweeps and external RenderDoc/Nsight comparison.
- Manual F7 interaction and two complete Engine benchmarks in one process. The same profiler methods used by the UI and repeated Benchmark instances are exercised by deterministic tests.

Close #82
