### PR TITLE
fix(vulkan): diagnose RTSS swapchain injection and fail validation smokes

### DIFF
--- a/docs/benchmarks/issue99-validation/README.md
+++ b/docs/benchmarks/issue99-validation/README.md
@@ -1,0 +1,63 @@
+# Issue #99: RTSS interception and validation regression
+
+Windows / RTX 4070 Ti / NVIDIA 616.56 / Khronos validation 1.3.290,
+2026-09-04. RTSS executable version: 7.3.5.28314.
+
+## Root-cause evidence
+
+The earlier [PR #98 comparison](../issue98-validation/README.md) reproduces
+8 `VUID-VkSwapchainCreateInfoKHR-imageFormat-01778` and
+6 `VUID-VkImageViewCreateInfo-usage-02275` occurrences in each five-second
+benchmark on clean base and PR, with GPU profiling enabled or disabled.
+
+For #99, `VK_LOADER_DEBUG=layer` identified the active chain: AMD switchable
+graphics, NVIDIA Optimus/present, OBS, RTSS and Khronos validation. Repeating
+with `VK_LOADER_LAYERS_DISABLE=~implicit~` still produced the usage errors.
+The [first error's callback stack](rtss-stack.txt) contains RTSSHooks64.dll
+between test_vulkan_resources.exe and the validation DLL. The excerpt retains
+module names/offsets only. It was collected while investigating swapchain
+creation, not as a successful full resource test.
+
+After the user exited RTSS, the **same previously built game executable**
+(`b999bd881a02` plus the #98 review fix, build UTC 11:18:54) produced no VUIDs.
+See [enabled control](clean-enabled.txt) and [disabled control](clean-disabled.txt).
+These controls precede the new diagnostics build, so they establish that the
+fix is removing the RTSS hook, not changing rendering code. The new build was
+then checked separately below.
+
+All game runs use seed 42, five seconds, warmup zero, 1920×1080, IMMEDIATE,
+view distance 512 and the bundled resource pack. Validation stays enabled;
+neither SRGB format nor image usage was changed. The final diagnostics print
+`format=50 imageUsage=18` (B8G8R8A8_SRGB, COLOR_ATTACHMENT | TRANSFER_DST).
+
+RTSS application's automatic profile writes were denied by Windows. No global
+or application profile was changed. Stopping RTSS is sufficient for the tested
+control; durable per-application exclusion must still be configured before
+restarting it, as described in [the resolution guide](../../vulkan-validation.md).
+
+## Final branch checks
+
+| Check | Result |
+| --- | --- |
+| Windows/MSVC Release build | Passed |
+| [Full CTest](ctest.txt) | 12/12, 41.93 s |
+| [Final targeted Vulkan tests](ctest-vulkan.txt) | 2/2, 1.53 s |
+| [Profiler enabled](final-enabled.txt) | 2,425 GPU samples, mean 0.549 ms, zero VUIDs |
+| [Profiler disabled](final-disabled.txt) | GPU unavailable, zero VUIDs |
+| git diff --check | Passed |
+
+VulkanResourceSmoke now fails on any error-severity callback, including errors
+during device shutdown. Its final success message follows validation checking.
+VulkanValidationErrorReporting intentionally calls vkSubmitDebugUtilsMessageEXT
+with a diagnostic ERROR and expects a failing process; it issues no invalid
+Vulkan resource command. CTest inversion verifies the failure path instead of
+letting resource-operation success hide validation errors. It skips when the
+validation layer is unavailable.
+
+The new runtime hint only appears with a matching usage VUID and an RTSS hook
+loaded. Windows-only stack diagnostics are opt-in, once per process, and report
+module names rather than full filesystem paths. Normal error reporting is
+unchanged; no VUIDs are filtered out. Linux/macOS were not run locally.
+
+Loader warnings about Galaxy layer naming can remain without RTSS. They are
+not error-severity validation reports and do not invalidate the zero-VUID result.

--- a/docs/benchmarks/issue99-validation/clean-disabled.txt
+++ b/docs/benchmarks/issue99-validation/clean-disabled.txt
@@ -1,0 +1,65 @@
+[Vulkan] Layer name GalaxyOverlayVkLayer does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_VERBOSE does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_DEBUG does not conform to naming standard (Policy #LLP_LAYER_3)
+Vulkan device: NVIDIA GeForce RTX 4070 Ti
+Vulkan API: 1.4.351
+  validation=yes dynamicRendering=yes timelineSemaphores=yes portabilitySubset=no
+  VMA allocator: ready
+Swapchain present mode: FIFO (VSync on)
+Resource pack: ./ressources/default-resource-pack.zip
+Texture array: 101 layers (16x16)
+WorldRenderer ready (Shadow/Opaque/Water/Sky + post)
+ChunkPool: pre-allocated 8894 chunks
+SDL version: 3004012
+ft_vox: Vulkan — streaming procedural world
+  WASD fly · mouse look · LMB/RMB edit · T block · B borders
+  C free mouse · F1–F7 panels · F10 VSync · Esc quit
+  ThreadPool workers: 16
+Bootstrap: 25 chunks around spawn
+World seed: 42 chunks=25 view=512
+[stream] chunks=26 draw=9 shadow=25 q=3350/1/0
+Swapchain present mode: IMMEDIATE (VSync off, uncapped)
+Bootstrap: 25 chunks around spawn
+[bench] World reloaded seed=42 chunks=25
+[stream] chunks=527 draw=180 shadow=82 q=3004/1/2
+[stream] chunks=493 draw=150 shadow=65 q=3018/2/2
+[stream] chunks=490 draw=147 shadow=62 q=3027/2/2
+[stream] chunks=489 draw=150 shadow=69 q=3028/1/2
+[stream] chunks=494 draw=156 shadow=69 q=3019/1/2
+
+ft_vox Benchmark Report
+=======================
+Score: 9923 / 10000  Grade: S
+Revision: b999bd881a02* (dirty tree at build)
+  git b999bd881a02  branch feat/82-gpu-timestamp-profiler  describe b999bd8-dirty
+  build UTC 2026-09-04T11:18:54Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00098s  Frames: 2263
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 2.15664  min 0.8885  max 51.6451
+  p50 2.062  p95 2.5367  p99 4.5984
+  avg FPS 463.685  1% low FPS 217.467
+  frames >16.7ms: 5  >33.3ms: 1
+
+CPU scopes (avg ms)
+  Streaming 0.429986  Visibility 0.00479947
+  Acquire 0.130507  Record 1.40038  MeshUpload 0.0431291
+  ImGui 0.0425878  Present 0.0944457
+
+Worker jobs
+  TerrainGen  n=2561  avgMs=1.60775  totalMs=4117.46
+  MeshBuild   n=2362  avgMs=2.81905  totalMs=6658.59
+  MeshLOD     n=5  avgMs=0.0498  totalMs=0.249
+
+GPU timestamp queries: unavailable
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2561 avgMs=0.059834 totalMs=153.235
+  MeshQueue n=2368 avgMs=0.0600469 totalMs=142.191
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=529 draw=183 qLoad/Gen/Mesh=3302/12/10
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.
+Benchmark saved: docs/benchmarks/bench_20260904_113433_b999bd881a02__s42_sc9923.txt

--- a/docs/benchmarks/issue99-validation/clean-enabled.txt
+++ b/docs/benchmarks/issue99-validation/clean-enabled.txt
@@ -1,0 +1,76 @@
+[Vulkan] Layer name GalaxyOverlayVkLayer does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_VERBOSE does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_DEBUG does not conform to naming standard (Policy #LLP_LAYER_3)
+Vulkan device: NVIDIA GeForce RTX 4070 Ti
+Vulkan API: 1.4.351
+  validation=yes dynamicRendering=yes timelineSemaphores=yes portabilitySubset=no
+  VMA allocator: ready
+Swapchain present mode: FIFO (VSync on)
+Resource pack: ./ressources/default-resource-pack.zip
+Texture array: 101 layers (16x16)
+WorldRenderer ready (Shadow/Opaque/Water/Sky + post)
+ChunkPool: pre-allocated 8894 chunks
+SDL version: 3004012
+ft_vox: Vulkan — streaming procedural world
+  WASD fly · mouse look · LMB/RMB edit · T block · B borders
+  C free mouse · F1–F7 panels · F10 VSync · Esc quit
+  ThreadPool workers: 16
+Bootstrap: 25 chunks around spawn
+World seed: 42 chunks=25 view=512
+[stream] chunks=26 draw=9 shadow=25 q=3350/1/0
+Swapchain present mode: IMMEDIATE (VSync off, uncapped)
+Bootstrap: 25 chunks around spawn
+[bench] World reloaded seed=42 chunks=25
+[stream] chunks=539 draw=188 shadow=78 q=2989/1/2
+[stream] chunks=501 draw=161 shadow=65 q=3015/1/2
+[stream] chunks=488 draw=146 shadow=62 q=3026/2/2
+[stream] chunks=506 draw=161 shadow=79 q=3005/1/2
+[stream] chunks=508 draw=175 shadow=78 q=3010/1/2
+
+ft_vox Benchmark Report
+=======================
+Score: 9963 / 10000  Grade: S
+Revision: b999bd881a02* (dirty tree at build)
+  git b999bd881a02  branch feat/82-gpu-timestamp-profiler  describe b999bd8-dirty
+  build UTC 2026-09-04T11:18:54Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00198s  Frames: 2462
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 1.98191  min 0.9199  max 23.9457
+  p50 1.8797  p95 2.5778  p99 3.0985
+  avg FPS 504.565  1% low FPS 322.737
+  frames >16.7ms: 1  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.385026  Visibility 0.00428286
+  Acquire 0.085049  Record 1.34446  MeshUpload 0.0378674
+  ImGui 0.0393342  Present 0.0838615
+
+Worker jobs
+  TerrainGen  n=2645  avgMs=1.4165  totalMs=3746.63
+  MeshBuild   n=2515  avgMs=2.46271  totalMs=6193.72
+  MeshLOD     n=1  avgMs=0.027  totalMs=0.027
+
+GPU timestamp queries: available
+  samples=2461 avgMs=0.554026
+  p95Ms=0.70128 p99Ms=0.942272
+  Uploads avgMs=0.00778073
+  Shadow avgMs=0.0397814
+  Opaque avgMs=0.0759166
+  Overlays avgMs=7.3232e-05
+  Water avgMs=0.0386166
+  Sky avgMs=0.214286
+  Post avgMs=0.1723
+  ImGui avgMs=0.00513415
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2645 avgMs=0.0236635 totalMs=62.59
+  MeshQueue n=2517 avgMs=0.0200942 totalMs=50.577
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=546 draw=193 qLoad/Gen/Mesh=3305/10/9
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.
+Benchmark saved: docs/benchmarks/bench_20260904_113426_b999bd881a02__s42_sc9963.txt

--- a/docs/benchmarks/issue99-validation/ctest-vulkan.txt
+++ b/docs/benchmarks/issue99-validation/ctest-vulkan.txt
@@ -1,0 +1,9 @@
+Test project D:/Projects/ft_vox/build
+    Start 2: VulkanResourceSmoke
+1/2 Test #2: VulkanResourceSmoke ..............   Passed    0.82 sec
+    Start 3: VulkanValidationErrorReporting
+2/2 Test #3: VulkanValidationErrorReporting ...   Passed    0.70 sec
+
+100% tests passed out of 2
+
+Total Test time (real) =   1.53 sec

--- a/docs/benchmarks/issue99-validation/ctest.txt
+++ b/docs/benchmarks/issue99-validation/ctest.txt
@@ -1,0 +1,29 @@
+Test project D:/Projects/ft_vox/build
+      Start  1: NetworkIntegrationTest
+ 1/12 Test  #1: NetworkIntegrationTest ...........   Passed    1.20 sec
+      Start  2: VulkanResourceSmoke
+ 2/12 Test  #2: VulkanResourceSmoke ..............   Passed    0.80 sec
+      Start  3: VulkanValidationErrorReporting
+ 3/12 Test  #3: VulkanValidationErrorReporting ...   Passed    0.67 sec
+      Start  4: VisualLookDefaults
+ 4/12 Test  #4: VisualLookDefaults ...............   Passed    0.01 sec
+      Start  5: RenderHelpers
+ 5/12 Test  #5: RenderHelpers ....................   Passed    0.02 sec
+      Start  6: StreamOptHelpers
+ 6/12 Test  #6: StreamOptHelpers .................   Passed    0.02 sec
+      Start  7: TerrainGeneration
+ 7/12 Test  #7: TerrainGeneration ................   Passed   37.95 sec
+      Start  8: BiomeMapGeneration
+ 8/12 Test  #8: BiomeMapGeneration ...............   Passed    1.07 sec
+      Start  9: InputRouting
+ 9/12 Test  #9: InputRouting .....................   Passed    0.01 sec
+      Start 10: ChunkLifecycle
+10/12 Test #10: ChunkLifecycle ...................   Passed    0.05 sec
+      Start 11: ProfilerWorkerConsistency
+11/12 Test #11: ProfilerWorkerConsistency ........   Passed    0.08 sec
+      Start 12: GpuProfile
+12/12 Test #12: GpuProfile .......................   Passed    0.02 sec
+
+100% tests passed out of 12
+
+Total Test time (real) =  41.93 sec

--- a/docs/benchmarks/issue99-validation/final-disabled.txt
+++ b/docs/benchmarks/issue99-validation/final-disabled.txt
@@ -1,0 +1,67 @@
+[Vulkan] Layer name GalaxyOverlayVkLayer does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_VERBOSE does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_DEBUG does not conform to naming standard (Policy #LLP_LAYER_3)
+Vulkan device: NVIDIA GeForce RTX 4070 Ti
+Vulkan API: 1.4.351
+  validation=yes dynamicRendering=yes timelineSemaphores=yes portabilitySubset=no
+  VMA allocator: ready
+[Vulkan] Swapchain request before dispatch: format=50 imageUsage=18 (COLOR_ATTACHMENT | TRANSFER_DST)
+Swapchain present mode: FIFO (VSync on)
+Resource pack: ./ressources/default-resource-pack.zip
+Texture array: 101 layers (16x16)
+WorldRenderer ready (Shadow/Opaque/Water/Sky + post)
+ChunkPool: pre-allocated 8894 chunks
+SDL version: 3004012
+ft_vox: Vulkan — streaming procedural world
+  WASD fly · mouse look · LMB/RMB edit · T block · B borders
+  C free mouse · F1–F7 panels · F10 VSync · Esc quit
+  ThreadPool workers: 16
+Bootstrap: 25 chunks around spawn
+World seed: 42 chunks=25 view=512
+[stream] chunks=26 draw=9 shadow=25 q=3350/1/0
+[Vulkan] Swapchain request before dispatch: format=50 imageUsage=18 (COLOR_ATTACHMENT | TRANSFER_DST)
+Swapchain present mode: IMMEDIATE (VSync off, uncapped)
+Bootstrap: 25 chunks around spawn
+[bench] World reloaded seed=42 chunks=25
+[stream] chunks=544 draw=194 shadow=79 q=2997/1/2
+[stream] chunks=506 draw=164 shadow=69 q=3007/1/2
+[stream] chunks=490 draw=157 shadow=65 q=3026/2/2
+[stream] chunks=491 draw=154 shadow=67 q=3025/1/2
+[stream] chunks=492 draw=152 shadow=70 q=3022/1/2
+
+ft_vox Benchmark Report
+=======================
+Score: 9978 / 10000  Grade: S
+Revision: 4c88585f1862* (dirty tree at build)
+  git 4c88585f1862  branch fix/99-srgb-swapchain-validation  describe 4c88585-dirty
+  build UTC 2026-09-04T11:37:42Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00299s  Frames: 2439
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 1.99815  min 0.9763  max 24.0481
+  p50 1.9792  p95 2.4248  p99 2.7022
+  avg FPS 500.463  1% low FPS 370.069
+  frames >16.7ms: 1  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.402421  Visibility 0.00470529
+  Acquire 0.0814506  Record 1.37902  MeshUpload 0.0406625
+  ImGui 0.0419355  Present 0.0794248
+
+Worker jobs
+  TerrainGen  n=2608  avgMs=1.50415  totalMs=3922.83
+  MeshBuild   n=2484  avgMs=2.8402  totalMs=7055.05
+  MeshLOD     n=1  avgMs=0.031  totalMs=0.031
+
+GPU timestamp queries: unavailable
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2609 avgMs=0.0227244 totalMs=59.288
+  MeshQueue n=2486 avgMs=0.0215229 totalMs=53.506
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=546 draw=198 qLoad/Gen/Mesh=3302/24/10
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.
+Benchmark saved: docs/benchmarks/bench_20260904_113800_4c88585f1862__s42_sc9978.txt

--- a/docs/benchmarks/issue99-validation/final-enabled.txt
+++ b/docs/benchmarks/issue99-validation/final-enabled.txt
@@ -1,0 +1,78 @@
+[Vulkan] Layer name GalaxyOverlayVkLayer does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_VERBOSE does not conform to naming standard (Policy #LLP_LAYER_3)
+[Vulkan] Layer name GalaxyOverlayVkLayer_DEBUG does not conform to naming standard (Policy #LLP_LAYER_3)
+Vulkan device: NVIDIA GeForce RTX 4070 Ti
+Vulkan API: 1.4.351
+  validation=yes dynamicRendering=yes timelineSemaphores=yes portabilitySubset=no
+  VMA allocator: ready
+[Vulkan] Swapchain request before dispatch: format=50 imageUsage=18 (COLOR_ATTACHMENT | TRANSFER_DST)
+Swapchain present mode: FIFO (VSync on)
+Resource pack: ./ressources/default-resource-pack.zip
+Texture array: 101 layers (16x16)
+WorldRenderer ready (Shadow/Opaque/Water/Sky + post)
+ChunkPool: pre-allocated 8894 chunks
+SDL version: 3004012
+ft_vox: Vulkan — streaming procedural world
+  WASD fly · mouse look · LMB/RMB edit · T block · B borders
+  C free mouse · F1–F7 panels · F10 VSync · Esc quit
+  ThreadPool workers: 16
+Bootstrap: 25 chunks around spawn
+World seed: 42 chunks=25 view=512
+[stream] chunks=26 draw=9 shadow=25 q=3350/1/0
+[Vulkan] Swapchain request before dispatch: format=50 imageUsage=18 (COLOR_ATTACHMENT | TRANSFER_DST)
+Swapchain present mode: IMMEDIATE (VSync off, uncapped)
+Bootstrap: 25 chunks around spawn
+[bench] World reloaded seed=42 chunks=25
+[stream] chunks=533 draw=194 shadow=78 q=3004/1/2
+[stream] chunks=505 draw=166 shadow=68 q=3012/1/2
+[stream] chunks=488 draw=154 shadow=66 q=3026/1/1
+[stream] chunks=491 draw=152 shadow=66 q=3024/1/2
+[stream] chunks=487 draw=161 shadow=68 q=3024/1/2
+
+ft_vox Benchmark Report
+=======================
+Score: 9981 / 10000  Grade: S
+Revision: 4c88585f1862* (dirty tree at build)
+  git 4c88585f1862  branch fix/99-srgb-swapchain-validation  describe 4c88585-dirty
+  build UTC 2026-09-04T11:37:42Z
+Seed: 42  Duration: 5s  Warmup: 0s  Measured: 5.00099s  Frames: 2426
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 2.0116  min 0.9379  max 24.7497
+  p50 2.0257  p95 2.4136  p99 2.6706
+  avg FPS 497.118  1% low FPS 374.448
+  frames >16.7ms: 1  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.399164  Visibility 0.00454134
+  Acquire 0.0861963  Record 1.38707  MeshUpload 0.0393984
+  ImGui 0.0410144  Present 0.0844049
+
+Worker jobs
+  TerrainGen  n=2593  avgMs=1.50541  totalMs=3903.53
+  MeshBuild   n=2468  avgMs=2.85525  totalMs=7046.77
+  MeshLOD     n=0  avgMs=0  totalMs=0
+
+GPU timestamp queries: available
+  samples=2425 avgMs=0.549489
+  p95Ms=0.76896 p99Ms=0.906048
+  Uploads avgMs=0.00771646
+  Shadow avgMs=0.038142
+  Opaque avgMs=0.0739742
+  Overlays avgMs=9.20544e-05
+  Water avgMs=0.0385974
+  Sky avgMs=0.213386
+  Post avgMs=0.17274
+  ImGui avgMs=0.00470702
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=2593 avgMs=0.0181917 totalMs=47.171
+  MeshQueue n=2469 avgMs=0.0173503 totalMs=42.838
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=541 draw=198 qLoad/Gen/Mesh=3307/11/9
+
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.
+Benchmark saved: docs/benchmarks/bench_20260904_113753_4c88585f1862__s42_sc9981.txt

--- a/docs/benchmarks/issue99-validation/rtss-stack.txt
+++ b/docs/benchmarks/issue99-validation/rtss-stack.txt
@@ -1,0 +1,14 @@
+[Validation stack] test_vulkan_resources.exe + 23335
+[Validation stack] VkLayer_khronos_validation.dll + 8893565
+[Validation stack] VkLayer_khronos_validation.dll + 8900565
+[Validation stack] VkLayer_khronos_validation.dll + 3425925
+[Validation stack] VkLayer_khronos_validation.dll + 5095325
+[Validation stack] VkLayer_khronos_validation.dll + 5098964
+[Validation stack] VkLayer_khronos_validation.dll + 5666405
+[Validation stack] RTSSHooks64.dll + 523461
+[Validation stack] test_vulkan_resources.exe + 28908
+[Validation stack] test_vulkan_resources.exe + 29426
+[Validation stack] test_vulkan_resources.exe + 11115
+[Validation stack] test_vulkan_resources.exe + 120428
+[Validation stack] KERNEL32.DLL + 183479
+[Validation stack] ntdll.dll + 699756

--- a/docs/gpu-profiling.md
+++ b/docs/gpu-profiling.md
@@ -65,9 +65,11 @@ the corrected PR with profiling enabled and disabled:
 `VUID-VkSwapchainCreateInfoKHR-imageFormat-01778` and
 `VUID-VkImageViewCreateInfo-usage-02275` concerning STORAGE usage on SRGB
 swapchain images (8 and 6 occurrences respectively in each run).
-Full application validation is **not clean**, but this is preexisting rather
-than introduced by the timestamp profiler. The root cause remains unresolved
-and is tracked in [#99](https://github.com/gkehren/ft_vox/issues/99).
+That comparison was **not clean**, but this was preexisting rather than
+introduced by the timestamp profiler. Follow-up investigation in
+[#99](https://github.com/gkehren/ft_vox/issues/99) identified RTSSHooks64.dll
+interception; exiting RTSS removes both VUIDs. See
+[the RTSS exclusion procedure](vulkan-validation.md) for clean validation.
 See the [review validation report](benchmarks/issue98-validation/README.md)
 for full logs, environment, tests and limits of the comparison.
 

--- a/docs/vulkan-graphics.md
+++ b/docs/vulkan-graphics.md
@@ -327,6 +327,8 @@ Do not treat this section as “already shipped.” For historical feature discu
 
 ## 11. Related docs
 
+- [`vulkan-validation.md`](vulkan-validation.md) — RTSS SRGB/STORAGE diagnosis, per-app exclusion and validation error reporting
+
 - [`gpu-profiling.md`](gpu-profiling.md) — GPU timestamp lifecycle, UI, benchmark metrics and validation
 
 - [`engine-architecture.md`](engine-architecture.md) — Engine loop, chunks, streaming, terrain generation  

--- a/docs/vulkan-validation.md
+++ b/docs/vulkan-validation.md
@@ -1,0 +1,78 @@
+# Vulkan validation and injected overlays
+
+## SRGB/STORAGE errors from RTSS (issue #99)
+
+On the investigated Windows machine, RivaTuner Statistics Server (RTSS)
+7.3.5.28314 hooks Vulkan dispatch and adds STORAGE/TRANSFER_SRC usage to the
+swapchain creation request. The engine requests only COLOR_ATTACHMENT |
+TRANSFER_DST (decimal 18), with `VK_FORMAT_B8G8R8A8_SRGB`. That SRGB format does
+not support storage images on the tested GPU, so validation reports:
+
+- `VUID-VkSwapchainCreateInfoKHR-imageFormat-01778`
+- `VUID-VkImageViewCreateInfo-usage-02275`
+
+This is not a GPU timestamp issue. The errors reproduce on the pre-profiler
+base, with profiling enabled or disabled. A validation callback stack contains
+`test_vulkan_resources.exe → RTSSHooks64.dll → VkLayer_khronos_validation.dll`.
+Exiting RTSS removes both VUIDs with the same game binary, format, validation
+layer, resource pack and benchmark command. No format fallback or VUID filter
+is needed.
+
+`VK_LOADER_LAYERS_DISABLE=~implicit~` does **not** suffice: RTSSHooks64.dll can
+remain injected independently of `VK_LAYER_RTSS`. Hiding the OSD also does not
+necessarily disable injection. Other installed overlays were not identified
+as the cause in this experiment.
+
+## Durable local resolution
+
+In RTSS, add application profiles for **ft_vox.exe** and
+**test_vulkan_resources.exe**, set **Application detection level = None** for
+each, and restart those executables. This scopes the exclusion to this project;
+other applications can retain their overlays and limiter. RTSS's SDK names the
+corresponding property `AppDetectionLevel` (0 means None).
+
+Alternatively, exit RTSS while validating. If Windows denies saving its
+application profiles in Program Files, configure them from an RTSS instance
+with the necessary permissions. The engine does not modify global or per-app
+RTSS settings, stop RTSS, or unload injected modules automatically.
+
+On the development machine, automatic profile writes were denied, and the user
+exited RTSS for the control runs. **The permanent application exclusions still
+need to be saved before RTSS is restarted.** No RTSS configuration was changed.
+
+## Reproduce and diagnose
+
+Run from the repository root, with RTSS excluded or exited:
+
+```powershell
+$env:FT_VOX_VALIDATION = '1'
+$env:FT_VOX_GPU_PROFILING = '1'
+.\build\Release\ft_vox.exe --seed 42 --benchmark 5 --benchmark-warmup 0 --vsync off
+$env:FT_VOX_GPU_PROFILING = '0'
+.\build\Release\ft_vox.exe --seed 42 --benchmark 5 --benchmark-warmup 0 --vsync off
+ctest --test-dir build -C Release --output-on-failure
+```
+
+For investigation on Windows, `FT_VOX_TRACE_VALIDATION=1` additionally prints
+the actual swapchain request before dispatch and the module names/offsets of
+the first validation error's callback stack. It is diagnostic only, not a
+symbolized backtrace, and has no per-frame tracing cost when disabled. The
+normal error path emits a once-per-process RTSS remediation hint only when one
+of the two usage VUIDs occurs and an RTSS hook module is loaded. A loaded module
+alone is not taken as proof of an error.
+
+Validation messages remain visible. `VkContext::validationErrorCount()` counts
+error-severity callbacks, including initialization and shutdown; a new init
+resets the counter. VulkanResourceSmoke fails if any such error occurred, even
+when resource operations succeeded. Loader naming warnings do not count as
+validation errors.
+
+VulkanValidationErrorReporting deliberately submits a debug-utils ERROR message
+without invalid GPU work. CTest expects the executable to fail; this verifies
+that error reporting cannot silently pass. It skips when validation is
+unavailable. Do not mistake this clearly labelled synthetic diagnostic for a
+renderer VUID.
+
+See [the validation evidence](benchmarks/issue99-validation/README.md) for
+before/after results. Khronos documents the requested swapchain usage in
+[`VkSwapchainCreateInfoKHR`](https://docs.vulkan.org/refpages/latest/refpages/source/VkSwapchainCreateInfoKHR.html).

--- a/src/Vulkan/VkContext.cpp
+++ b/src/Vulkan/VkContext.cpp
@@ -6,6 +6,9 @@
 #include <cstring>
 #include <array>
 #include <cstdlib>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 namespace
 {
@@ -13,11 +16,45 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
 	VkDebugUtilsMessageSeverityFlagBitsEXT severity,
 	VkDebugUtilsMessageTypeFlagsEXT /*types*/,
 	const VkDebugUtilsMessengerCallbackDataEXT *callbackData,
-	void * /*userData*/)
+	void *userData)
 {
+	if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT && userData)
+		static_cast<std::atomic<uint64_t> *>(userData)->fetch_add(1, std::memory_order_relaxed);
 	if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
 	{
 		std::cerr << "[Vulkan] " << callbackData->pMessage << "\n";
+#ifdef _WIN32
+		const char *id = callbackData->pMessageIdName;
+		const bool swapchainUsageError = id &&
+			(std::strcmp(id, "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778") == 0 ||
+			 std::strcmp(id, "VUID-VkImageViewCreateInfo-usage-02275") == 0);
+		static std::atomic<bool> reportedRtss{false};
+		if (swapchainUsageError && (GetModuleHandleW(L"RTSSHooks64.dll") || GetModuleHandleW(L"RTSSHooks.dll")) &&
+			!reportedRtss.exchange(true))
+			std::cerr << "[Vulkan] RTSS hooks are loaded. They can add STORAGE usage to SRGB swapchain images "
+				"outside the Vulkan layer chain. Set Application detection level to None for this executable "
+				"in RivaTuner Statistics Server, then restart it. See docs/vulkan-validation.md.\n";
+		const char *trace = std::getenv("FT_VOX_TRACE_VALIDATION");
+		static std::atomic<bool> traced{false};
+		if (trace && std::strcmp(trace, "1") == 0 &&
+			severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT && !traced.exchange(true))
+		{
+			void *frames[32]{};
+			const auto n = CaptureStackBackTrace(0, 32, frames, nullptr);
+			for (USHORT i = 0; i < n; ++i)
+			{
+				HMODULE module = nullptr;
+				char path[MAX_PATH]{};
+				if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+					reinterpret_cast<LPCSTR>(frames[i]), &module))
+					GetModuleFileNameA(module, path, MAX_PATH);
+				path[MAX_PATH - 1] = '\0';
+				const char *name = std::strrchr(path, '\\');
+				std::cerr << "[Validation stack] " << (name ? name + 1 : path) << " + " <<
+					(reinterpret_cast<uintptr_t>(frames[i]) - reinterpret_cast<uintptr_t>(module)) << '\n';
+			}
+		}
+#endif
 	}
 	return VK_FALSE;
 }
@@ -74,6 +111,7 @@ void VkContext::waitIdle() const
 
 void VkContext::init(SDL_Window *window)
 {
+	m_validationErrors.store(0, std::memory_order_relaxed);
 	auto getProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(SDL_Vulkan_GetVkGetInstanceProcAddr());
 	if (!getProcAddr)
 		throw std::runtime_error("Failed to get vkGetInstanceProcAddr from SDL: " + std::string(SDL_GetError()));
@@ -254,6 +292,7 @@ void VkContext::createInstance(SDL_Window *window)
 			VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
 			VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
 		debugCreateInfo.pfnUserCallback = debugCallback;
+		debugCreateInfo.pUserData = &m_validationErrors;
 		createInfo.pNext = &debugCreateInfo;
 	}
 
@@ -302,6 +341,7 @@ void VkContext::setupDebugMessenger()
 		VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
 		VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
 	createInfo.pfnUserCallback = debugCallback;
+	createInfo.pUserData = &m_validationErrors;
 
 	if (vkCreateDebugUtilsMessengerEXT(m_instance, &createInfo, nullptr, &m_debugMessenger) != VK_SUCCESS)
 		throw std::runtime_error("Failed to set up Vulkan debug messenger");

--- a/src/Vulkan/VkContext.hpp
+++ b/src/Vulkan/VkContext.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <cstdint>
 #include <memory>
+#include <atomic>
 
 struct QueueFamilyIndices
 {
@@ -56,6 +57,8 @@ public:
 	bool hasTimelineSemaphores() const { return m_timelineSemaphores; }
 	bool hasPortabilitySubset() const { return m_portabilitySubset; }
 	bool isValidationEnabled() const { return m_validationEnabled; }
+	/// Includes initialization and shutdown; reset only by the next init().
+	uint64_t validationErrorCount() const { return m_validationErrors.load(std::memory_order_relaxed); }
 
 	const VkPhysicalDeviceProperties &getDeviceProperties() const { return m_deviceProperties; }
 
@@ -89,6 +92,7 @@ private:
 	VkPhysicalDeviceProperties m_deviceProperties{};
 
 	bool m_validationEnabled{false};
+	std::atomic<uint64_t> m_validationErrors{0};
 	bool m_dynamicRendering{false};
 	bool m_timelineSemaphores{false};
 	bool m_portabilitySubset{false};

--- a/src/Vulkan/VkSwapchain.cpp
+++ b/src/Vulkan/VkSwapchain.cpp
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <limits>
 #include <stdexcept>
+#include <cstdlib>
+#include <cstring>
 
 VkSwapchain::~VkSwapchain()
 {
@@ -190,6 +192,9 @@ void VkSwapchain::createSwapchain(uint32_t width, uint32_t height)
 	createInfo.presentMode = presentMode;
 	createInfo.clipped = VK_TRUE;
 	createInfo.oldSwapchain = VK_NULL_HANDLE;
+	if (const char *trace = std::getenv("FT_VOX_TRACE_VALIDATION"); trace && std::strcmp(trace, "1") == 0)
+		std::cerr << "[Vulkan] Swapchain request before dispatch: format=" << createInfo.imageFormat
+			<< " imageUsage=" << createInfo.imageUsage << " (COLOR_ATTACHMENT | TRANSFER_DST)\n";
 
 	if (vkCreateSwapchainKHR(m_context->getDevice(), &createInfo, nullptr, &m_swapchain) != VK_SUCCESS)
 		throw std::runtime_error("Failed to create swapchain");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,12 +77,17 @@ add_custom_command(TARGET test_vulkan_resources POST_BUILD
 )
 
 add_test(NAME VulkanResourceSmoke COMMAND test_vulkan_resources)
+add_test(NAME VulkanValidationErrorReporting COMMAND test_vulkan_resources --validation-error-probe)
+set_tests_properties(VulkanValidationErrorReporting PROPERTIES
+    WILL_FAIL TRUE
+    SKIP_RETURN_CODE 77
+)
+set_property(TEST VulkanValidationErrorReporting APPEND PROPERTY ENVIRONMENT "FT_VOX_VALIDATION=1")
 if(APPLE)
-    set_tests_properties(VulkanResourceSmoke PROPERTIES
-        ENVIRONMENT "VK_ICD_FILENAMES=/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json"
-    )
+    set_property(TEST VulkanResourceSmoke VulkanValidationErrorReporting APPEND PROPERTY
+        ENVIRONMENT "VK_ICD_FILENAMES=/opt/homebrew/etc/vulkan/icd.d/MoltenVK_icd.json")
 endif()
-set_tests_properties(VulkanResourceSmoke PROPERTIES
+set_tests_properties(VulkanResourceSmoke VulkanValidationErrorReporting PROPERTIES
     WORKING_DIRECTORY $<TARGET_FILE_DIR:test_vulkan_resources>
 )
 

--- a/tests/test_vulkan_resources.cpp
+++ b/tests/test_vulkan_resources.cpp
@@ -40,8 +40,9 @@ static std::string resolveSpv(const char *name)
 	return std::string("ressources/shaders/spv/") + name;
 }
 
-int main()
+int main(int argc, char **argv)
 {
+	const bool validationErrorProbe = argc == 2 && std::string(argv[1]) == "--validation-error-probe";
 	if (!SDL_Init(SDL_INIT_VIDEO))
 	{
 		std::cerr << "FAIL: SDL_Init: " << SDL_GetError() << "\n";
@@ -72,6 +73,15 @@ int main()
 	{
 		VkContext context;
 		context.init(window);
+		if (validationErrorProbe && !context.isValidationEnabled())
+		{
+			std::cout << "SKIP: validation error probe requires Khronos validation\n";
+			context.shutdown();
+			SDL_DestroyWindow(window);
+			SDL_Vulkan_UnloadLibrary();
+			SDL_Quit();
+			return 77;
+		}
 		if (!context.hasDynamicRendering() ||
 			((!vkCmdBeginRendering && !vkCmdBeginRenderingKHR) ||
 			 (!vkCmdEndRendering && !vkCmdEndRenderingKHR)))
@@ -218,11 +228,25 @@ int main()
 
 		if (runVulkanResourceSmoke(context, vert, frag))
 		{
-			std::cout << "ALL RESOURCE SMOKES PASSED\n";
+			std::cout << "RESOURCE OPERATIONS PASSED\n";
 			exitCode = EXIT_SUCCESS;
 		}
 
+		if (validationErrorProbe)
+		{
+			// Exercise the real debug messenger without issuing an invalid GPU command.
+			VkDebugUtilsMessengerCallbackDataEXT message{VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT};
+			message.pMessageIdName = "FT_VOX_TEST_VALIDATION_ERROR";
+			message.pMessage = "Intentional diagnostic error: the smoke must return failure.";
+			vkSubmitDebugUtilsMessageEXT(context.getInstance(), VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
+				VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT, &message);
+		}
 		context.shutdown();
+		if (context.validationErrorCount() != 0)
+			throw std::runtime_error("Vulkan validation reported " +
+				std::to_string(context.validationErrorCount()) + " error(s); resource success is not clean validation");
+		if (exitCode == EXIT_SUCCESS)
+			std::cout << "ALL RESOURCE SMOKES PASSED (no validation errors reported)\n";
 	}
 	catch (const std::exception &e)
 	{


### PR DESCRIPTION
SRGB swapchain validation errors came from RTSSHooks64.dll intercepting Vulkan dispatch and adding STORAGE/TRANSFER_SRC usage. Disabling implicit Vulkan layers did not remove this separate hook. The engine itself requests only COLOR_ATTACHMENT | TRANSFER_DST, and exiting RTSS eliminates both usage VUIDs without changing the game binary or the SRGB format.

Implementation:
- Emit a once-per-process remediation hint when an affected swapchain/image usage VUID occurs with an RTSS hook loaded. Direct users to per-application detection exclusions instead of suppressing errors or changing formats.
- Add opt-in FT_VOX_TRACE_VALIDATION=1 diagnostics: print swapchain format and usage before dispatch, and on Windows capture the first error's callback stack as module names and offsets without full filesystem paths.
- Count error-severity validation callbacks through VkContext, including initialization and shutdown. Retain the count until the next init and use an atomic counter for callbacks from multiple threads.
- Make VulkanResourceSmoke fail when validation errors occur even if its resource operations succeed. Emit final success only after checking the post-shutdown error count; preserve normal validation message output.
- Document RTSS per-application exclusions, independent hook injection, diagnostic commands, controlled before/after evidence and local limits. Update the GPU profiler documentation with the resolved root cause.

Tests and measurements:
- Add VulkanValidationErrorReporting: submit an intentional debug-utils ERROR without invalid GPU commands and require the smoke process to fail. CTest expects that failure and skips the probe if validation is unavailable.
- Capture RTSSHooks64.dll between the application and Khronos validation in the first swapchain error's callback stack, even with implicit layers disabled. RTSS executable version is 7.3.5.28314.
- After the user exits RTSS, repeat the five-second seed-42 benchmark with the previously built executable: zero VUIDs with GPU profiling enabled and disabled, retaining 1920x1080, IMMEDIATE and the bundled resource pack.
- Recheck the final branch build: zero VUIDs in both profiling modes; enabled run records 2,425 GPU samples averaging 0.549 ms. Diagnostics confirm format=50 and imageUsage=18 before each swapchain creation.
- Preserve complete control/final benchmark logs, CTest results and a module-only stack excerpt under docs/benchmarks/issue99-validation.

Validation:
- Windows/MSVC Release build passes; CTest passes 12/12 in 41.93 s.
- Final targeted Vulkan tests pass 2/2 in 1.53 s; git diff --check passes.
- No VUID filtering, SRGB fallback, injected-module unloading or automatic RTSS settings changes are introduced. Loader naming warnings may remain.
- Windows denied automatic RTSS profile writes. The user stopped RTSS for validation; permanent exclusions for ft_vox.exe and test_vulkan_resources.exe must still be saved before restarting RTSS.
- Linux/macOS were not tested locally. Short runtime measurements establish functionality and attribution, not an engine performance improvement.

Close #99