### PR TITLE
feat(chunk): decouple chunk metadata from lazily allocated voxel storage (#102)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ set(FT_VOX_SOURCES
     ${CMAKE_SOURCE_DIR}/src/Camera/Camera.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/Chunk.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/ChunkPool.cpp
+    ${CMAKE_SOURCE_DIR}/src/Chunk/VoxelPool.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/ChunkManager.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainGenerator.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainVegetation.cpp

--- a/docs/benchmarks/issue112-ab/README.md
+++ b/docs/benchmarks/issue112-ab/README.md
@@ -1,0 +1,32 @@
+# Interleaved A/B reference: base da00e51 vs PR 2b92493 (issue #102)
+
+Three interleaved 60s runs per side (15s warmup, seed 42, telemetry on,
+validation off, IMMEDIATE present), same binary pair.
+
+**Timing caveat (machine under external load):** the GPU and CPU were
+also being used by other programs while these runs were captured. The
+frame-time deltas below (avg/p95/p99, MeshBuild, TerrainGen) must NOT be
+read as reliable performance conclusions - the load is uncontrolled and
+not symmetric between runs. Re-run on an idle machine before drawing any
+timing conclusion.
+
+What stays valid under external load:
+
+- Memory metrics are structural counters, not timings: `voxel.bytes`
+  peak 555.88 -> 290.69 MiB (-47.7%), retained pool high-water
+  `voxel.pool.capacityBytes` ~290.7 MiB (4,651 blocks),
+  `voxel.pool.growEvents` 68-86 per measurement window.
+- Functional invariants: zero pool rejects, zero staging failures,
+  ownership counts balanced.
+
+| Metric (medians) | Base da00e51 | PR 2b92493 | Delta |
+| --- | ---: | ---: | ---: |
+| voxel.bytes peak | 555.88 MiB | 290.69 MiB | -47.7% (structural) |
+| voxel.pool.capacityBytes | n/a | 290.69 MiB | new |
+| voxel.pool.capacity / active peak | n/a | 4,651 blocks | new |
+| voxel.pool.growEvents | n/a | 68-86 | new |
+| Frame avg / p95 / p99 | 2.803 / 6.267 / 8.171 ms | 2.525 / 5.439 / 5.991 ms | unreliable (load) |
+| TerrainGen avg/job | 1.537 ms | 1.565 ms | +1.8% (unreliable) |
+| Streaming avg | 0.380 ms | 0.382 ms | +0.5% (unreliable) |
+| MeshBuild avg/job | 2.782 ms | 2.953 ms | +6.1% (unreliable) |
+| Pool rejects / staging failures | 0 / 0 | 0 / 0 | = |

--- a/docs/benchmarks/issue112-ab/README.md
+++ b/docs/benchmarks/issue112-ab/README.md
@@ -17,7 +17,11 @@ What stays valid under external load:
   `voxel.pool.capacityBytes` ~290.7 MiB (4,651 blocks),
   `voxel.pool.growEvents` 68-86 per measurement window.
 - Functional invariants: zero pool rejects, zero staging failures,
-  ownership counts balanced.
+  ownership counts balanced. VoxelPool balance holds on every PR run's
+  final sample: `voxel.pool.capacity == voxel.pool.active +
+  voxel.pool.free` (4647 = 4619 + 28, 4651 = 4619 + 32,
+  4652 = 4619 + 33). Peaks are intentionally not summed the same way -
+  the three peaks may have been reached on different frames.
 
 | Metric (medians) | Base da00e51 | PR 2b92493 | Delta |
 | --- | ---: | ---: | ---: |

--- a/docs/benchmarks/issue112-ab/base_run1.txt
+++ b/docs/benchmarks/issue112-ab/base_run1.txt
@@ -1,0 +1,95 @@
+ft_vox Benchmark Report
+=======================
+Score: 9795 / 10000  Grade: S
+Revision: da00e51046e9
+  git da00e51046e9  branch HEAD  describe da00e51
+  build UTC 2026-09-04T15:43:40Z
+Seed: 42  Duration: 60s  Warmup: 15s  Measured: 60.0035s  Frames: 19477
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 3.06958  min 0.6292  max 21.8707
+  p50 2.6381  p95 6.6998  p99 9.4601
+  avg FPS 325.777  1% low FPS 105.707
+  frames >16.7ms: 2  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.410713  Visibility 0.0742054
+  Acquire 2.13388  Record 0.400734  MeshUpload 0.0477853
+  ImGui 0.0447126  Present 0.0635917
+
+Worker jobs
+  TerrainGen  n=16884  avgMs=1.60686  totalMs=27130.2
+  MeshBuild   n=14759  avgMs=2.95201  totalMs=43568.7
+  MeshLOD     n=12832  avgMs=0.0406548  totalMs=521.683
+
+GPU timestamp queries: available
+  samples=19475 avgMs=2.6886
+  p95Ms=4.83738 p99Ms=5.33395
+  Uploads avgMs=0.00976816
+  Shadow avgMs=0.251103
+  Opaque avgMs=1.65581
+  Overlays avgMs=0.000205273
+  Water avgMs=0.113945
+  Sky avgMs=0.246092
+  Post avgMs=0.366685
+  ImGui avgMs=0.0448527
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=16884 avgMs=0.0120796 totalMs=203.952
+  MeshQueue n=27591 avgMs=0.0114944 totalMs=317.143
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=4630 draw=1309 qLoad/Gen/Mesh=5/6/6
+
+Memory / workload: enabled
+  Ownership bytes (not process RSS); current / peak at publication boundaries
+  voxel.bytes current=582877184 peak=582877184
+  shell.sizeBytes current=424229400 peak=461678616
+  shell.capacityBytes current=743467248 peak=743467248
+  cpu.opaque.vertex.sizeBytes current=46144 peak=1082144
+  cpu.opaque.vertex.capacityBytes current=1032132388 peak=1032132388
+  cpu.opaque.index.sizeBytes current=9888 peak=231888
+  cpu.opaque.index.capacityBytes current=221168656 peak=221168656
+  cpu.water.vertex.sizeBytes current=39872 peak=126112
+  cpu.water.vertex.capacityBytes current=76321280 peak=76321280
+  cpu.water.index.sizeBytes current=8544 peak=27024
+  cpu.water.index.capacityBytes current=16352224 peak=16352224
+  column.bytes current=36429824 peak=36429824
+  occupancy.bytes current=72859648 peak=72859648
+  gpu.opaque.vertex.bytes current=469491344 peak=485919728
+  gpu.opaque.index.bytes current=100605288 peak=104125656
+  gpu.water.vertex.bytes current=5428976 peak=7633472
+  gpu.water.index.bytes current=1163352 peak=1635744
+  gpu.retired.bytes current=1916376 peak=5827600
+  gpu.retired.buffers current=28 peak=112
+  pool.capacity current=8894 peak=8894
+  pool.acquired current=4620 peak=4655
+  pool.free current=4274 peak=4347
+  chunks.active current=4620 peak=4630
+  chunks.deferred current=0 peak=37
+  staging.slice.bytes current=34816 peak=1079808
+  cpu.mesh.capacityBytes current=1345974548 peak=1345974548
+  gpu.live.bytes current=576688960 peak=596909576
+  mesh.allocations.created total=77796 avgPerFrame=3.99425
+  mesh.allocations.destroyed total=76766 avgPerFrame=3.94137
+  pool.rejected total=0 avgPerFrame=0
+  upload.chunks total=26263 avgPerFrame=1.34841
+  upload.vertexBytes total=2114999264 avgPerFrame=108590
+  upload.indexBytes total=453214128 avgPerFrame=23269.2
+  upload.deferred total=0 avgPerFrame=0
+  staging.failures total=0 avgPerFrame=0
+  draws.opaque total=24008606 avgPerFrame=1232.66
+  draws.water total=15295084 avgPerFrame=785.29
+  draws.shadow.0 total=2734630 avgPerFrame=140.403
+  draws.shadow.1 total=4477370 avgPerFrame=229.88
+  draws.shadow.2 total=5326178 avgPerFrame=273.46
+  draws.shadow.total=12538178 avgPerFrame=643.743
+  mesh.skylight n=14759 totalMs=15984.9
+  mesh.blocklight n=14759 totalMs=3267.82
+  mesh.occupancy n=14759 totalMs=617.578
+  mesh.facesGreedyAO n=14759 totalMs=23686.7
+  mesh.LOD n=12832 totalMs=513.706
+  mesh.maskCells=2374461696 aoVertices=63748492 opaqueVertices=73455592 opaqueIndices=110183388 waterVertices=3432868 waterIndices=5149302
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue112-ab/base_run2.txt
+++ b/docs/benchmarks/issue112-ab/base_run2.txt
@@ -1,0 +1,95 @@
+ft_vox Benchmark Report
+=======================
+Score: 9847 / 10000  Grade: S
+Revision: da00e51046e9
+  git da00e51046e9  branch HEAD  describe da00e51
+  build UTC 2026-09-04T15:43:40Z
+Seed: 42  Duration: 60s  Warmup: 15s  Measured: 60.0011s  Frames: 25359
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 2.35634  min 0.5924  max 16.5425
+  p50 1.4177  p95 5.8694  p99 6.502
+  avg FPS 424.386  1% low FPS 153.799
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.352152  Visibility 0.0644909
+  Acquire 1.52691  Record 0.364928  MeshUpload 0.0382014
+  ImGui 0.0409128  Present 0.0578492
+
+Worker jobs
+  TerrainGen  n=16889  avgMs=1.50953  totalMs=25494.4
+  MeshBuild   n=14763  avgMs=2.75927  totalMs=40735.1
+  MeshLOD     n=15283  avgMs=0.035996  totalMs=550.127
+
+GPU timestamp queries: available
+  samples=25357 avgMs=2.09247
+  p95Ms=3.84099 p99Ms=4.28157
+  Uploads avgMs=0.00684917
+  Shadow avgMs=0.25186
+  Opaque avgMs=1.20655
+  Overlays avgMs=5.14887e-05
+  Water avgMs=0.0904828
+  Sky avgMs=0.256931
+  Post avgMs=0.264453
+  ImGui avgMs=0.0151488
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=16889 avgMs=0.0107873 totalMs=182.186
+  MeshQueue n=30046 avgMs=0.010407 totalMs=312.689
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=4630 draw=1567 qLoad/Gen/Mesh=5/5/5
+
+Memory / workload: enabled
+  Ownership bytes (not process RSS); current / peak at publication boundaries
+  voxel.bytes current=582877184 peak=582877184
+  shell.sizeBytes current=355349592 peak=461595024
+  shell.capacityBytes current=743467248 peak=743467248
+  cpu.opaque.vertex.sizeBytes current=57008 peak=1127168
+  cpu.opaque.vertex.capacityBytes current=1030281868 peak=1030281868
+  cpu.opaque.index.sizeBytes current=12216 peak=241536
+  cpu.opaque.index.capacityBytes current=220771996 peak=220771996
+  cpu.water.vertex.sizeBytes current=336 peak=124768
+  cpu.water.vertex.capacityBytes current=81278764 peak=81278764
+  cpu.water.index.sizeBytes current=72 peak=26736
+  cpu.water.index.capacityBytes current=17414608 peak=17414608
+  column.bytes current=36429824 peak=36429824
+  occupancy.bytes current=72859648 peak=72859648
+  gpu.opaque.vertex.bytes current=489959568 peak=493185952
+  gpu.opaque.index.bytes current=104991336 peak=105682704
+  gpu.water.vertex.bytes current=8623776 peak=12797792
+  gpu.water.index.bytes current=1847952 peak=2742384
+  gpu.retired.bytes current=0 peak=4424352
+  gpu.retired.buffers current=0 peak=82
+  pool.capacity current=8894 peak=8894
+  pool.acquired current=4620 peak=4648
+  pool.free current=4274 peak=4350
+  chunks.active current=4620 peak=4630
+  chunks.deferred current=0 peak=28
+  staging.slice.bytes current=35328 peak=1079808
+  cpu.mesh.capacityBytes current=1349747236 peak=1349747236
+  gpu.live.bytes current=605422632 peak=609328688
+  mesh.allocations.created total=85896 avgPerFrame=3.3872
+  mesh.allocations.destroyed total=82766 avgPerFrame=3.26377
+  pool.rejected total=0 avgPerFrame=0
+  upload.chunks total=29433 avgPerFrame=1.16065
+  upload.vertexBytes total=2205232288 avgPerFrame=86960.5
+  upload.indexBytes total=472549776 avgPerFrame=18634.4
+  upload.deferred total=0 avgPerFrame=0
+  staging.failures total=0 avgPerFrame=0
+  draws.opaque total=33288052 avgPerFrame=1312.67
+  draws.water total=20633380 avgPerFrame=813.651
+  draws.shadow.0 total=3591330 avgPerFrame=141.62
+  draws.shadow.1 total=5894677 avgPerFrame=232.449
+  draws.shadow.2 total=7013680 avgPerFrame=276.576
+  draws.shadow.total=16499687 avgPerFrame=650.644
+  mesh.skylight n=14763 totalMs=14713.3
+  mesh.blocklight n=14763 totalMs=2972.29
+  mesh.occupancy n=14763 totalMs=561.373
+  mesh.facesGreedyAO n=14763 totalMs=22478
+  mesh.LOD n=15283 totalMs=542.054
+  mesh.maskCells=2375109376 aoVertices=63735484 opaqueVertices=75472112 opaqueIndices=113208168 waterVertices=3913164 waterIndices=5869746
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue112-ab/base_run3.txt
+++ b/docs/benchmarks/issue112-ab/base_run3.txt
@@ -1,0 +1,95 @@
+ft_vox Benchmark Report
+=======================
+Score: 9802 / 10000  Grade: S
+Revision: da00e51046e9
+  git da00e51046e9  branch HEAD  describe da00e51
+  build UTC 2026-09-04T15:43:40Z
+Seed: 42  Duration: 60s  Warmup: 15s  Measured: 60.0004s  Frames: 21327
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 2.80296  min 0.5736  max 18.5595
+  p50 1.5649  p95 6.267  p99 8.1715
+  avg FPS 356.766  1% low FPS 122.377
+  frames >16.7ms: 4  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.37976  Visibility 0.0686736
+  Acquire 1.94764  Record 0.361649  MeshUpload 0.0422929
+  ImGui 0.0407667  Present 0.0583184
+
+Worker jobs
+  TerrainGen  n=16889  avgMs=1.53742  totalMs=25965.5
+  MeshBuild   n=14768  avgMs=2.78192  totalMs=41083.4
+  MeshLOD     n=13911  avgMs=0.038008  totalMs=528.729
+
+GPU timestamp queries: available
+  samples=21325 avgMs=2.44916
+  p95Ms=4.54493 p99Ms=5.02214
+  Uploads avgMs=0.0104781
+  Shadow avgMs=0.243438
+  Opaque avgMs=1.47818
+  Overlays avgMs=0.000270202
+  Water avgMs=0.114095
+  Sky avgMs=0.242663
+  Post avgMs=0.330998
+  ImGui avgMs=0.0289031
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=16892 avgMs=0.01154 totalMs=194.933
+  MeshQueue n=28679 avgMs=0.0106586 totalMs=305.679
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=4630 draw=1538 qLoad/Gen/Mesh=5/7/7
+
+Memory / workload: enabled
+  Ownership bytes (not process RSS); current / peak at publication boundaries
+  voxel.bytes current=582877184 peak=582877184
+  shell.sizeBytes current=363123648 peak=462347352
+  shell.capacityBytes current=743467248 peak=743467248
+  cpu.opaque.vertex.sizeBytes current=57344 peak=1555008
+  cpu.opaque.vertex.capacityBytes current=1036420392 peak=1036420392
+  cpu.opaque.index.sizeBytes current=12288 peak=333216
+  cpu.opaque.index.capacityBytes current=222087500 peak=222087500
+  cpu.water.vertex.sizeBytes current=0 peak=124768
+  cpu.water.vertex.capacityBytes current=78077440 peak=78077440
+  cpu.water.index.sizeBytes current=0 peak=26736
+  cpu.water.index.capacityBytes current=16728512 peak=16728512
+  column.bytes current=36429824 peak=36429824
+  occupancy.bytes current=72859648 peak=72859648
+  gpu.opaque.vertex.bytes current=487379200 peak=489607104
+  gpu.opaque.index.bytes current=104438400 peak=104915808
+  gpu.water.vertex.bytes current=8557248 peak=8610560
+  gpu.water.index.bytes current=1833696 peak=1845120
+  gpu.retired.bytes current=2020824 peak=6363576
+  gpu.retired.buffers current=34 peak=114
+  pool.capacity current=8894 peak=8894
+  pool.acquired current=4620 peak=4653
+  pool.free current=4274 peak=4349
+  chunks.active current=4620 peak=4630
+  chunks.deferred current=0 peak=39
+  staging.slice.bytes current=680960 peak=1228544
+  cpu.mesh.capacityBytes current=1353313844 peak=1353313844
+  gpu.live.bytes current=602208544 peak=604958464
+  mesh.allocations.created total=81108 avgPerFrame=3.80307
+  mesh.allocations.destroyed total=78188 avgPerFrame=3.66615
+  pool.rejected total=0 avgPerFrame=0
+  upload.chunks total=27529 avgPerFrame=1.29081
+  upload.vertexBytes total=2151708832 avgPerFrame=100891
+  upload.indexBytes total=461080464 avgPerFrame=21619.6
+  upload.deferred total=0 avgPerFrame=0
+  staging.failures total=0 avgPerFrame=0
+  draws.opaque total=26584923 avgPerFrame=1246.54
+  draws.water total=16763386 avgPerFrame=786.017
+  draws.shadow.0 total=3004758 avgPerFrame=140.89
+  draws.shadow.1 total=4927640 avgPerFrame=231.052
+  draws.shadow.2 total=5884765 avgPerFrame=275.93
+  draws.shadow.total=13817163 avgPerFrame=647.872
+  mesh.skylight n=14768 totalMs=15193.8
+  mesh.blocklight n=14768 totalMs=3081.39
+  mesh.occupancy n=14768 totalMs=577.88
+  mesh.facesGreedyAO n=14768 totalMs=22219.6
+  mesh.LOD n=13911 totalMs=521.329
+  mesh.maskCells=2375905536 aoVertices=63779480 opaqueVertices=74392980 opaqueIndices=111589470 waterVertices=3631364 waterIndices=5447046
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue112-ab/pr_run1.txt
+++ b/docs/benchmarks/issue112-ab/pr_run1.txt
@@ -1,0 +1,100 @@
+ft_vox Benchmark Report
+=======================
+Score: 9867 / 10000  Grade: S
+Revision: 2b924932cbd5
+  git 2b924932cbd5  branch issue-102-decouple-chunk-voxel-storage  describe 2b92493
+  build UTC 2026-09-04T15:41:22Z
+Seed: 42  Duration: 60s  Warmup: 15s  Measured: 60.0013s  Frames: 31259
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 1.91029  min 0.5428  max 12.281
+  p50 1.4232  p95 3.9493  p99 5.8428
+  avg FPS 523.48  1% low FPS 171.151
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.308295  Visibility 0.0570639
+  Acquire 1.14081  Record 0.352884  MeshUpload 0.0300987
+  ImGui 0.0391517  Present 0.0569523
+
+Worker jobs
+  TerrainGen  n=16887  avgMs=1.40252  totalMs=23684.3
+  MeshBuild   n=14758  avgMs=2.56044  totalMs=37787
+  MeshLOD     n=16778  avgMs=0.0398691  totalMs=668.923
+
+GPU timestamp queries: available
+  samples=31257 avgMs=1.64934
+  p95Ms=2.8759 p99Ms=3.77453
+  Uploads avgMs=0.00513162
+  Shadow avgMs=0.190465
+  Opaque avgMs=0.929953
+  Overlays avgMs=6.86991e-05
+  Water avgMs=0.0841912
+  Sky avgMs=0.209428
+  Post avgMs=0.220239
+  ImGui avgMs=0.00972117
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=16887 avgMs=0.0105642 totalMs=178.398
+  MeshQueue n=31536 avgMs=0.0103585 totalMs=326.666
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=4630 draw=1569 qLoad/Gen/Mesh=5/5/5
+
+Memory / workload: enabled
+  Ownership bytes (not process RSS); current / peak at publication boundaries
+  voxel.bytes current=302710784 peak=304545792
+  shell.sizeBytes current=355433184 peak=460341144
+  shell.capacityBytes current=743467248 peak=743467248
+  cpu.opaque.vertex.sizeBytes current=49280 peak=1010688
+  cpu.opaque.vertex.capacityBytes current=1036599816 peak=1036599816
+  cpu.opaque.index.sizeBytes current=10560 peak=216576
+  cpu.opaque.index.capacityBytes current=222125992 peak=222125992
+  cpu.water.vertex.sizeBytes current=8064 peak=125664
+  cpu.water.vertex.capacityBytes current=84444920 peak=84444920
+  cpu.water.index.sizeBytes current=1728 peak=26928
+  cpu.water.index.capacityBytes current=18093184 peak=18093184
+  column.bytes current=36429824 peak=36429824
+  occupancy.bytes current=72859648 peak=72859648
+  gpu.opaque.vertex.bytes current=489935152 peak=506018912
+  gpu.opaque.index.bytes current=104986104 peak=108432624
+  gpu.water.vertex.bytes current=8615824 peak=13264832
+  gpu.water.index.bytes current=1846248 peak=2842464
+  gpu.retired.bytes current=0 peak=5902944
+  gpu.retired.buffers current=0 peak=106
+  pool.capacity current=8894 peak=8894
+  pool.acquired current=4619 peak=4647
+  pool.free current=4275 peak=4346
+  chunks.active current=4619 peak=4630
+  chunks.deferred current=0 peak=36
+  staging.slice.bytes current=34816 peak=854784
+  cpu.mesh.capacityBytes current=1361263912 peak=1361263912
+  gpu.live.bytes current=605383328 peak=628328432
+  voxel.pool.capacity current=4647 peak=4647
+  voxel.pool.active current=4619 peak=4647
+  voxel.pool.free current=28 peak=39
+  voxel.pool.capacityBytes current=304545792 peak=304545792
+  mesh.allocations.created total=90382 avgPerFrame=2.89139
+  mesh.allocations.destroyed total=87318 avgPerFrame=2.79337
+  pool.rejected total=0 avgPerFrame=0
+  upload.chunks total=31234 avgPerFrame=0.9992
+  upload.vertexBytes total=2256092944 avgPerFrame=72174.2
+  upload.indexBytes total=483448488 avgPerFrame=15465.9
+  upload.deferred total=0 avgPerFrame=0
+  staging.failures total=0 avgPerFrame=0
+  draws.opaque total=45230805 avgPerFrame=1446.97
+  draws.water total=26664076 avgPerFrame=853.005
+  draws.shadow.0 total=4391837 avgPerFrame=140.498
+  draws.shadow.1 total=7191768 avgPerFrame=230.07
+  draws.shadow.2 total=8566499 avgPerFrame=274.049
+  voxel.pool.growEvents total=68 avgPerFrame=0.00217537
+  draws.shadow.total=20150104 avgPerFrame=644.618
+  mesh.skylight n=14758 totalMs=13513.9
+  mesh.blocklight n=14758 totalMs=2972.5
+  mesh.occupancy n=14758 totalMs=401.73
+  mesh.facesGreedyAO n=14758 totalMs=20888.8
+  mesh.LOD n=16778 totalMs=660.853
+  mesh.maskCells=2374307328 aoVertices=63702592 opaqueVertices=76687276 opaqueIndices=115030914 waterVertices=4195988 waterIndices=6293982
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue112-ab/pr_run2.txt
+++ b/docs/benchmarks/issue112-ab/pr_run2.txt
@@ -1,0 +1,100 @@
+ft_vox Benchmark Report
+=======================
+Score: 9874 / 10000  Grade: S
+Revision: 2b924932cbd5
+  git 2b924932cbd5  branch issue-102-decouple-chunk-voxel-storage  describe 2b92493
+  build UTC 2026-09-04T15:41:22Z
+Seed: 42  Duration: 60s  Warmup: 15s  Measured: 60.0002s  Frames: 23659
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 2.52504  min 0.582  max 15.8371
+  p50 1.7802  p95 5.4391  p99 5.9913
+  avg FPS 396.034  1% low FPS 166.909
+  frames >16.7ms: 0  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.397075  Visibility 0.0720513
+  Acquire 1.62605  Record 0.38129  MeshUpload 0.0423113
+  ImGui 0.0433825  Present 0.0620923
+
+Worker jobs
+  TerrainGen  n=16882  avgMs=1.58572  totalMs=26770.1
+  MeshBuild   n=14751  avgMs=3.00056  totalMs=44261.2
+  MeshLOD     n=14956  avgMs=0.0515427  totalMs=770.873
+
+GPU timestamp queries: available
+  samples=23657 avgMs=2.25271
+  p95Ms=3.6479 p99Ms=3.96166
+  Uploads avgMs=0.00775547
+  Shadow avgMs=0.232404
+  Opaque avgMs=1.35131
+  Overlays avgMs=6.01233e-05
+  Water avgMs=0.10458
+  Sky avgMs=0.229919
+  Post avgMs=0.298408
+  ImGui avgMs=0.0280672
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=16882 avgMs=0.0112602 totalMs=190.095
+  MeshQueue n=29707 avgMs=0.0114636 totalMs=340.548
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=4630 draw=1329 qLoad/Gen/Mesh=5/7/6
+
+Memory / workload: enabled
+  Ownership bytes (not process RSS); current / peak at publication boundaries
+  voxel.bytes current=302710784 peak=304807936
+  shell.sizeBytes current=409099248 peak=460257552
+  shell.capacityBytes current=743467248 peak=743467248
+  cpu.opaque.vertex.sizeBytes current=0 peak=1031296
+  cpu.opaque.vertex.capacityBytes current=1034428696 peak=1034428696
+  cpu.opaque.index.sizeBytes current=0 peak=220992
+  cpu.opaque.index.capacityBytes current=221660724 peak=221660724
+  cpu.water.vertex.sizeBytes current=28672 peak=122976
+  cpu.water.vertex.capacityBytes current=81504640 peak=81504640
+  cpu.water.index.sizeBytes current=6144 peak=26352
+  cpu.water.index.capacityBytes current=17463144 peak=17463144
+  column.bytes current=36429824 peak=36429824
+  occupancy.bytes current=72859648 peak=72859648
+  gpu.opaque.vertex.bytes current=473472608 peak=487301808
+  gpu.opaque.index.bytes current=101458416 peak=104421816
+  gpu.water.vertex.bytes current=6504848 peak=7334768
+  gpu.water.index.bytes current=1393896 peak=1571736
+  gpu.retired.bytes current=1571072 peak=4127736
+  gpu.retired.buffers current=26 peak=102
+  pool.capacity current=8894 peak=8894
+  pool.acquired current=4619 peak=4651
+  pool.free current=4275 peak=4344
+  chunks.active current=4619 peak=4630
+  chunks.deferred current=0 peak=30
+  staging.slice.bytes current=277248 peak=1044992
+  cpu.mesh.capacityBytes current=1355057204 peak=1355057204
+  gpu.live.bytes current=582829768 peak=599229736
+  voxel.pool.capacity current=4651 peak=4651
+  voxel.pool.active current=4619 peak=4651
+  voxel.pool.free current=32 peak=41
+  voxel.pool.capacityBytes current=304807936 peak=304807936
+  mesh.allocations.created total=85804 avgPerFrame=3.6267
+  mesh.allocations.destroyed total=84374 avgPerFrame=3.56625
+  pool.rejected total=0 avgPerFrame=0
+  upload.chunks total=29412 avgPerFrame=1.24316
+  upload.vertexBytes total=2203245968 avgPerFrame=93125.1
+  upload.indexBytes total=472124136 avgPerFrame=19955.4
+  upload.deferred total=0 avgPerFrame=0
+  staging.failures total=0 avgPerFrame=0
+  draws.opaque total=29463353 avgPerFrame=1245.33
+  draws.water total=18693465 avgPerFrame=790.121
+  draws.shadow.0 total=3346956 avgPerFrame=141.467
+  draws.shadow.1 total=5494626 avgPerFrame=232.243
+  draws.shadow.2 total=6533388 avgPerFrame=276.148
+  voxel.pool.growEvents total=81 avgPerFrame=0.00342364
+  draws.shadow.total=15374970 avgPerFrame=649.857
+  mesh.skylight n=14751 totalMs=16220.5
+  mesh.blocklight n=14751 totalMs=3509.8
+  mesh.occupancy n=14751 totalMs=451.83
+  mesh.facesGreedyAO n=14751 totalMs=24069.1
+  mesh.LOD n=14956 totalMs=762.362
+  mesh.maskCells=2373181440 aoVertices=63673760 opaqueVertices=75116064 opaqueIndices=112674096 waterVertices=3872640 waterIndices=5808960
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/benchmarks/issue112-ab/pr_run3.txt
+++ b/docs/benchmarks/issue112-ab/pr_run3.txt
@@ -1,0 +1,100 @@
+ft_vox Benchmark Report
+=======================
+Score: 9823 / 10000  Grade: S
+Revision: 2b924932cbd5
+  git 2b924932cbd5  branch issue-102-decouple-chunk-voxel-storage  describe 2b92493
+  build UTC 2026-09-04T15:41:22Z
+Seed: 42  Duration: 60s  Warmup: 15s  Measured: 60s  Frames: 22045
+Device: NVIDIA GeForce RTX 4070 Ti
+Viewport: 1920x1080  ViewDist: 512  VSync: off  PresentMode: IMMEDIATE
+
+Frame times (ms)
+  avg 2.71099  min 0.5874  max 23.5547
+  p50 1.7927  p95 6.3475  p99 7.6986
+  avg FPS 368.868  1% low FPS 129.894
+  frames >16.7ms: 3  >33.3ms: 0
+
+CPU scopes (avg ms)
+  Streaming 0.381672  Visibility 0.0704176
+  Acquire 1.84153  Record 0.369434  MeshUpload 0.0407501
+  ImGui 0.0425617  Present 0.0598987
+
+Worker jobs
+  TerrainGen  n=16879  avgMs=1.56514  totalMs=26417.9
+  MeshBuild   n=14746  avgMs=2.95263  totalMs=43539.5
+  MeshLOD     n=14182  avgMs=0.049569  totalMs=702.987
+
+GPU timestamp queries: available
+  samples=22043 avgMs=2.44688
+  p95Ms=3.99862 p99Ms=4.5783
+  Uploads avgMs=0.0087986
+  Shadow avgMs=0.269035
+  Opaque avgMs=1.45837
+  Overlays avgMs=0.00018921
+  Water avgMs=0.11196
+  Sky avgMs=0.277495
+  Post avgMs=0.300154
+  ImGui avgMs=0.0207271
+  Delayed graphics-queue intervals; overlapping passes are not additive.
+Biome map: zoom=0 mode=scheduled (fixed center when enabled)
+  TerrainQueue n=16879 avgMs=0.0126926 totalMs=214.238
+  MeshQueue n=28928 avgMs=0.0118725 totalMs=343.448
+  BiomeMap n=0 avgMs=0 totalMs=0
+Peaks: chunks=4630 draw=1376 qLoad/Gen/Mesh=5/9/6
+
+Memory / workload: enabled
+  Ownership bytes (not process RSS); current / peak at publication boundaries
+  voxel.bytes current=302710784 peak=304873472
+  shell.sizeBytes current=423560664 peak=459923184
+  shell.capacityBytes current=743467248 peak=743467248
+  cpu.opaque.vertex.sizeBytes current=28672 peak=1394736
+  cpu.opaque.vertex.capacityBytes current=1034615428 peak=1034615428
+  cpu.opaque.index.sizeBytes current=6144 peak=298872
+  cpu.opaque.index.capacityBytes current=221700756 peak=221700756
+  cpu.water.vertex.sizeBytes current=28672 peak=139888
+  cpu.water.vertex.capacityBytes current=82008164 peak=82008164
+  cpu.water.index.sizeBytes current=6144 peak=29976
+  cpu.water.index.capacityBytes current=17571020 peak=17571020
+  column.bytes current=36429824 peak=36429824
+  occupancy.bytes current=72859648 peak=72859648
+  gpu.opaque.vertex.bytes current=469563920 peak=491760080
+  gpu.opaque.index.bytes current=100620840 peak=105377160
+  gpu.water.vertex.bytes current=5478704 peak=11396336
+  gpu.water.index.bytes current=1174008 peak=2442072
+  gpu.retired.bytes current=104448 peak=4374984
+  gpu.retired.buffers current=6 peak=100
+  pool.capacity current=8894 peak=8894
+  pool.acquired current=4619 peak=4652
+  pool.free current=4275 peak=4341
+  chunks.active current=4619 peak=4630
+  chunks.deferred current=0 peak=31
+  staging.slice.bytes current=34816 peak=1333504
+  cpu.mesh.capacityBytes current=1355895368 peak=1355895368
+  gpu.live.bytes current=576837472 peak=605349056
+  voxel.pool.capacity current=4652 peak=4652
+  voxel.pool.active current=4619 peak=4652
+  voxel.pool.free current=33 peak=44
+  voxel.pool.capacityBytes current=304873472 peak=304873472
+  mesh.allocations.created total=82458 avgPerFrame=3.74044
+  mesh.allocations.destroyed total=81468 avgPerFrame=3.69553
+  pool.rejected total=0 avgPerFrame=0
+  upload.chunks total=28039 avgPerFrame=1.2719
+  upload.vertexBytes total=2164310400 avgPerFrame=98176.9
+  upload.indexBytes total=463780800 avgPerFrame=21037.9
+  upload.deferred total=0 avgPerFrame=0
+  staging.failures total=0 avgPerFrame=0
+  draws.opaque total=27781768 avgPerFrame=1260.23
+  draws.water total=17697937 avgPerFrame=802.81
+  draws.shadow.0 total=3145652 avgPerFrame=142.692
+  draws.shadow.1 total=5178522 avgPerFrame=234.907
+  draws.shadow.2 total=6143628 avgPerFrame=278.686
+  voxel.pool.growEvents total=86 avgPerFrame=0.00390111
+  draws.shadow.total=14467802 avgPerFrame=656.285
+  mesh.skylight n=14746 totalMs=15996.9
+  mesh.blocklight n=14746 totalMs=3439.63
+  mesh.occupancy n=14746 totalMs=447.29
+  mesh.facesGreedyAO n=14746 totalMs=23646
+  mesh.LOD n=14182 totalMs=695.655
+  mesh.maskCells=2372364288 aoVertices=63678400 opaqueVertices=74477676 opaqueIndices=111716514 waterVertices=3723092 waterIndices=5584638
+Score: 45% avgFPS@60 + 15% headroom + 30% 1%low@60 + 10% stability;
+       -15% max penalty for fraction of frames >33ms.

--- a/docs/workload-telemetry.md
+++ b/docs/workload-telemetry.md
@@ -19,7 +19,7 @@ and peak values. Events expose interval totals and averages per measured frame.
 | Fields | Meaning |
 | --- | --- |
 | `voxel.bytes` | Resident voxel storage capacity owned by active, voxel-backed chunks (free pool slots carry 0) |
-| `voxel.pool.*` | VoxelStoragePool state sampled once per measured frame: `capacity`/`active`/`free` count 64 KiB blocks and `capacityBytes` covers blocks retained by the pool including the free list — the high-water reuse footprint. `voxel.pool.growEvents` counts allocations beyond the free list in the interval (steady-state streaming should be near zero) |
+| `voxel.pool.*` | VoxelStoragePool state. **Persistent:** `capacity` and `capacityBytes` describe retained backing memory (64 KiB blocks including the free list) and survive capture boundaries. **Capture-local:** `active` and `free` are sampled during measured frames and reset at the beginning of each capture, so previous runs cannot contribute their peaks. `voxel.pool.growEvents` counts allocations beyond the free list in the interval (steady-state streaming should be near zero) |
 | `shell.sizeBytes`, `shell.capacityBytes` | Logical shell data and retained allocation; clearing a shell does not free its capacity |
 | `cpu.{opaque,water}.{vertex,index}.*` | Each CPU mesh vector's logical size and retained capacity |
 | `cpu.mesh.capacityBytes` | Combined retained mesh capacity, with its own simultaneous peak |

--- a/docs/workload-telemetry.md
+++ b/docs/workload-telemetry.md
@@ -18,7 +18,7 @@ and peak values. Events expose interval totals and averages per measured frame.
 
 | Fields | Meaning |
 | --- | --- |
-| `voxel.bytes` | Allocated voxel vector capacity, including every free pool chunk |
+| `voxel.bytes` | Resident voxel storage capacity owned by active, voxel-backed chunks (free pool slots carry 0) |
 | `shell.sizeBytes`, `shell.capacityBytes` | Logical shell data and retained allocation; clearing a shell does not free its capacity |
 | `cpu.{opaque,water}.{vertex,index}.*` | Each CPU mesh vector's logical size and retained capacity |
 | `cpu.mesh.capacityBytes` | Combined retained mesh capacity, with its own simultaneous peak |

--- a/docs/workload-telemetry.md
+++ b/docs/workload-telemetry.md
@@ -19,11 +19,12 @@ and peak values. Events expose interval totals and averages per measured frame.
 | Fields | Meaning |
 | --- | --- |
 | `voxel.bytes` | Resident voxel storage capacity owned by active, voxel-backed chunks (free pool slots carry 0) |
+| `voxel.pool.*` | VoxelStoragePool state sampled once per measured frame: `capacity`/`active`/`free` count 64 KiB blocks and `capacityBytes` covers blocks retained by the pool including the free list — the high-water reuse footprint. `voxel.pool.growEvents` counts allocations beyond the free list in the interval (steady-state streaming should be near zero) |
 | `shell.sizeBytes`, `shell.capacityBytes` | Logical shell data and retained allocation; clearing a shell does not free its capacity |
 | `cpu.{opaque,water}.{vertex,index}.*` | Each CPU mesh vector's logical size and retained capacity |
 | `cpu.mesh.capacityBytes` | Combined retained mesh capacity, with its own simultaneous peak |
 | `column.bytes`, `occupancy.bytes` | Inline biome/color/height arrays and occupancy bitsets, including free chunks |
-| `pool.*` | Capacity, acquired and free chunks; rejected acquisitions are interval events |
+| `pool.*` | ChunkPool state only: capacity, acquired and free chunk slots; rejected acquisitions are interval events (VoxelPool blocks are reported by `voxel.pool.*`) |
 | `chunks.active`, `chunks.deferred` | End-of-measured-frame manager counts, including the deferred chunk-release backlog |
 | `gpu.{opaque,water}.{vertex,index}.bytes` | Requested buffer bytes from successful mesh VMA allocations until retirement or immediate destruction |
 | `gpu.live.bytes` | Sum of those four live gauges, with its own simultaneous peak |

--- a/src/Chunk/Chunk.cpp
+++ b/src/Chunk/Chunk.cpp
@@ -35,17 +35,18 @@ struct MeshWorkspace
 
 static thread_local MeshWorkspace s_meshWorkspace;
 
-Chunk::Chunk(const glm::vec3 &position, ChunkState state)
+Chunk::Chunk(const glm::vec3 &position, ChunkState state, VoxelPool *voxelPool)
     : position(position), visible(false), state(state),
       opaqueIndexCount(0), waterIndexCount(0),
-      voxels(CHUNK_VOLUME),
+      m_voxelPool(voxelPool),
+      m_storage(nullptr),
       neighborShellVoxels(18 * (CHUNK_HEIGHT + 2) * 18,
                           static_cast<uint8_t>(AIR)),
       meshNeedsUpdate(true) { publishCpuTelemetry(); }
 
 Chunk::Chunk(Chunk &&other) noexcept
     : position(std::move(other.position)), visible(other.visible),
-      state(other.state.load()), voxels(std::move(other.voxels)),
+      state(other.state.load()),
       m_allocator(other.m_allocator),
       vertexBuffer(other.vertexBuffer),
       indexBuffer(other.indexBuffer),
@@ -53,6 +54,8 @@ Chunk::Chunk(Chunk &&other) noexcept
       waterIndexBuffer(other.waterIndexBuffer),
       opaqueIndexCount(other.opaqueIndexCount), waterIndexCount(other.waterIndexCount),
       meshNeedsUpdate(other.meshNeedsUpdate.load()),
+      m_voxelPool(other.m_voxelPool),
+      m_storage(other.m_storage),
       activeVoxels(std::move(other.activeVoxels)),
       neighborShellVoxels(std::move(other.neighborShellVoxels)),
       biomeGrassColors(other.biomeGrassColors),
@@ -63,6 +66,8 @@ Chunk::Chunk(Chunk &&other) noexcept
       waterVertices(std::move(other.waterVertices)), waterIndices(std::move(other.waterIndices)),
       m_isLODMesh(other.m_isLODMesh)
 {
+  other.m_storage = nullptr;
+  other.m_voxelPool = nullptr;
   other.publishCpuTelemetry();
   publishCpuTelemetry();
   other.m_allocator = VK_NULL_HANDLE;
@@ -78,11 +83,15 @@ Chunk &Chunk::operator=(Chunk &&other) noexcept
   if (this != &other)
   {
     releaseGPU();
+    releaseVoxelStorage();
 
     position = std::move(other.position);
     visible = other.visible;
     state.store(other.state.load());
-    voxels = std::move(other.voxels);
+    m_voxelPool = other.m_voxelPool;
+    m_storage = other.m_storage;
+    other.m_storage = nullptr;
+    other.m_voxelPool = nullptr;
     activeVoxels = std::move(other.activeVoxels);
     neighborShellVoxels = std::move(other.neighborShellVoxels);
     biomeGrassColors = other.biomeGrassColors;
@@ -119,8 +128,37 @@ Chunk &Chunk::operator=(Chunk &&other) noexcept
 
 Chunk::~Chunk()
 {
+  releaseVoxelStorage();
   telemetry::registry().replaceCpu(m_cpuTelemetry, std::array<uint64_t, 13>{});
   releaseGPU();
+}
+
+void Chunk::acquireVoxelStorage()
+{
+  if (m_storage)
+    return;
+  VoxelPool &pool = m_voxelPool ? *m_voxelPool : VoxelPool::defaultPool();
+  m_storage = pool.acquire();
+  publishCpuTelemetry();
+}
+
+void Chunk::releaseVoxelStorage()
+{
+  if (!m_storage)
+    return;
+  VoxelPool &pool = m_voxelPool ? *m_voxelPool : VoxelPool::defaultPool();
+  pool.release(m_storage);
+  m_storage = nullptr;
+  publishCpuTelemetry();
+}
+
+void Chunk::ensureVoxelStorage()
+{
+  if (!m_storage)
+  {
+    acquireVoxelStorage();
+    std::fill(m_storage->voxels.begin(), m_storage->voxels.end(), Voxel{static_cast<uint8_t>(AIR)});
+  }
 }
 
 const glm::vec3 &Chunk::getPosition() const { return position; }
@@ -147,12 +185,18 @@ ChunkState Chunk::getState() const { return state; }
 
 Voxel &Chunk::getVoxel(uint32_t x, uint32_t y, uint32_t z)
 {
-  return voxels[getIndex(x, y, z)];
+  ensureVoxelStorage();
+  return m_storage->voxels[getIndex(x, y, z)];
 }
 
 const Voxel &Chunk::getVoxel(uint32_t x, uint32_t y, uint32_t z) const
 {
-  return voxels[getIndex(x, y, z)];
+  if (!m_storage)
+  {
+    static constexpr Voxel s_air{static_cast<uint8_t>(AIR)};
+    return s_air;
+  }
+  return m_storage->voxels[getIndex(x, y, z)];
 }
 
 void Chunk::setVoxel(int x, int y, int z, TextureType type)
@@ -161,13 +205,16 @@ void Chunk::setVoxel(int x, int y, int z, TextureType type)
       static_cast<uint32_t>(z) < CHUNK_SIZE)
   {
     size_t index = getIndex(x, y, z);
-    voxels[index].type = static_cast<uint8_t>(type);
     if (type != AIR)
     {
+      ensureVoxelStorage();
+      m_storage->voxels[index].type = static_cast<uint8_t>(type);
       activeVoxels.set(index);
     }
     else
     {
+      if (m_storage)
+        m_storage->voxels[index].type = static_cast<uint8_t>(AIR);
       activeVoxels.reset(index);
     }
   }
@@ -185,6 +232,9 @@ void Chunk::setVoxel(int x, int y, int z, TextureType type)
 
 bool Chunk::deleteVoxel(const glm::vec3 &position)
 {
+  if (!m_storage)
+    return false;
+
   int x = static_cast<int>(position.x - this->position.x);
   int y = static_cast<int>(position.y - this->position.y);
   int z = static_cast<int>(position.z - this->position.z);
@@ -228,6 +278,8 @@ bool Chunk::isVoxelActive(int x, int y, int z) const
   if (static_cast<uint32_t>(x) < CHUNK_SIZE && static_cast<uint32_t>(y) < CHUNK_HEIGHT &&
       static_cast<uint32_t>(z) < CHUNK_SIZE)
   {
+    if (!m_storage)
+      return false;
     size_t index = getIndex(x, y, z);
     return activeVoxels.test(index);
   }
@@ -255,12 +307,13 @@ void Chunk::generateTerrain(TerrainGenerator &generator)
 
   // Generate directly into this pooled chunk's reusable storage: no
   // temporary ChunkData and no CHUNK_VOLUME / border-shell copies after
-  // generation. resize() only ever grows once; pool recycles keep capacity.
-  voxels.resize(CHUNK_VOLUME);
+  // generation.
+  if (!m_storage)
+    acquireVoxelStorage();
   neighborShellVoxels.resize(kBorderVoxelCount);
 
   ChunkGenerationTarget target{
-      .voxels = std::span<Voxel, CHUNK_VOLUME>(voxels),
+      .voxels = std::span<Voxel, CHUNK_VOLUME>(m_storage->voxels),
       .borderVoxels = std::span<uint8_t, kBorderVoxelCount>(neighborShellVoxels),
       .biomes = biomeTypes,
       .heightMap = heightMap,
@@ -272,7 +325,7 @@ void Chunk::generateTerrain(TerrainGenerator &generator)
   activeVoxels.reset(); // Clear all bits first
   for (int i = 0; i < CHUNK_VOLUME; ++i)
   {
-    if (this->voxels[i].type !=
+    if (this->m_storage->voxels[i].type !=
         TextureType::AIR)
     { // Or your equivalent of an air block
       activeVoxels.set(i);
@@ -474,8 +527,15 @@ void Chunk::generateMesh()
     // Dense type strip for the pure helper (same layout as getIndex).
     thread_local std::vector<uint8_t> typeScratch;
     typeScratch.resize(CHUNK_VOLUME);
-    for (size_t i = 0; i < voxels.size() && i < static_cast<size_t>(CHUNK_VOLUME); ++i)
-      typeScratch[i] = voxels[i].type;
+    if (m_storage)
+    {
+      for (size_t i = 0; i < CHUNK_VOLUME; ++i)
+        typeScratch[i] = m_storage->voxels[i].type;
+    }
+    else
+    {
+      std::fill(typeScratch.begin(), typeScratch.end(), static_cast<uint8_t>(AIR));
+    }
     if (!computeOccupancyY(typeScratch.data(), occMinY, occMaxY))
     {
       meshNeedsUpdate = true;
@@ -1404,13 +1464,11 @@ void Chunk::reset(const glm::vec3 &newPosition, ResetMode mode)
   waterVertices.clear();
   waterIndices.clear();
 
-  // Generation resets caller-owned storage itself. Avoid another full-buffer
-  // write on acquisition; retirement still leaves a completely empty chunk.
+  // Full reset returns voxel storage to the pool for retirement.
+  // ForGeneration retains dirty storage until generateTerrain() overwrites it.
   if (mode == ResetMode::Full)
   {
-    if (voxels.size() != CHUNK_VOLUME)
-      voxels.resize(CHUNK_VOLUME);
-    std::fill(voxels.begin(), voxels.end(), Voxel{static_cast<uint8_t>(AIR)});
+    releaseVoxelStorage();
   }
 
   activeVoxels.reset();
@@ -1430,7 +1488,7 @@ void Chunk::publishCpuTelemetry()
 {
   if (!telemetry::registry().enabled) return;
   const std::array<uint64_t, 13> current{
-    voxels.capacity()*sizeof(Voxel), neighborShellVoxels.size(), neighborShellVoxels.capacity(),
+    m_storage ? sizeof(VoxelStorage) : 0, neighborShellVoxels.size(), neighborShellVoxels.capacity(),
     vertices.size()*sizeof(Vertex), vertices.capacity()*sizeof(Vertex),
     indices.size()*sizeof(uint32_t), indices.capacity()*sizeof(uint32_t),
     waterVertices.size()*sizeof(Vertex), waterVertices.capacity()*sizeof(Vertex),

--- a/src/Chunk/Chunk.cpp
+++ b/src/Chunk/Chunk.cpp
@@ -38,7 +38,7 @@ static thread_local MeshWorkspace s_meshWorkspace;
 Chunk::Chunk(const glm::vec3 &position, ChunkState state, VoxelPool *voxelPool)
     : position(position), visible(false), state(state),
       opaqueIndexCount(0), waterIndexCount(0),
-      m_voxelPool(voxelPool),
+      m_voxelPool(voxelPool ? voxelPool : &VoxelPool::defaultPool()),
       m_storage(nullptr),
       neighborShellVoxels(18 * (CHUNK_HEIGHT + 2) * 18,
                           static_cast<uint8_t>(AIR)),
@@ -67,7 +67,6 @@ Chunk::Chunk(Chunk &&other) noexcept
       m_isLODMesh(other.m_isLODMesh)
 {
   other.m_storage = nullptr;
-  other.m_voxelPool = nullptr;
   other.publishCpuTelemetry();
   publishCpuTelemetry();
   other.m_allocator = VK_NULL_HANDLE;
@@ -83,15 +82,35 @@ Chunk &Chunk::operator=(Chunk &&other) noexcept
   if (this != &other)
   {
     releaseGPU();
-    releaseVoxelStorage();
+    releaseVoxelStorageOnRetire();
 
     position = std::move(other.position);
     visible = other.visible;
     state.store(other.state.load());
-    m_voxelPool = other.m_voxelPool;
-    m_storage = other.m_storage;
-    other.m_storage = nullptr;
-    other.m_voxelPool = nullptr;
+
+    // If destination has a different pool than source, return source storage to its pool
+    // and re-acquire from destination pool. Otherwise just transfer pointer.
+    if (m_voxelPool != other.m_voxelPool)
+    {
+      if (other.m_storage)
+      {
+        VoxelStorage *otherStorage = other.m_storage;
+        other.m_storage = nullptr;
+        m_storage = m_voxelPool->acquire();
+        std::copy(otherStorage->voxels.begin(), otherStorage->voxels.end(), m_storage->voxels.begin());
+        other.m_voxelPool->release(otherStorage);
+      }
+      else
+      {
+        m_storage = nullptr;
+      }
+    }
+    else
+    {
+      m_storage = other.m_storage;
+      other.m_storage = nullptr;
+    }
+
     activeVoxels = std::move(other.activeVoxels);
     neighborShellVoxels = std::move(other.neighborShellVoxels);
     biomeGrassColors = other.biomeGrassColors;
@@ -128,36 +147,44 @@ Chunk &Chunk::operator=(Chunk &&other) noexcept
 
 Chunk::~Chunk()
 {
-  releaseVoxelStorage();
+  releaseVoxelStorageOnRetire();
   telemetry::registry().replaceCpu(m_cpuTelemetry, std::array<uint64_t, 13>{});
   releaseGPU();
 }
 
-void Chunk::acquireVoxelStorage()
+bool Chunk::prepareVoxelStorageForGeneration()
 {
   if (m_storage)
-    return;
-  VoxelPool &pool = m_voxelPool ? *m_voxelPool : VoxelPool::defaultPool();
-  m_storage = pool.acquire();
-  publishCpuTelemetry();
+    return true;
+  try
+  {
+    m_storage = m_voxelPool->acquire();
+    publishCpuTelemetry();
+    return true;
+  }
+  catch (const std::bad_alloc &)
+  {
+    return false;
+  }
 }
 
-void Chunk::releaseVoxelStorage()
+void Chunk::releaseVoxelStorageOnRetire()
 {
   if (!m_storage)
     return;
-  VoxelPool &pool = m_voxelPool ? *m_voxelPool : VoxelPool::defaultPool();
-  pool.release(m_storage);
+  VoxelStorage *st = m_storage;
   m_storage = nullptr;
+  m_voxelPool->release(st);
   publishCpuTelemetry();
 }
 
-void Chunk::ensureVoxelStorage()
+void Chunk::ensureVoxelStorageForEdit()
 {
   if (!m_storage)
   {
-    acquireVoxelStorage();
+    m_storage = m_voxelPool->acquire();
     std::fill(m_storage->voxels.begin(), m_storage->voxels.end(), Voxel{static_cast<uint8_t>(AIR)});
+    publishCpuTelemetry();
   }
 }
 
@@ -183,12 +210,6 @@ void Chunk::setState(ChunkState state)
 
 ChunkState Chunk::getState() const { return state; }
 
-Voxel &Chunk::getVoxel(uint32_t x, uint32_t y, uint32_t z)
-{
-  ensureVoxelStorage();
-  return m_storage->voxels[getIndex(x, y, z)];
-}
-
 const Voxel &Chunk::getVoxel(uint32_t x, uint32_t y, uint32_t z) const
 {
   if (!m_storage)
@@ -207,7 +228,7 @@ void Chunk::setVoxel(int x, int y, int z, TextureType type)
     size_t index = getIndex(x, y, z);
     if (type != AIR)
     {
-      ensureVoxelStorage();
+      ensureVoxelStorageForEdit();
       m_storage->voxels[index].type = static_cast<uint8_t>(type);
       activeVoxels.set(index);
     }
@@ -307,9 +328,8 @@ void Chunk::generateTerrain(TerrainGenerator &generator)
 
   // Generate directly into this pooled chunk's reusable storage: no
   // temporary ChunkData and no CHUNK_VOLUME / border-shell copies after
-  // generation.
-  if (!m_storage)
-    acquireVoxelStorage();
+  // generation. Storage MUST have been prepared on the main thread prior to dispatch.
+  assert(m_storage != nullptr && "VoxelStorage must be prepared before generateTerrain");
   neighborShellVoxels.resize(kBorderVoxelCount);
 
   ChunkGenerationTarget target{
@@ -1468,7 +1488,7 @@ void Chunk::reset(const glm::vec3 &newPosition, ResetMode mode)
   // ForGeneration retains dirty storage until generateTerrain() overwrites it.
   if (mode == ResetMode::Full)
   {
-    releaseVoxelStorage();
+    releaseVoxelStorageOnRetire();
   }
 
   activeVoxels.reset();

--- a/src/Chunk/Chunk.cpp
+++ b/src/Chunk/Chunk.cpp
@@ -88,28 +88,15 @@ Chunk &Chunk::operator=(Chunk &&other) noexcept
     visible = other.visible;
     state.store(other.state.load());
 
-    // If destination has a different pool than source, return source storage to its pool
-    // and re-acquire from destination pool. Otherwise just transfer pointer.
-    if (m_voxelPool != other.m_voxelPool)
-    {
-      if (other.m_storage)
-      {
-        VoxelStorage *otherStorage = other.m_storage;
-        other.m_storage = nullptr;
-        m_storage = m_voxelPool->acquire();
-        std::copy(otherStorage->voxels.begin(), otherStorage->voxels.end(), m_storage->voxels.begin());
-        other.m_voxelPool->release(otherStorage);
-      }
-      else
-      {
-        m_storage = nullptr;
-      }
-    }
-    else
-    {
-      m_storage = other.m_storage;
-      other.m_storage = nullptr;
-    }
+    // A move transfers complete ownership (issue #112 review): the voxel
+    // storage and the pool that owns it travel together. The destination
+    // may end up referencing the source's VoxelPool — re-acquiring from
+    // the destination pool here would put an allocation and a 64 KiB copy
+    // inside a noexcept move, and zeroing the source before acquiring
+    // would mutilate it if that allocation threw.
+    m_voxelPool = other.m_voxelPool;
+    m_storage = other.m_storage;
+    other.m_storage = nullptr;
 
     activeVoxels = std::move(other.activeVoxels);
     neighborShellVoxels = std::move(other.neighborShellVoxels);

--- a/src/Chunk/Chunk.hpp
+++ b/src/Chunk/Chunk.hpp
@@ -18,6 +18,7 @@
 #include <chrono>
 
 #include <Chunk/TerrainGenerator.hpp>
+#include <Chunk/VoxelPool.hpp>
 #include <Vulkan/VkBuffer.hpp>
 #include <Camera/Camera.hpp>
 #include <utils.hpp>
@@ -33,7 +34,7 @@ class GpuResourceRetire;
 class Chunk
 {
 public:
-	Chunk(const glm::vec3 &position, ChunkState state = ChunkState::UNLOADED);
+	Chunk(const glm::vec3 &position, ChunkState state = ChunkState::UNLOADED, VoxelPool *voxelPool = nullptr);
 	Chunk(Chunk &&other) noexcept;
 	Chunk &operator=(Chunk &&other) noexcept;
 	~Chunk();
@@ -51,6 +52,12 @@ public:
 
 	bool deleteVoxel(const glm::vec3 &position);
 	bool placeVoxel(const glm::vec3 &position, TextureType type);
+
+	bool hasVoxelStorage() const { return m_storage != nullptr; }
+	void acquireVoxelStorage();
+	void releaseVoxelStorage();
+	void setVoxelPool(VoxelPool *pool) { m_voxelPool = pool; }
+	VoxelPool *getVoxelPool() const { return m_voxelPool; }
 
 	/// Bind opaque mesh and draw indexed into cmd. Returns index count.
 	uint32_t draw(VkCommandBuffer cmd);
@@ -117,7 +124,9 @@ private:
 	std::vector<uint32_t> indices;
 	std::vector<Vertex> waterVertices;
 	std::vector<uint32_t> waterIndices;
-	std::vector<Voxel> voxels;
+	VoxelPool *m_voxelPool{nullptr};
+	VoxelStorage *m_storage{nullptr};
+	void ensureVoxelStorage();
 	std::bitset<CHUNK_VOLUME> activeVoxels;
 	std::vector<uint8_t> neighborShellVoxels;
 

--- a/src/Chunk/Chunk.hpp
+++ b/src/Chunk/Chunk.hpp
@@ -45,7 +45,6 @@ public:
 	void setState(ChunkState state);
 	ChunkState getState() const;
 
-	Voxel &getVoxel(uint32_t x, uint32_t y, uint32_t z);
 	const Voxel &getVoxel(uint32_t x, uint32_t y, uint32_t z) const;
 	bool isVoxelActive(int x, int y, int z) const;
 	void setVoxel(int x, int y, int z, TextureType type);
@@ -54,10 +53,14 @@ public:
 	bool placeVoxel(const glm::vec3 &position, TextureType type);
 
 	bool hasVoxelStorage() const { return m_storage != nullptr; }
-	void acquireVoxelStorage();
-	void releaseVoxelStorage();
-	void setVoxelPool(VoxelPool *pool) { m_voxelPool = pool; }
 	VoxelPool *getVoxelPool() const { return m_voxelPool; }
+
+	/// Acquire voxel storage before dispatching to generation thread.
+	/// Returns false if allocation fails (e.g. std::bad_alloc).
+	bool prepareVoxelStorageForGeneration();
+
+	/// Release voxel storage upon chunk retirement.
+	void releaseVoxelStorageOnRetire();
 
 	/// Bind opaque mesh and draw indexed into cmd. Returns index count.
 	uint32_t draw(VkCommandBuffer cmd);
@@ -92,9 +95,10 @@ public:
 								   const Chunk *south, const Chunk *north);
 
 	enum class ResetMode { Full, ForGeneration };
-	/// ForGeneration retains voxel contents until generateTerrain() overwrites
-	/// them. Do not read/mesh those voxels before generation completes.
-	/// Full (the default) also clears voxels, for retirement without regeneration.
+	/// ForGeneration retains voxel storage (if any) until generateTerrain()
+	/// overwrites it, avoiding deallocation/reallocation during pool recycling.
+	/// Do not read/mesh voxels in this chunk before generation completes.
+	/// Full (the default) releases voxel storage back to the pool, for retirement without regeneration.
 	void reset(const glm::vec3 &newPosition, ResetMode mode = ResetMode::Full);
 
 	uint32_t getOpaqueIndexCount() const { return opaqueIndexCount; }
@@ -126,7 +130,7 @@ private:
 	std::vector<uint32_t> waterIndices;
 	VoxelPool *m_voxelPool{nullptr};
 	VoxelStorage *m_storage{nullptr};
-	void ensureVoxelStorage();
+	void ensureVoxelStorageForEdit();
 	std::bitset<CHUNK_VOLUME> activeVoxels;
 	std::vector<uint8_t> neighborShellVoxels;
 

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -795,6 +795,24 @@ size_t ChunkManager::pendingMeshJobs() const
 	return m_pendingMeshJobsCount.load();
 }
 
+bool ChunkManager::prepareAndGenerateChunk(Chunk *chunk, TerrainGenerator &generator)
+{
+	if (!chunk)
+		return false;
+	// Shared synchronous bootstrap contract (issue #112): voxel storage is
+	// prepared on the calling thread immediately before generation; workers
+	// never acquire or release voxel backing. On allocation failure the
+	// chunk is returned to the pool so the slot is not leaked.
+	if (!chunk->prepareVoxelStorageForGeneration())
+	{
+		if (m_chunkPool)
+			m_chunkPool->release(chunk);
+		return false;
+	}
+	chunk->generateTerrain(generator);
+	return true;
+}
+
 void ChunkManager::generateInitialArea(const glm::vec3 &center, int radiusChunks, VmaAllocator allocator,
 									   ImmediateCommands &imm)
 {
@@ -832,7 +850,8 @@ void ChunkManager::generateInitialArea(const glm::vec3 &center, int radiusChunks
 				if (!chunk)
 					continue;
 			}
-			chunk->generateTerrain(*m_terrainGenerator);
+			if (!prepareAndGenerateChunk(chunk, *m_terrainGenerator))
+				continue;
 			created.emplace_back(pos, chunk);
 		}
 	}

--- a/src/Chunk/ChunkManager.cpp
+++ b/src/Chunk/ChunkManager.cpp
@@ -233,6 +233,8 @@ void ChunkManager::generatePendingVoxels(const Camera &camera, const RenderSetti
 	for (int i = 0; i < n; ++i)
 	{
 		Chunk *chunk = queue[i].chunk;
+		if (!chunk->prepareVoxelStorageForGeneration())
+			continue; // Allocation failed (e.g. OOM), retry next tick
 		const TaskPriority prio = calculateTaskPriority(queue[i].distSq, lodThreshSq);
 		chunk->setInTransit(true);
 		m_pendingGenJobsCount.fetch_add(1);

--- a/src/Chunk/ChunkManager.hpp
+++ b/src/Chunk/ChunkManager.hpp
@@ -82,6 +82,12 @@ public:
 	void generateInitialArea(const glm::vec3 &center, int radiusChunks, VmaAllocator allocator,
 							 ImmediateCommands &imm);
 
+	/// Shared synchronous generation contract (issue #112): prepares voxel
+	/// storage on the calling thread immediately before generateTerrain().
+	/// Returns false — and releases the chunk back to the pool — when the
+	/// storage allocation fails, so no slot is leaked.
+	bool prepareAndGenerateChunk(Chunk *chunk, TerrainGenerator &generator);
+
 private:
 	void queueUnloadOutOfRange(const Camera &camera, const RenderSettings &settings);
 	void loadChunksAroundPlayer(const glm::ivec3 &cameraChunkPos, const Camera &camera,

--- a/src/Chunk/ChunkPool.cpp
+++ b/src/Chunk/ChunkPool.cpp
@@ -55,7 +55,7 @@ void ChunkPool::growUnlocked(size_t addCount)
 
 	for (size_t i = 0; i < canAdd; ++i)
 	{
-		m_storage.push_back(std::make_unique<Chunk>(glm::vec3(0.0f)));
+		m_storage.push_back(std::make_unique<Chunk>(glm::vec3(0.0f), ChunkState::UNLOADED, &m_voxelPool));
 		Chunk *ptr = m_storage.back().get();
 		m_freeList.push_back(ptr);
 		m_owned.push_back(ptr);

--- a/src/Chunk/ChunkPool.hpp
+++ b/src/Chunk/ChunkPool.hpp
@@ -68,6 +68,9 @@ private:
 	std::array<size_t, 3> m_telemetry{};
 	void growUnlocked(size_t addCount); // caller holds m_mutex
 
+	// Must be declared before m_storage so it outlives all Chunk destructors
+	// (members destroy in reverse order): retiring chunks release their
+	// VoxelStorage back into this pool.
 	VoxelPool m_voxelPool;
 
 	/// All pool-owned chunks; unique_ptr keeps addresses stable across vector growth.

--- a/src/Chunk/ChunkPool.hpp
+++ b/src/Chunk/ChunkPool.hpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <array>
 #include <glm/glm.hpp>
+#include <Chunk/VoxelPool.hpp>
 
 class Chunk;
 
@@ -56,10 +57,18 @@ public:
 	/// Number of successful grow operations (ensureCapacity that allocated).
 	size_t growEvents() const { return m_growEvents.load(std::memory_order_relaxed); }
 
+	size_t voxelStorageCapacity() const { return m_voxelPool.capacity(); }
+	size_t voxelStorageActive() const { return m_voxelPool.activeCount(); }
+	size_t voxelStorageFree() const { return m_voxelPool.freeCount(); }
+	VoxelPool &voxelPool() { return m_voxelPool; }
+	const VoxelPool &voxelPool() const { return m_voxelPool; }
+
 private:
 	void publishTelemetry(); // caller holds m_mutex
 	std::array<size_t, 3> m_telemetry{};
 	void growUnlocked(size_t addCount); // caller holds m_mutex
+
+	VoxelPool m_voxelPool;
 
 	/// All pool-owned chunks; unique_ptr keeps addresses stable across vector growth.
 	std::vector<std::unique_ptr<Chunk>> m_storage;

--- a/src/Chunk/VoxelPool.cpp
+++ b/src/Chunk/VoxelPool.cpp
@@ -14,21 +14,8 @@ VoxelPool::~VoxelPool()
 	// unique_ptrs in m_storage automatically free all VoxelStorage blocks.
 }
 
-void VoxelPool::publishTelemetry(size_t cap, size_t act, size_t fre)
-{
-	// Publish snapshot outside m_mutex to avoid lock hierarchy inversions
-	auto &t = telemetry::registry();
-	if (!t.enabled)
-		return;
-	const std::array<size_t, 3> now{cap, act, fre};
-	for (size_t i = 0; i < now.size(); ++i)
-		t.replace(static_cast<telemetry::Gauge>(telemetry::PoolCapacity + i), m_telemetry[i], now[i]);
-	m_telemetry = now;
-}
-
 VoxelStorage *VoxelPool::acquire()
 {
-	size_t cap = 0, act = 0, fre = 0;
 	{
 		std::lock_guard<std::mutex> lock(m_mutex);
 		if (!m_freeList.empty())
@@ -36,53 +23,58 @@ VoxelStorage *VoxelPool::acquire()
 			VoxelStorage *s = m_freeList.back();
 			m_freeList.pop_back();
 			m_activeCount.fetch_add(1, std::memory_order_relaxed);
-			cap = m_storage.size();
-			act = m_activeCount.load(std::memory_order_relaxed);
-			fre = m_freeList.size();
-			publishTelemetry(cap, act, fre);
 			return s;
 		}
 	}
 
-	// Allocate uninitialized storage outside the mutex
-	auto block = std::make_unique_for_overwrite<VoxelStorage>();
-	VoxelStorage *ptr = block.get();
-
+	// Allocate uninitialized storage outside the mutex. Growing is an event,
+	// not a gauge publication: the pool stays a low-level thread-safe
+	// component and the main thread publishes the voxel.pool.* gauges as a
+	// per-frame snapshot (issue #112 review).
+	VoxelStorage *ptr = nullptr;
 	{
+		auto block = std::make_unique_for_overwrite<VoxelStorage>();
+		ptr = block.get();
 		std::lock_guard<std::mutex> lock(m_mutex);
 		m_storage.push_back(std::move(block));
 		auto it = std::lower_bound(m_owned.begin(), m_owned.end(), ptr);
 		m_owned.insert(it, ptr);
 		m_activeCount.fetch_add(1, std::memory_order_relaxed);
-		cap = m_storage.size();
-		act = m_activeCount.load(std::memory_order_relaxed);
-		fre = m_freeList.size();
 	}
-	publishTelemetry(cap, act, fre);
+	telemetry::registry().add(telemetry::VoxelPoolGrow);
 	return ptr;
 }
 
 void VoxelPool::release(VoxelStorage *storage)
 {
 	assert(storage != nullptr && "Cannot release null VoxelStorage");
-	size_t cap = 0, act = 0, fre = 0;
-	{
-		std::lock_guard<std::mutex> lock(m_mutex);
-		assert(std::binary_search(m_owned.begin(), m_owned.end(), storage) &&
-			   "VoxelStorage does not belong to this VoxelPool");
-		assert(std::find(m_freeList.begin(), m_freeList.end(), storage) == m_freeList.end() &&
-			   "Double release of VoxelStorage detected");
+	if (!storage)
+		return;
 
-		m_freeList.push_back(storage);
-		const size_t acq = m_activeCount.load(std::memory_order_relaxed);
-		if (acq > 0)
-			m_activeCount.fetch_sub(1, std::memory_order_relaxed);
+	std::lock_guard<std::mutex> lock(m_mutex);
 
-		cap = m_storage.size();
-		act = m_activeCount.load(std::memory_order_relaxed);
-		fre = m_freeList.size();
-	}
-	publishTelemetry(cap, act, fre);
+	// Release-build safety (issue #112 review): the asserts vanish in
+	// Release, so a wrong-pool or double release must not corrupt the free
+	// list — refuse it instead.
+	const bool owned =
+		std::binary_search(m_owned.begin(), m_owned.end(), storage);
+	assert(owned && "VoxelStorage returned to wrong pool");
+	if (!owned)
+		return;
+
+	const bool alreadyFree =
+		std::find(m_freeList.begin(), m_freeList.end(), storage) != m_freeList.end();
+	assert(!alreadyFree && "Double release of VoxelStorage detected");
+	if (alreadyFree)
+		return;
+
+	m_freeList.push_back(storage);
+
+	// Guard against silent underflow if a broken lifecycle double-frees.
+	const size_t active = m_activeCount.load(std::memory_order_relaxed);
+	assert(active > 0 && "VoxelPool active count underflow");
+	if (active > 0)
+		m_activeCount.fetch_sub(1, std::memory_order_relaxed);
 }
 
 size_t VoxelPool::capacity() const
@@ -104,32 +96,24 @@ size_t VoxelPool::freeCount() const
 
 void VoxelPool::reserve(size_t minCapacity)
 {
-	size_t cap = 0, act = 0, fre = 0;
+	std::lock_guard<std::mutex> lock(m_mutex);
+	if (m_storage.size() >= minCapacity)
+		return;
+
+	const size_t addCount = minCapacity - m_storage.size();
+	m_storage.reserve(m_storage.size() + addCount);
+	m_freeList.reserve(m_freeList.size() + addCount);
+	m_owned.reserve(m_owned.size() + addCount);
+
+	for (size_t i = 0; i < addCount; ++i)
 	{
-		std::lock_guard<std::mutex> lock(m_mutex);
-		if (m_storage.size() >= minCapacity)
-			return;
-
-		const size_t addCount = minCapacity - m_storage.size();
-		m_storage.reserve(m_storage.size() + addCount);
-		m_freeList.reserve(m_freeList.size() + addCount);
-		m_owned.reserve(m_owned.size() + addCount);
-
-		for (size_t i = 0; i < addCount; ++i)
-		{
-			auto block = std::make_unique_for_overwrite<VoxelStorage>();
-			VoxelStorage *ptr = block.get();
-			m_storage.push_back(std::move(block));
-			m_freeList.push_back(ptr);
-			m_owned.push_back(ptr);
-		}
-		std::sort(m_owned.begin(), m_owned.end());
-
-		cap = m_storage.size();
-		act = m_activeCount.load(std::memory_order_relaxed);
-		fre = m_freeList.size();
+		auto block = std::make_unique_for_overwrite<VoxelStorage>();
+		VoxelStorage *ptr = block.get();
+		m_storage.push_back(std::move(block));
+		m_freeList.push_back(ptr);
+		m_owned.push_back(ptr);
 	}
-	publishTelemetry(cap, act, fre);
+	std::sort(m_owned.begin(), m_owned.end());
 }
 
 VoxelPool &VoxelPool::defaultPool()

--- a/src/Chunk/VoxelPool.cpp
+++ b/src/Chunk/VoxelPool.cpp
@@ -53,9 +53,9 @@ void VoxelPool::release(VoxelStorage *storage)
 
 	std::lock_guard<std::mutex> lock(m_mutex);
 
-	// Release-build safety (issue #112 review): the asserts vanish in
-	// Release, so a wrong-pool or double release must not corrupt the free
-	// list — refuse it instead.
+	// Two protection levels (issue #112 review):
+	// Debug: a programming error is fatal and immediately visible.
+	// Release: refuse invalid ownership without corrupting the pool.
 	const bool owned =
 		std::binary_search(m_owned.begin(), m_owned.end(), storage);
 	assert(owned && "VoxelStorage returned to wrong pool");

--- a/src/Chunk/VoxelPool.cpp
+++ b/src/Chunk/VoxelPool.cpp
@@ -1,0 +1,97 @@
+#include "VoxelPool.hpp"
+#include <algorithm>
+
+VoxelPool::VoxelPool(size_t initialCapacity)
+{
+	if (initialCapacity > 0)
+		reserve(initialCapacity);
+}
+
+VoxelPool::~VoxelPool()
+{
+	// unique_ptrs in m_storage automatically free all VoxelStorage blocks.
+}
+
+VoxelStorage *VoxelPool::acquire()
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	if (!m_freeList.empty())
+	{
+		VoxelStorage *s = m_freeList.back();
+		m_freeList.pop_back();
+		m_activeCount.fetch_add(1, std::memory_order_relaxed);
+		return s;
+	}
+
+	auto block = std::make_unique<VoxelStorage>();
+	VoxelStorage *ptr = block.get();
+	m_storage.push_back(std::move(block));
+	auto it = std::lower_bound(m_owned.begin(), m_owned.end(), ptr);
+	m_owned.insert(it, ptr);
+	m_activeCount.fetch_add(1, std::memory_order_relaxed);
+	return ptr;
+}
+
+void VoxelPool::release(VoxelStorage *storage)
+{
+	if (!storage)
+		return;
+
+	std::lock_guard<std::mutex> lock(m_mutex);
+	if (std::binary_search(m_owned.begin(), m_owned.end(), storage))
+	{
+		m_freeList.push_back(storage);
+	}
+	else
+	{
+		delete storage;
+	}
+	const size_t acq = m_activeCount.load(std::memory_order_relaxed);
+	if (acq > 0)
+		m_activeCount.fetch_sub(1, std::memory_order_relaxed);
+}
+
+size_t VoxelPool::capacity() const
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return m_storage.size();
+}
+
+size_t VoxelPool::activeCount() const
+{
+	return m_activeCount.load(std::memory_order_relaxed);
+}
+
+size_t VoxelPool::freeCount() const
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return m_freeList.size();
+}
+
+void VoxelPool::reserve(size_t minCapacity)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	if (m_storage.size() >= minCapacity)
+		return;
+
+	const size_t addCount = minCapacity - m_storage.size();
+	m_storage.reserve(m_storage.size() + addCount);
+	m_freeList.reserve(m_freeList.size() + addCount);
+	m_owned.reserve(m_owned.size() + addCount);
+
+	for (size_t i = 0; i < addCount; ++i)
+	{
+		auto block = std::make_unique<VoxelStorage>();
+		VoxelStorage *ptr = block.get();
+		m_storage.push_back(std::move(block));
+		m_freeList.push_back(ptr);
+		m_owned.push_back(ptr);
+	}
+	std::sort(m_owned.begin(), m_owned.end());
+}
+
+VoxelPool &VoxelPool::defaultPool()
+{
+	static VoxelPool s_defaultPool;
+	return s_defaultPool;
+}

--- a/src/Chunk/VoxelPool.cpp
+++ b/src/Chunk/VoxelPool.cpp
@@ -1,5 +1,7 @@
 #include "VoxelPool.hpp"
+#include <Engine/WorkloadTelemetry.hpp>
 #include <algorithm>
+#include <cassert>
 
 VoxelPool::VoxelPool(size_t initialCapacity)
 {
@@ -12,43 +14,75 @@ VoxelPool::~VoxelPool()
 	// unique_ptrs in m_storage automatically free all VoxelStorage blocks.
 }
 
+void VoxelPool::publishTelemetry(size_t cap, size_t act, size_t fre)
+{
+	// Publish snapshot outside m_mutex to avoid lock hierarchy inversions
+	auto &t = telemetry::registry();
+	if (!t.enabled)
+		return;
+	const std::array<size_t, 3> now{cap, act, fre};
+	for (size_t i = 0; i < now.size(); ++i)
+		t.replace(static_cast<telemetry::Gauge>(telemetry::PoolCapacity + i), m_telemetry[i], now[i]);
+	m_telemetry = now;
+}
+
 VoxelStorage *VoxelPool::acquire()
 {
-	std::lock_guard<std::mutex> lock(m_mutex);
-	if (!m_freeList.empty())
+	size_t cap = 0, act = 0, fre = 0;
 	{
-		VoxelStorage *s = m_freeList.back();
-		m_freeList.pop_back();
-		m_activeCount.fetch_add(1, std::memory_order_relaxed);
-		return s;
+		std::lock_guard<std::mutex> lock(m_mutex);
+		if (!m_freeList.empty())
+		{
+			VoxelStorage *s = m_freeList.back();
+			m_freeList.pop_back();
+			m_activeCount.fetch_add(1, std::memory_order_relaxed);
+			cap = m_storage.size();
+			act = m_activeCount.load(std::memory_order_relaxed);
+			fre = m_freeList.size();
+			publishTelemetry(cap, act, fre);
+			return s;
+		}
 	}
 
-	auto block = std::make_unique<VoxelStorage>();
+	// Allocate uninitialized storage outside the mutex
+	auto block = std::make_unique_for_overwrite<VoxelStorage>();
 	VoxelStorage *ptr = block.get();
-	m_storage.push_back(std::move(block));
-	auto it = std::lower_bound(m_owned.begin(), m_owned.end(), ptr);
-	m_owned.insert(it, ptr);
-	m_activeCount.fetch_add(1, std::memory_order_relaxed);
+
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		m_storage.push_back(std::move(block));
+		auto it = std::lower_bound(m_owned.begin(), m_owned.end(), ptr);
+		m_owned.insert(it, ptr);
+		m_activeCount.fetch_add(1, std::memory_order_relaxed);
+		cap = m_storage.size();
+		act = m_activeCount.load(std::memory_order_relaxed);
+		fre = m_freeList.size();
+	}
+	publishTelemetry(cap, act, fre);
 	return ptr;
 }
 
 void VoxelPool::release(VoxelStorage *storage)
 {
-	if (!storage)
-		return;
+	assert(storage != nullptr && "Cannot release null VoxelStorage");
+	size_t cap = 0, act = 0, fre = 0;
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		assert(std::binary_search(m_owned.begin(), m_owned.end(), storage) &&
+			   "VoxelStorage does not belong to this VoxelPool");
+		assert(std::find(m_freeList.begin(), m_freeList.end(), storage) == m_freeList.end() &&
+			   "Double release of VoxelStorage detected");
 
-	std::lock_guard<std::mutex> lock(m_mutex);
-	if (std::binary_search(m_owned.begin(), m_owned.end(), storage))
-	{
 		m_freeList.push_back(storage);
+		const size_t acq = m_activeCount.load(std::memory_order_relaxed);
+		if (acq > 0)
+			m_activeCount.fetch_sub(1, std::memory_order_relaxed);
+
+		cap = m_storage.size();
+		act = m_activeCount.load(std::memory_order_relaxed);
+		fre = m_freeList.size();
 	}
-	else
-	{
-		delete storage;
-	}
-	const size_t acq = m_activeCount.load(std::memory_order_relaxed);
-	if (acq > 0)
-		m_activeCount.fetch_sub(1, std::memory_order_relaxed);
+	publishTelemetry(cap, act, fre);
 }
 
 size_t VoxelPool::capacity() const
@@ -70,24 +104,32 @@ size_t VoxelPool::freeCount() const
 
 void VoxelPool::reserve(size_t minCapacity)
 {
-	std::lock_guard<std::mutex> lock(m_mutex);
-	if (m_storage.size() >= minCapacity)
-		return;
-
-	const size_t addCount = minCapacity - m_storage.size();
-	m_storage.reserve(m_storage.size() + addCount);
-	m_freeList.reserve(m_freeList.size() + addCount);
-	m_owned.reserve(m_owned.size() + addCount);
-
-	for (size_t i = 0; i < addCount; ++i)
+	size_t cap = 0, act = 0, fre = 0;
 	{
-		auto block = std::make_unique<VoxelStorage>();
-		VoxelStorage *ptr = block.get();
-		m_storage.push_back(std::move(block));
-		m_freeList.push_back(ptr);
-		m_owned.push_back(ptr);
+		std::lock_guard<std::mutex> lock(m_mutex);
+		if (m_storage.size() >= minCapacity)
+			return;
+
+		const size_t addCount = minCapacity - m_storage.size();
+		m_storage.reserve(m_storage.size() + addCount);
+		m_freeList.reserve(m_freeList.size() + addCount);
+		m_owned.reserve(m_owned.size() + addCount);
+
+		for (size_t i = 0; i < addCount; ++i)
+		{
+			auto block = std::make_unique_for_overwrite<VoxelStorage>();
+			VoxelStorage *ptr = block.get();
+			m_storage.push_back(std::move(block));
+			m_freeList.push_back(ptr);
+			m_owned.push_back(ptr);
+		}
+		std::sort(m_owned.begin(), m_owned.end());
+
+		cap = m_storage.size();
+		act = m_activeCount.load(std::memory_order_relaxed);
+		fre = m_freeList.size();
 	}
-	std::sort(m_owned.begin(), m_owned.end());
+	publishTelemetry(cap, act, fre);
 }
 
 VoxelPool &VoxelPool::defaultPool()

--- a/src/Chunk/VoxelPool.hpp
+++ b/src/Chunk/VoxelPool.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <vector>
+#include <mutex>
+#include <cstddef>
+#include <atomic>
+#include <utils.hpp>
+
+/// Decoupled voxel backing storage for a single chunk.
+/// Size: exactly CHUNK_VOLUME bytes (65,536 voxels).
+struct VoxelStorage
+{
+	std::array<Voxel, CHUNK_VOLUME> voxels;
+
+	Voxel *data() { return voxels.data(); }
+	const Voxel *data() const { return voxels.data(); }
+	size_t size() const { return CHUNK_VOLUME; }
+	Voxel &operator[](size_t idx) { return voxels[idx]; }
+	const Voxel &operator[](size_t idx) const { return voxels[idx]; }
+};
+
+/// Reusable pool of pointer-stable VoxelStorage blocks.
+///
+/// Backs active chunks with 64 KiB voxel memory on demand without allocating
+/// storage for free pool chunk slots. Reuses returned blocks from a free list
+/// so no steady-state heap allocation occurs during continuous streaming.
+class VoxelPool
+{
+public:
+	explicit VoxelPool(size_t initialCapacity = 0);
+	~VoxelPool();
+
+	VoxelPool(const VoxelPool &) = delete;
+	VoxelPool &operator=(const VoxelPool &) = delete;
+	VoxelPool(VoxelPool &&) = delete;
+	VoxelPool &operator=(VoxelPool &&) = delete;
+
+	/// Acquire a VoxelStorage block. Reuses from free list if available,
+	/// or allocates a new block if free list is empty. Thread-safe.
+	VoxelStorage *acquire();
+
+	/// Return a VoxelStorage block to the pool for future reuse. Thread-safe.
+	void release(VoxelStorage *storage);
+
+	/// Total number of VoxelStorage blocks currently allocated in this pool.
+	size_t capacity() const;
+
+	/// Number of VoxelStorage blocks currently in use.
+	size_t activeCount() const;
+
+	/// Number of VoxelStorage blocks available in the free list.
+	size_t freeCount() const;
+
+	/// Pre-allocate up to minCapacity blocks. Thread-safe.
+	void reserve(size_t minCapacity);
+
+	/// Default global pool used by standalone chunks outside of ChunkPool.
+	static VoxelPool &defaultPool();
+
+private:
+	mutable std::mutex m_mutex;
+	std::vector<std::unique_ptr<VoxelStorage>> m_storage;
+	std::vector<VoxelStorage *> m_freeList;
+	std::vector<const VoxelStorage *> m_owned;
+	std::atomic<size_t> m_activeCount{0};
+};

--- a/src/Chunk/VoxelPool.hpp
+++ b/src/Chunk/VoxelPool.hpp
@@ -60,9 +60,12 @@ public:
 	static VoxelPool &defaultPool();
 
 private:
+	void publishTelemetry(size_t cap, size_t act, size_t fre);
+
 	mutable std::mutex m_mutex;
 	std::vector<std::unique_ptr<VoxelStorage>> m_storage;
 	std::vector<VoxelStorage *> m_freeList;
 	std::vector<const VoxelStorage *> m_owned;
 	std::atomic<size_t> m_activeCount{0};
+	std::array<size_t, 3> m_telemetry{};
 };

--- a/src/Chunk/VoxelPool.hpp
+++ b/src/Chunk/VoxelPool.hpp
@@ -60,12 +60,9 @@ public:
 	static VoxelPool &defaultPool();
 
 private:
-	void publishTelemetry(size_t cap, size_t act, size_t fre);
-
 	mutable std::mutex m_mutex;
 	std::vector<std::unique_ptr<VoxelStorage>> m_storage;
 	std::vector<VoxelStorage *> m_freeList;
 	std::vector<const VoxelStorage *> m_owned;
 	std::atomic<size_t> m_activeCount{0};
-	std::array<size_t, 3> m_telemetry{};
 };

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -815,6 +815,19 @@ void Engine::sampleBenchmarkFrame()
     auto& telemetry = telemetry::registry();
     telemetry.set(telemetry::ActiveChunks, chunkManager ? chunkManager->chunkCount() : 0);
     telemetry.set(telemetry::DeferredChunks, chunkManager ? chunkManager->deferredReleaseCount() : 0);
+    // voxel.pool.* gauges are published here on the main thread as a
+    // coherent per-frame snapshot (issue #112 review): the VoxelPool itself
+    // stays a low-level thread-safe component without telemetry in its
+    // hot path. capacityBytes covers blocks retained by the pool including
+    // the free list, i.e. the high-water reuse footprint.
+    if (chunkManager && chunkManager->getChunkPool())
+    {
+        const size_t voxelCap = chunkManager->getChunkPool()->voxelStorageCapacity();
+        telemetry.set(telemetry::VoxelPoolCapacity, voxelCap);
+        telemetry.set(telemetry::VoxelPoolActive, chunkManager->getChunkPool()->voxelStorageActive());
+        telemetry.set(telemetry::VoxelPoolFree, chunkManager->getChunkPool()->voxelStorageFree());
+        telemetry.set(telemetry::VoxelPoolCapacityBytes, voxelCap * sizeof(VoxelStorage));
+    }
 	m_benchmark.sampleFrame(
 		prof.lastFrameMs(), prof.lastScopeMs("Streaming"), prof.lastScopeMs("Acquire"),
 		prof.lastScopeMs("Record"), prof.lastScopeMs("ImGui"), prof.lastScopeMs("Present"),

--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -1009,13 +1009,16 @@ void Engine::run()
 				const glm::vec3 eye = camera.getPosition();
 				if (Chunk *ch = chunkManager->getChunkAtWorldPos(eye))
 				{
-					const int chunkX = static_cast<int>(std::floor(eye.x / static_cast<float>(CHUNK_SIZE)));
-					const int chunkZ = static_cast<int>(std::floor(eye.z / static_cast<float>(CHUNK_SIZE)));
-					const int lx = static_cast<int>(std::floor(eye.x)) - chunkX * CHUNK_SIZE;
-					const int ly = static_cast<int>(std::floor(eye.y));
-					const int lz = static_cast<int>(std::floor(eye.z)) - chunkZ * CHUNK_SIZE;
-					if (lx >= 0 && lx < CHUNK_SIZE && ly >= 0 && ly < CHUNK_HEIGHT && lz >= 0 && lz < CHUNK_SIZE)
-						underwater = (static_cast<TextureType>(ch->getVoxel(lx, ly, lz).type) == WATER);
+					if (ch->getState() >= ChunkState::GENERATED)
+					{
+						const int chunkX = static_cast<int>(std::floor(eye.x / static_cast<float>(CHUNK_SIZE)));
+						const int chunkZ = static_cast<int>(std::floor(eye.z / static_cast<float>(CHUNK_SIZE)));
+						const int lx = static_cast<int>(std::floor(eye.x)) - chunkX * CHUNK_SIZE;
+						const int ly = static_cast<int>(std::floor(eye.y));
+						const int lz = static_cast<int>(std::floor(eye.z)) - chunkZ * CHUNK_SIZE;
+						if (lx >= 0 && lx < CHUNK_SIZE && ly >= 0 && ly < CHUNK_HEIGHT && lz >= 0 && lz < CHUNK_SIZE)
+							underwater = (static_cast<TextureType>(ch->getVoxel(lx, ly, lz).type) == WATER);
+					}
 				}
 			}
 			worldRenderer->postSettings().underwater = underwater;

--- a/src/Engine/WorkloadTelemetry.hpp
+++ b/src/Engine/WorkloadTelemetry.hpp
@@ -51,16 +51,20 @@ enum Stage : size_t { Skylight, Blocklight, Occupancy, FacesGreedyAO, Lod, Stage
 inline constexpr const char* stageNames[] = {"skylight", "blocklight", "occupancy", "facesGreedyAO", "LOD"};
 
 // Capture-local gauges describe transient state sampled during a capture
-// window (staging slice usage; end-of-frame chunk-manager samples). Unlike
-// ownership gauges they are NOT carried across a beginCapture() boundary:
-// a warmup high-water mark must not become a measurement peak. Gauges
-// default to persistent ownership; classify one here only if its value is
-// meaningless outside the currently running capture.
+// window (staging slice usage; end-of-frame chunk-manager samples; the
+// VoxelPool active/free split). Unlike ownership gauges they are NOT
+// carried across a beginCapture() boundary: a warmup high-water mark must
+// not become a measurement peak. Gauges default to persistent ownership;
+// classify one here only if its value is meaningless outside the currently
+// running capture. Note VoxelPoolCapacity/VoxelPoolCapacityBytes stay
+// persistent: retained backing memory really exists at the boundary.
 inline constexpr bool isCaptureLocalGauge(Gauge g) {
     switch (g) {
     case StagingUsed:
     case ActiveChunks:
     case DeferredChunks:
+    case VoxelPoolActive:
+    case VoxelPoolFree:
         return true;
     default:
         return false;

--- a/src/Engine/WorkloadTelemetry.hpp
+++ b/src/Engine/WorkloadTelemetry.hpp
@@ -18,7 +18,9 @@ enum Gauge : size_t {
     WaterIndexBytes, WaterIndexCapacity, ColumnBytes, OccupancyBytes,
     GpuOpaqueVertex, GpuOpaqueIndex, GpuWaterVertex, GpuWaterIndex,
     RetiredBytes, RetiredBuffers, PoolCapacity, PoolAcquired, PoolFree,
-    ActiveChunks, DeferredChunks, StagingUsed, CpuMeshCapacity, GpuLiveBytes, GaugeCount
+    ActiveChunks, DeferredChunks, StagingUsed, CpuMeshCapacity, GpuLiveBytes,
+    VoxelPoolCapacity, VoxelPoolActive, VoxelPoolFree, VoxelPoolCapacityBytes,
+    GaugeCount
 };
 inline constexpr const char* gaugeNames[] = {
     "voxel.bytes", "shell.sizeBytes", "shell.capacityBytes",
@@ -30,18 +32,20 @@ inline constexpr const char* gaugeNames[] = {
     "gpu.opaque.index.bytes", "gpu.water.vertex.bytes", "gpu.water.index.bytes",
     "gpu.retired.bytes", "gpu.retired.buffers", "pool.capacity", "pool.acquired",
     "pool.free", "chunks.active", "chunks.deferred", "staging.slice.bytes",
-    "cpu.mesh.capacityBytes", "gpu.live.bytes"
+    "cpu.mesh.capacityBytes", "gpu.live.bytes",
+    "voxel.pool.capacity", "voxel.pool.active", "voxel.pool.free",
+    "voxel.pool.capacityBytes"
 };
 enum Event : size_t {
     AllocCreated, AllocDestroyed, PoolRejected, UploadChunks, UploadVertexBytes,
     UploadIndexBytes, UploadDeferred, StagingFailures, OpaqueDraws, WaterDraws,
-    Shadow0, Shadow1, Shadow2, EventCount
+    Shadow0, Shadow1, Shadow2, VoxelPoolGrow, EventCount
 };
 inline constexpr const char* eventNames[] = {
     "mesh.allocations.created", "mesh.allocations.destroyed", "pool.rejected",
     "upload.chunks", "upload.vertexBytes", "upload.indexBytes", "upload.deferred",
     "staging.failures", "draws.opaque", "draws.water", "draws.shadow.0",
-    "draws.shadow.1", "draws.shadow.2"
+    "draws.shadow.1", "draws.shadow.2", "voxel.pool.growEvents"
 };
 enum Stage : size_t { Skylight, Blocklight, Occupancy, FacesGreedyAO, Lod, StageCount };
 inline constexpr const char* stageNames[] = {"skylight", "blocklight", "occupancy", "facesGreedyAO", "LOD"};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -357,7 +357,7 @@ add_test(NAME GpuProfile COMMAND test_gpu_profile)
 
 add_executable(test_workload_telemetry test_workload_telemetry.cpp)
 target_include_directories(test_workload_telemetry PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(test_workload_telemetry PRIVATE Threads::Threads)
+target_link_libraries(test_workload_telemetry PRIVATE glm Threads::Threads)
 add_test(NAME WorkloadTelemetry COMMAND test_workload_telemetry)
 set_tests_properties(WorkloadTelemetry PROPERTIES ENVIRONMENT "FT_VOX_TELEMETRY=1")
 add_test(NAME WorkloadTelemetryDisabled COMMAND test_workload_telemetry)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -249,10 +249,13 @@ add_test(NAME InputRouting COMMAND test_input_routing)
 add_executable(test_chunk_lifecycle
     test_chunk_lifecycle.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/Chunk.cpp
+    ${CMAKE_SOURCE_DIR}/src/Chunk/ChunkManager.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/ChunkPool.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/VoxelPool.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainGenerator.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainVegetation.cpp
+    ${CMAKE_SOURCE_DIR}/src/Engine/Profiler.cpp
+    ${CMAKE_SOURCE_DIR}/src/Camera/Camera.cpp
     ${FT_VOX_VULKAN_SOURCES}
 )
 
@@ -297,6 +300,31 @@ if(APPLE)
 endif()
 
 add_test(NAME ChunkLifecycle COMMAND test_chunk_lifecycle)
+
+# ---------------------------------------------------------------------------
+# VoxelPool contract (issue #112 review): ownership, high-water reuse,
+# foreign/double release refusal, concurrency, growth events.
+# ---------------------------------------------------------------------------
+add_executable(test_voxel_pool
+    test_voxel_pool.cpp
+    ${CMAKE_SOURCE_DIR}/src/Chunk/VoxelPool.cpp
+)
+
+target_include_directories(test_voxel_pool PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_compile_definitions(test_voxel_pool PRIVATE
+    GLM_FORCE_DEPTH_ZERO_TO_ONE
+    GLM_ENABLE_EXPERIMENTAL
+)
+
+target_link_libraries(test_voxel_pool PRIVATE
+    glm
+    Threads::Threads
+)
+
+add_test(NAME VoxelPool COMMAND test_voxel_pool)
 
 # ---------------------------------------------------------------------------
 # Profiler worker consistency and stress test (Issue #79)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -250,6 +250,7 @@ add_executable(test_chunk_lifecycle
     test_chunk_lifecycle.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/Chunk.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/ChunkPool.cpp
+    ${CMAKE_SOURCE_DIR}/src/Chunk/VoxelPool.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainGenerator.cpp
     ${CMAKE_SOURCE_DIR}/src/Chunk/TerrainVegetation.cpp
     ${FT_VOX_VULKAN_SOURCES}

--- a/tests/test_chunk_lifecycle.cpp
+++ b/tests/test_chunk_lifecycle.cpp
@@ -5,6 +5,7 @@
 // pooled-style storage across reset/regenerate cycles - with the
 // activeVoxels cache staying in sync and no capacity churn.
 #include <Chunk/Chunk.hpp>
+#include <Chunk/ChunkManager.hpp>
 #include <Chunk/ChunkPool.hpp>
 #include <Chunk/TerrainGenerator.hpp>
 
@@ -343,23 +344,76 @@ int main(int argc, char **argv)
 		CHECK(emptyChunk.getVoxel(0, 0, 0).type == STONE, "read back stone block");
 	}
 
-	// 6) Cross-pool move-assignment safety.
+	// 6) Cross-pool move semantics (issue #112 review): a move transfers the
+	// storage together with the pool that owns it — O(1), noexcept, no
+	// reallocation and no uninitialized reads. The destination therefore
+	// ends up referencing the source's pool.
 	{
 		VoxelPool poolA;
 		VoxelPool poolB;
+		const int crossSeed = 2024;
+		TerrainGenerator crossGen(crossSeed);
+		const ChunkData reference = crossGen.generateChunk(10, 0);
+
 		Chunk chunkA(glm::vec3(10.0f, 0.0f, 0.0f), ChunkState::UNLOADED, &poolA);
 		Chunk chunkB(glm::vec3(20.0f, 0.0f, 0.0f), ChunkState::UNLOADED, &poolB);
 		CHECK(chunkA.prepareVoxelStorageForGeneration(), "prepare chunkA storage");
+		chunkA.generateTerrain(crossGen);
 		CHECK(poolA.activeCount() == 1, "poolA active count 1");
 		CHECK(poolB.activeCount() == 0, "poolB active count 0");
 
 		chunkB = std::move(chunkA);
-		CHECK(poolA.activeCount() == 0, "poolA active count 0 after cross-pool move");
-		CHECK(poolB.activeCount() == 1, "poolB active count 1 after cross-pool move");
+		CHECK(chunkB.getVoxelPool() == &poolA, "destination adopts source pool");
+		CHECK(poolA.activeCount() == 1, "poolA active count 1 after cross-pool move");
+		CHECK(poolB.activeCount() == 0, "poolB active count 0 after cross-pool move");
 		CHECK(!ChunkStateProbe::hasStorage(chunkA), "chunkA lost storage");
-		CHECK(ChunkStateProbe::hasStorage(chunkB), "chunkB has storage in poolB");
+		CHECK(ChunkStateProbe::hasStorage(chunkB), "chunkB owns the transferred storage");
+		CHECK(std::memcmp(ChunkStateProbe::voxels(chunkB).data(), reference.voxels.data(),
+						  CHUNK_VOLUME * sizeof(Voxel)) == 0,
+			  "cross-pool move carries the generated content, not uninitialized bytes");
 		chunkB.reset(glm::vec3(0.0f));
-		CHECK(poolB.activeCount() == 0, "poolB active count 0 after reset");
+		CHECK(poolA.activeCount() == 0, "storage returns to the traveled pool on reset");
+	}
+
+	// 6b) Cross-pool move-construction: same transfer model, plus destructor
+	// returning the storage to the pool the chunk references.
+	{
+		VoxelPool poolA;
+		VoxelPool poolB;
+		Chunk chunkA(glm::vec3(0.0f), ChunkState::UNLOADED, &poolA);
+		CHECK(chunkA.prepareVoxelStorageForGeneration(), "prepare chunkA storage (move-ctor)");
+		const void *storage = ChunkStateProbe::voxels(chunkA).data();
+		Chunk chunkB(std::move(chunkA));
+		CHECK(chunkB.getVoxelPool() == &poolA, "move-ctor adopts source pool");
+		CHECK(ChunkStateProbe::voxels(chunkB).data() == storage, "move-ctor keeps exact storage");
+		CHECK(!ChunkStateProbe::hasStorage(chunkA), "source left without storage");
+		CHECK(poolA.activeCount() == 1, "poolA active count 1 during move-ctor");
+		{
+			Chunk consumer(std::move(chunkB));
+			CHECK(poolA.activeCount() == 1, "storage follows the second move");
+		}
+		CHECK(poolA.activeCount() == 0, "destruction returns storage to the owning pool");
+		(void)poolB;
+	}
+
+	// 6c) ChunkPool destructor must retire chunks that still hold live
+	// voxel storage — no use-after-free, no double release.
+	{
+		TerrainGenerator dtorGen(9);
+		{
+			ChunkPool pool(8);
+			Chunk *c = pool.acquire(glm::vec3(0.0f));
+			CHECK(c != nullptr, "destructor-test acquisition succeeds");
+			if (c)
+			{
+				CHECK(c->prepareVoxelStorageForGeneration(), "destructor-test prepare succeeds");
+				c->generateTerrain(dtorGen);
+			}
+			// Intentionally no release: the ChunkPool destructor retires
+			// every chunk and returns voxel storage through the VoxelPool,
+			// which must outlive all Chunk destructors.
+		}
+		std::cout << "chunk pool destructor completed cleanly with live storage\n";
 	}
 
 	// 7) Steady-state VoxelPool recycling high-water mark.
@@ -399,6 +453,23 @@ int main(int argc, char **argv)
 		CHECK(vp.activeCount() == 0, "concurrent stress ends with 0 active");
 		CHECK(vp.capacity() == vp.freeCount(), "capacity matches free list count");
 		CHECK(vp.capacity() <= static_cast<size_t>(kThreads), "capacity bounded by thread count");
+	}
+
+	// 9) Synchronous bootstrap contract (issue #112): the ChunkManager
+	// helper prepares storage on the calling thread, generates, and returns
+	// the chunk to the pool when preparation fails.
+	{
+		ChunkPool pool(4);
+		ChunkManager manager(&gen, nullptr, &pool);
+		Chunk *chunk = pool.acquire(glm::vec3(0.0f));
+		CHECK(chunk != nullptr, "bootstrap acquisition succeeds");
+		CHECK(manager.prepareAndGenerateChunk(chunk, gen), "bootstrap prepare+generate succeeds");
+		CHECK(chunk->getState() == ChunkState::GENERATED, "bootstrap chunk generated");
+		CHECK(ChunkStateProbe::hasStorage(*chunk), "bootstrap chunk owns voxel storage");
+		CHECK(pool.voxelStorageActive() == 1, "bootstrap storage accounted active");
+		CHECK(!manager.prepareAndGenerateChunk(nullptr, gen), "null chunk rejected");
+		pool.release(chunk);
+		CHECK(pool.voxelStorageActive() == 0, "bootstrap release returns storage");
 	}
 
 	if (g_fails != 0)

--- a/tests/test_chunk_lifecycle.cpp
+++ b/tests/test_chunk_lifecycle.cpp
@@ -28,11 +28,23 @@ static int g_fails = 0;
 		}                                                                      \
 	} while (0)
 
+struct VoxelView : std::span<const Voxel>
+{
+	using std::span<const Voxel>::span;
+	size_t capacity() const { return size(); }
+};
+
 // Friend probe declared in Chunk.hpp: verifies full private state without
 // exposing per-column generation data through the public API.
 struct ChunkStateProbe
 {
-	static const std::vector<Voxel> &voxels(const Chunk &c) { return c.voxels; }
+	static bool hasStorage(const Chunk &c) { return c.hasVoxelStorage(); }
+	static VoxelView voxels(const Chunk &c)
+	{
+		if (c.m_storage)
+			return VoxelView(c.m_storage->voxels.data(), CHUNK_VOLUME);
+		return VoxelView();
+	}
 	static const std::vector<uint8_t> &shell(const Chunk &c)
 	{
 		return c.neighborShellVoxels;
@@ -73,7 +85,8 @@ struct ChunkSnapshot
 	static ChunkSnapshot capture(const Chunk &c)
 	{
 		ChunkSnapshot s;
-		s.voxels = ChunkStateProbe::voxels(c);
+		const auto v = ChunkStateProbe::voxels(c);
+		s.voxels.assign(v.begin(), v.end());
 		s.shell = ChunkStateProbe::shell(c);
 		s.grass = ChunkStateProbe::grass(c);
 		s.foliage = ChunkStateProbe::foliage(c);
@@ -85,10 +98,10 @@ struct ChunkSnapshot
 	}
 };
 
-static bool sameVoxels(const std::vector<Voxel> &a, const std::vector<Voxel> &b)
+static bool sameVoxels(std::span<const Voxel> a, std::span<const Voxel> b)
 {
 	return a.size() == b.size() &&
-		   std::memcmp(a.data(), b.data(), a.size() * sizeof(Voxel)) == 0;
+		   (a.empty() || std::memcmp(a.data(), b.data(), a.size() * sizeof(Voxel)) == 0);
 }
 
 static bool sameState(const ChunkSnapshot &a, const ChunkSnapshot &b)
@@ -104,10 +117,10 @@ static bool sameState(const ChunkSnapshot &a, const ChunkSnapshot &b)
 /// generated into, so a storage change could desynchronize them.
 static void checkActiveCacheInSync(const Chunk &chunk, const char *label)
 {
-	const auto &voxels = ChunkStateProbe::voxels(chunk);
+	const auto voxels = ChunkStateProbe::voxels(chunk);
 	const auto &active = ChunkStateProbe::active(chunk);
-	bool inSync = voxels.size() == CHUNK_VOLUME;
-	for (size_t i = 0; inSync && i < CHUNK_VOLUME; ++i)
+	bool inSync = !ChunkStateProbe::hasStorage(chunk) ? active.none() : voxels.size() == CHUNK_VOLUME;
+	for (size_t i = 0; inSync && i < voxels.size(); ++i)
 		inSync = active[i] == (voxels[i].type != static_cast<uint8_t>(AIR));
 	CHECK(inSync, label);
 }
@@ -176,16 +189,19 @@ int main(int argc, char **argv)
         {
             Chunk a(glm::vec3(0));
             const auto allocated = registry().snapshot();
-            CHECK(allocated.current[VoxelBytes] - before.current[VoxelBytes] == CHUNK_VOLUME * sizeof(Voxel), "resident voxel allocation");
+            CHECK(allocated.current[VoxelBytes] == before.current[VoxelBytes], "unloaded chunk has no voxel allocation");
+            a.acquireVoxelStorage();
+            const auto withStorage = registry().snapshot();
+            CHECK(withStorage.current[VoxelBytes] - before.current[VoxelBytes] == CHUNK_VOLUME * sizeof(Voxel), "resident voxel allocation");
             a.freeShellVoxels();
             auto cleared = registry().snapshot();
             CHECK(cleared.current[ShellBytes] == before.current[ShellBytes], "empty shell size");
             CHECK(cleared.current[ShellCapacity] == allocated.current[ShellCapacity], "empty shell retains capacity");
             Chunk b(std::move(a));
-            CHECK(registry().snapshot().current[VoxelBytes] == allocated.current[VoxelBytes], "move preserves total vector ownership");
+            CHECK(registry().snapshot().current[VoxelBytes] == withStorage.current[VoxelBytes], "move preserves total vector ownership");
             Chunk c(glm::vec3(0));
             c = std::move(b);
-            CHECK(registry().snapshot().current[VoxelBytes] == allocated.current[VoxelBytes], "move assignment releases destination storage");
+            CHECK(registry().snapshot().current[VoxelBytes] == withStorage.current[VoxelBytes], "move assignment releases destination storage");
             c.setVoxel(1, 1, 1, STONE);
             c.generateMesh();
             const auto meshed = registry().snapshot();
@@ -193,6 +209,7 @@ int main(int argc, char **argv)
             CHECK(meshed.current[CpuMeshCapacity] >= meshed.current[OpaqueVertexBytes], "retained mesh capacity covers its data");
             c.reset(glm::vec3(0));
             const auto reset = registry().snapshot();
+            CHECK(reset.current[VoxelBytes] == before.current[VoxelBytes], "full reset returns voxel storage to pool");
             CHECK(reset.current[OpaqueVertexBytes] == before.current[OpaqueVertexBytes], "reset clears logical mesh data");
             CHECK(reset.current[CpuMeshCapacity] == meshed.current[CpuMeshCapacity], "reset retains mesh allocations");
         }
@@ -208,8 +225,10 @@ int main(int argc, char **argv)
 	// 1) generateTerrain fills complete, correct state at position A.
 	Chunk a(glm::vec3(0.0f, 0.0f, 0.0f));
 	CHECK(a.getState() == ChunkState::UNLOADED, "fresh chunk starts UNLOADED");
+	CHECK(!ChunkStateProbe::hasStorage(a), "fresh chunk starts without voxel storage");
 	a.generateTerrain(gen);
 	CHECK(a.getState() == ChunkState::GENERATED, "generation completes");
+	CHECK(ChunkStateProbe::hasStorage(a), "generated chunk has voxel storage");
 	CHECK(ChunkStateProbe::voxels(a).size() == static_cast<size_t>(CHUNK_VOLUME),
 		  "voxel storage fully sized");
 	checkActiveCacheInSync(a, "activeVoxels cache in sync after generation");
@@ -224,6 +243,8 @@ int main(int argc, char **argv)
 
 	// 2) Move-construction carries the full generation state.
 	Chunk b(std::move(a));
+	CHECK(!ChunkStateProbe::hasStorage(a), "moved-from chunk has no storage");
+	CHECK(ChunkStateProbe::hasStorage(b), "moved-to chunk has storage");
 	const ChunkSnapshot snapB = ChunkSnapshot::capture(b);
 	CHECK(sameState(snapA, snapB),
 		  "move-constructor must preserve full generation state");
@@ -232,6 +253,8 @@ int main(int argc, char **argv)
 	// 3) Move-assignment carries the full generation state.
 	Chunk c(glm::vec3(9876.0f, 0.0f, -4321.0f));
 	c = std::move(b);
+	CHECK(!ChunkStateProbe::hasStorage(b), "moved-from chunk has no storage");
+	CHECK(ChunkStateProbe::hasStorage(c), "moved-to chunk has storage");
 	const ChunkSnapshot snapC = ChunkSnapshot::capture(c);
 	CHECK(sameState(snapA, snapC),
 		  "move-assignment must preserve full generation state");
@@ -258,8 +281,9 @@ int main(int argc, char **argv)
 	CHECK(ChunkStateProbe::shell(c).capacity() == shellCapacity,
 		  "shell capacity stable across recycle");
 
-	// Full reset must still clear storage when a chunk is retired.
+	// Full reset returns storage when a chunk is retired.
 	c.reset(glm::vec3(0.0f));
+	CHECK(!ChunkStateProbe::hasStorage(c), "default reset returns storage to pool");
 	CHECK(std::all_of(ChunkStateProbe::voxels(c).begin(),
 					  ChunkStateProbe::voxels(c).end(),
 					  [](Voxel v) { return v.type == AIR; }),
@@ -268,25 +292,34 @@ int main(int argc, char **argv)
 
 	// Exercise the real pool boundary, including cancelled generation.
 	ChunkPool pool(64);
+	CHECK(pool.voxelStorageCapacity() == 0, "constructing ChunkPool allocates 0 voxel storage");
 	Chunk *pooled = pool.acquire(glm::vec3(0.0f));
 	CHECK(pooled != nullptr, "pool acquisition succeeds");
+	CHECK(!ChunkStateProbe::hasStorage(*pooled), "acquired chunk has no storage before generation");
 	if (pooled)
 	{
 		pooled->generateTerrain(gen);
+		CHECK(ChunkStateProbe::hasStorage(*pooled), "pooled chunk has storage after generation");
+		CHECK(pool.voxelStorageCapacity() == 1, "voxel storage capacity grew on demand");
+		CHECK(pool.voxelStorageActive() == 1, "1 active voxel storage");
 		pool.release(pooled);
-		CHECK(std::all_of(ChunkStateProbe::voxels(*pooled).begin(),
-						  ChunkStateProbe::voxels(*pooled).end(),
-						  [](Voxel v) { return v.type == AIR; }),
-			  "pool release fully clears retired voxels");
+		CHECK(!ChunkStateProbe::hasStorage(*pooled), "pool release returns voxel storage to pool");
+		CHECK(pool.voxelStorageActive() == 0, "0 active voxel storage after release");
+		CHECK(pool.voxelStorageFree() == 1, "released storage returned to free list");
+
 		Chunk *reused = pool.acquire(glm::vec3(-CHUNK_SIZE, 0.0f, CHUNK_SIZE));
-		CHECK(reused == pooled, "pool reuses released storage");
+		CHECK(reused == pooled, "pool reuses released chunk slot");
+		CHECK(!ChunkStateProbe::hasStorage(*reused), "reacquired chunk slot has no storage before generation");
 		reused->generateTerrain(gen);
+		CHECK(pool.voxelStorageCapacity() == 1, "generation reused pooled storage without allocating");
+		CHECK(pool.voxelStorageActive() == 1, "1 active voxel storage");
 		checkMatchesOwning(*reused, gen, -CHUNK_SIZE, CHUNK_SIZE, "pool reuse");
 		checkActiveCacheInSync(*reused, "pool reuse active cache");
 		pool.release(reused);
 		pooled = pool.acquire(glm::vec3(0.0f));
 		pool.release(pooled); // cancelled before generation
 		CHECK(pool.acquiredCount() == 0, "cancelled acquisition returns to pool");
+		CHECK(pool.voxelStorageActive() == 0, "cancelled acquisition leaves no active storage");
 	}
 
 	if (g_fails != 0)

--- a/tests/test_chunk_lifecycle.cpp
+++ b/tests/test_chunk_lifecycle.cpp
@@ -15,6 +15,8 @@
 #include <cstring>
 #include <iostream>
 #include <vector>
+#include <thread>
+#include <set>
 
 static int g_fails = 0;
 
@@ -190,7 +192,7 @@ int main(int argc, char **argv)
             Chunk a(glm::vec3(0));
             const auto allocated = registry().snapshot();
             CHECK(allocated.current[VoxelBytes] == before.current[VoxelBytes], "unloaded chunk has no voxel allocation");
-            a.acquireVoxelStorage();
+            CHECK(a.prepareVoxelStorageForGeneration(), "prepare storage succeeds");
             const auto withStorage = registry().snapshot();
             CHECK(withStorage.current[VoxelBytes] - before.current[VoxelBytes] == CHUNK_VOLUME * sizeof(Voxel), "resident voxel allocation");
             a.freeShellVoxels();
@@ -226,7 +228,12 @@ int main(int argc, char **argv)
 	Chunk a(glm::vec3(0.0f, 0.0f, 0.0f));
 	CHECK(a.getState() == ChunkState::UNLOADED, "fresh chunk starts UNLOADED");
 	CHECK(!ChunkStateProbe::hasStorage(a), "fresh chunk starts without voxel storage");
+	CHECK(a.prepareVoxelStorageForGeneration(), "prepare storage succeeds");
+	const void *storagePtrA = ChunkStateProbe::voxels(a).data();
+	CHECK(storagePtrA != nullptr, "storage pointer is non-null after prepare");
 	a.generateTerrain(gen);
+	CHECK(ChunkStateProbe::voxels(a).data() == storagePtrA,
+		  "generation preserves exact storage pointer prepared on main thread");
 	CHECK(a.getState() == ChunkState::GENERATED, "generation completes");
 	CHECK(ChunkStateProbe::hasStorage(a), "generated chunk has voxel storage");
 	CHECK(ChunkStateProbe::voxels(a).size() == static_cast<size_t>(CHUNK_VOLUME),
@@ -298,6 +305,7 @@ int main(int argc, char **argv)
 	CHECK(!ChunkStateProbe::hasStorage(*pooled), "acquired chunk has no storage before generation");
 	if (pooled)
 	{
+		CHECK(pooled->prepareVoxelStorageForGeneration(), "prepare pooled storage succeeds");
 		pooled->generateTerrain(gen);
 		CHECK(ChunkStateProbe::hasStorage(*pooled), "pooled chunk has storage after generation");
 		CHECK(pool.voxelStorageCapacity() == 1, "voxel storage capacity grew on demand");
@@ -310,6 +318,7 @@ int main(int argc, char **argv)
 		Chunk *reused = pool.acquire(glm::vec3(-CHUNK_SIZE, 0.0f, CHUNK_SIZE));
 		CHECK(reused == pooled, "pool reuses released chunk slot");
 		CHECK(!ChunkStateProbe::hasStorage(*reused), "reacquired chunk slot has no storage before generation");
+		CHECK(reused->prepareVoxelStorageForGeneration(), "prepare storage on reuse succeeds");
 		reused->generateTerrain(gen);
 		CHECK(pool.voxelStorageCapacity() == 1, "generation reused pooled storage without allocating");
 		CHECK(pool.voxelStorageActive() == 1, "1 active voxel storage");
@@ -320,6 +329,76 @@ int main(int argc, char **argv)
 		pool.release(pooled); // cancelled before generation
 		CHECK(pool.acquiredCount() == 0, "cancelled acquisition returns to pool");
 		CHECK(pool.voxelStorageActive() == 0, "cancelled acquisition leaves no active storage");
+	}
+
+	// 5) setVoxel(..., AIR) on empty chunk does not allocate storage.
+	{
+		Chunk emptyChunk(glm::vec3(0.0f));
+		CHECK(!ChunkStateProbe::hasStorage(emptyChunk), "starts without storage");
+		CHECK(emptyChunk.getVoxel(0, 0, 0).type == AIR, "read on null storage returns AIR");
+		emptyChunk.setVoxel(0, 0, 0, AIR);
+		CHECK(!ChunkStateProbe::hasStorage(emptyChunk), "setting AIR does not allocate storage");
+		emptyChunk.setVoxel(0, 0, 0, STONE);
+		CHECK(ChunkStateProbe::hasStorage(emptyChunk), "setting non-AIR allocates storage");
+		CHECK(emptyChunk.getVoxel(0, 0, 0).type == STONE, "read back stone block");
+	}
+
+	// 6) Cross-pool move-assignment safety.
+	{
+		VoxelPool poolA;
+		VoxelPool poolB;
+		Chunk chunkA(glm::vec3(10.0f, 0.0f, 0.0f), ChunkState::UNLOADED, &poolA);
+		Chunk chunkB(glm::vec3(20.0f, 0.0f, 0.0f), ChunkState::UNLOADED, &poolB);
+		CHECK(chunkA.prepareVoxelStorageForGeneration(), "prepare chunkA storage");
+		CHECK(poolA.activeCount() == 1, "poolA active count 1");
+		CHECK(poolB.activeCount() == 0, "poolB active count 0");
+
+		chunkB = std::move(chunkA);
+		CHECK(poolA.activeCount() == 0, "poolA active count 0 after cross-pool move");
+		CHECK(poolB.activeCount() == 1, "poolB active count 1 after cross-pool move");
+		CHECK(!ChunkStateProbe::hasStorage(chunkA), "chunkA lost storage");
+		CHECK(ChunkStateProbe::hasStorage(chunkB), "chunkB has storage in poolB");
+		chunkB.reset(glm::vec3(0.0f));
+		CHECK(poolB.activeCount() == 0, "poolB active count 0 after reset");
+	}
+
+	// 7) Steady-state VoxelPool recycling high-water mark.
+	{
+		VoxelPool vp;
+		for (int cycle = 0; cycle < 1000; ++cycle)
+		{
+			VoxelStorage *s = vp.acquire();
+			vp.release(s);
+		}
+		CHECK(vp.capacity() == 1, "capacity capped at 1 for single-item recycling");
+		CHECK(vp.activeCount() == 0, "active count 0");
+		CHECK(vp.freeCount() == 1, "free count 1");
+	}
+
+	// 8) Multi-threaded VoxelPool stress test.
+	{
+		VoxelPool vp;
+		constexpr int kThreads = 4;
+		constexpr int kOpsPerThread = 2500;
+		std::vector<std::thread> workers;
+		workers.reserve(kThreads);
+		for (int t = 0; t < kThreads; ++t)
+		{
+			workers.emplace_back([&vp]() {
+				for (int i = 0; i < kOpsPerThread; ++i)
+				{
+					VoxelStorage *s = vp.acquire();
+					s->voxels[0].type = static_cast<uint8_t>(STONE);
+					vp.release(s);
+				}
+			});
+		}
+		for (auto &w : workers)
+			w.join();
+
+		CHECK(vp.activeCount() == 0, "concurrent stress ends with 0 active");
+		CHECK(vp.capacity() == vp.freeCount(), "capacity matches free list count");
+		CHECK(vp.capacity() <= static_cast<size_t>(kThreads), "capacity bounded by thread count");
 	}
 
 	if (g_fails != 0)

--- a/tests/test_voxel_pool.cpp
+++ b/tests/test_voxel_pool.cpp
@@ -66,6 +66,10 @@ int main()
 	}
 
 	// 3) Foreign release must be refused without corrupting either pool.
+	// Release-only: in Debug the ownership assert fires (the programming
+	// error must be immediately visible), so the graceful-refusal fallback
+	// is exercised where it actually runs.
+#ifdef NDEBUG
 	{
 		VoxelPool poolA;
 		VoxelPool poolB;
@@ -80,6 +84,7 @@ int main()
 	}
 
 	// 4) Double release must be refused without duplicating the free entry.
+	// Release-only for the same reason as above.
 	{
 		VoxelPool pool;
 		VoxelStorage *s = pool.acquire();
@@ -91,6 +96,7 @@ int main()
 		CHECK(t == s, "pool still hands out the block exactly once");
 		pool.release(t);
 	}
+#endif
 
 	// 5) Concurrent acquire/release stays balanced (used from the streaming
 	// workers historically; now also from edit paths).
@@ -132,9 +138,17 @@ int main()
 			  "each allocation beyond the free list is one grow event");
 		CHECK(afterReuse.events[telemetry::VoxelPoolGrow] == 2,
 			  "free-list reuse is not counted as growth");
+		// Grow events are capture-interval events: beginCapture() clears
+		// them and reuse after the boundary stays at zero.
+		registry.beginCapture();
+		CHECK(registry.snapshot().events[telemetry::VoxelPoolGrow] == 0,
+			  "beginCapture clears grow events");
 		pool.release(b);
+		VoxelStorage *secondReuse = pool.acquire();
+		CHECK(registry.snapshot().events[telemetry::VoxelPoolGrow] == 0,
+			  "reuse after the capture boundary is still not growth");
 		pool.release(reuse);
-		(void)registry;
+		pool.release(secondReuse);
 	}
 
 	// 7) Pointer stability: retained blocks keep their address for the pool

--- a/tests/test_voxel_pool.cpp
+++ b/tests/test_voxel_pool.cpp
@@ -1,0 +1,164 @@
+// VoxelPool contract (issue #112 review): pointer-stable reusable voxel
+// backing with strict ownership. Covers acquire/release/reuse, reserve and
+// high-water behavior, concurrency, foreign release and double release
+// refusal (Release-safe), and pool growth events.
+#include <Chunk/VoxelPool.hpp>
+#include <Engine/WorkloadTelemetry.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <iostream>
+#include <set>
+#include <thread>
+#include <vector>
+
+static int g_fails = 0;
+
+#define CHECK(cond, msg)                                                       \
+	do                                                                         \
+	{                                                                          \
+		if (!(cond))                                                           \
+		{                                                                      \
+			std::cerr << "FAIL: " << msg << " (" << __LINE__ << ")\n";         \
+			++g_fails;                                                         \
+		}                                                                      \
+	} while (0)
+
+int main()
+{
+	// 1) Single acquire/release and reuse of the same block.
+	{
+		VoxelPool pool;
+		VoxelStorage *first = pool.acquire();
+		CHECK(first != nullptr, "acquire returns a block");
+		pool.release(first);
+		CHECK(pool.capacity() == 1, "one block retained after release");
+		CHECK(pool.activeCount() == 0, "no active blocks after release");
+		CHECK(pool.freeCount() == 1, "released block is in the free list");
+		VoxelStorage *second = pool.acquire();
+		CHECK(second == first, "reuse hands back the same block");
+		CHECK(pool.capacity() == 1, "reuse does not grow the pool");
+		pool.release(second);
+	}
+
+	// 2) Reserve pre-allocates and the pool behaves as a high-water cache:
+	// capacity never shrinks and steady-state reuse does not grow it.
+	{
+		VoxelPool pool;
+		pool.reserve(10);
+		CHECK(pool.capacity() == 10, "reserve pre-allocates capacity");
+		CHECK(pool.freeCount() == 10, "reserved blocks are free");
+		std::vector<VoxelStorage *> held;
+		held.reserve(10);
+		for (int i = 0; i < 10; ++i)
+			held.push_back(pool.acquire());
+		CHECK(pool.freeCount() == 0, "all reserved blocks in use");
+		CHECK(pool.capacity() == 10, "acquiring reserved blocks does not grow the pool");
+		for (VoxelStorage *s : held)
+			pool.release(s);
+		CHECK(pool.capacity() == 10 && pool.freeCount() == 10,
+			  "high-water capacity retained after release");
+		// Reuse order hands back recently released blocks without growth.
+		VoxelStorage *again = pool.acquire();
+		CHECK(std::find(held.begin(), held.end(), again) != held.end(),
+			  "reacquired block comes from the free list");
+		pool.release(again);
+	}
+
+	// 3) Foreign release must be refused without corrupting either pool.
+	{
+		VoxelPool poolA;
+		VoxelPool poolB;
+		VoxelStorage *s = poolA.acquire();
+		poolB.release(s);
+		CHECK(poolA.activeCount() == 1, "foreign release leaves owner active count intact");
+		CHECK(poolA.freeCount() == 0, "foreign release does not touch owner free list");
+		CHECK(poolB.activeCount() == 0, "foreign release does not adopt the block");
+		CHECK(poolB.freeCount() == 0, "foreign release does not pollute borrower free list");
+		poolA.release(s);
+		CHECK(poolA.freeCount() == 1, "owner release still works after refused foreign release");
+	}
+
+	// 4) Double release must be refused without duplicating the free entry.
+	{
+		VoxelPool pool;
+		VoxelStorage *s = pool.acquire();
+		pool.release(s);
+		pool.release(s);
+		CHECK(pool.freeCount() == 1, "double release does not duplicate the free entry");
+		CHECK(pool.activeCount() == 0, "double release does not drive active negative");
+		VoxelStorage *t = pool.acquire();
+		CHECK(t == s, "pool still hands out the block exactly once");
+		pool.release(t);
+	}
+
+	// 5) Concurrent acquire/release stays balanced (used from the streaming
+	// workers historically; now also from edit paths).
+	{
+		VoxelPool pool;
+		constexpr int kThreads = 4;
+		constexpr int kOpsPerThread = 2000;
+		std::vector<std::thread> workers;
+		for (int t = 0; t < kThreads; ++t)
+		{
+			workers.emplace_back([&pool]() {
+				for (int i = 0; i < kOpsPerThread; ++i)
+				{
+					VoxelStorage *s = pool.acquire();
+					s->voxels[0].type = 1;
+					pool.release(s);
+				}
+			});
+		}
+		for (auto &w : workers)
+			w.join();
+		CHECK(pool.activeCount() == 0, "concurrent stress ends with 0 active");
+		CHECK(pool.capacity() == pool.freeCount(), "concurrent stress keeps free list consistent");
+	}
+
+	// 6) Growth events: growth beyond the free list is observable, reuse is
+	// not counted as growth.
+	{
+		auto &registry = telemetry::registry();
+		registry.beginCapture();
+		VoxelPool pool;
+		VoxelStorage *a = pool.acquire();
+		VoxelStorage *b = pool.acquire();
+		const auto afterGrowth = registry.snapshot();
+		pool.release(a);
+		VoxelStorage *reuse = pool.acquire();
+		const auto afterReuse = registry.snapshot();
+		CHECK(afterGrowth.events[telemetry::VoxelPoolGrow] == 2,
+			  "each allocation beyond the free list is one grow event");
+		CHECK(afterReuse.events[telemetry::VoxelPoolGrow] == 2,
+			  "free-list reuse is not counted as growth");
+		pool.release(b);
+		pool.release(reuse);
+		(void)registry;
+	}
+
+	// 7) Pointer stability: retained blocks keep their address for the pool
+	// lifetime (chunks hold raw VoxelStorage pointers).
+	{
+		VoxelPool pool;
+		std::set<VoxelStorage *> seen;
+		std::vector<VoxelStorage *> held;
+		for (int i = 0; i < 8; ++i)
+		{
+			VoxelStorage *s = pool.acquire();
+			CHECK(seen.insert(s).second, "no duplicate live block handed out");
+			held.push_back(s);
+		}
+		for (VoxelStorage *s : held)
+			pool.release(s);
+	}
+
+	if (g_fails != 0)
+	{
+		std::cerr << g_fails << " check(s) failed\n";
+		return 1;
+	}
+	std::cout << "PASS: voxel pool - acquire/release/reuse, reserve high-water, foreign and "
+			  << "double release refusal, concurrency, growth events\n";
+	return 0;
+}

--- a/tests/test_workload_telemetry.cpp
+++ b/tests/test_workload_telemetry.cpp
@@ -1,4 +1,5 @@
 #include <Engine/WorkloadTelemetry.hpp>
+#include <utils.hpp>
 #include <iostream>
 #include <stdexcept>
 #include <thread>
@@ -44,15 +45,20 @@ int main() {
         s = r.snapshot();
         require(!s.events[AllocCreated] && !s.stageCalls[Skylight], "second capture starts empty");
 
-        // Capture-local vs persistent gauges (issue #111 review): warmup
-        // staging high-water and end-of-frame chunk-manager samples must not
-        // leak into a new measurement window, while ownership gauges survive
-        // the boundary with their peak rebased to the carried-over value.
+        // Capture-local vs persistent gauges (issue #111/#112 reviews):
+        // warmup staging high-water, end-of-frame chunk-manager samples and
+        // the VoxelPool active/free split must not leak into a new
+        // measurement window, while ownership gauges (including the pool's
+        // retained capacity) survive the boundary with their peak rebased.
         Registry w;
         w.replace(VoxelBytes, 0, 65536);
         w.set(StagingUsed, 1024 * 1024);
         w.set(ActiveChunks, 4200);
         w.set(DeferredChunks, 20);
+        w.set(VoxelPoolCapacity, 4600);
+        w.set(VoxelPoolCapacityBytes, 4600ull * CHUNK_VOLUME);
+        w.set(VoxelPoolActive, 4200);
+        w.set(VoxelPoolFree, 400);
         w.add(AllocCreated);
         w.add(UploadChunks);
         w.add(StagingFailures);
@@ -63,23 +69,50 @@ int main() {
         const auto reset = w.snapshot();
         require(reset.current[VoxelBytes] == 65536 && reset.peak[VoxelBytes] == 65536,
                 "persistent ownership survives capture, peak rebased");
+        require(reset.current[VoxelPoolCapacity] == 4600 && reset.peak[VoxelPoolCapacity] == 4600,
+                "voxel pool retained capacity survives capture");
+        require(reset.current[VoxelPoolCapacityBytes] == 4600ull * CHUNK_VOLUME &&
+                reset.peak[VoxelPoolCapacityBytes] == 4600ull * CHUNK_VOLUME,
+                "voxel pool retained capacity bytes survive capture");
         require(reset.current[StagingUsed] == 0 && reset.peak[StagingUsed] == 0,
                 "capture resets transient staging current and peak");
         require(reset.current[ActiveChunks] == 0 && reset.peak[ActiveChunks] == 0 &&
                 reset.current[DeferredChunks] == 0 && reset.peak[DeferredChunks] == 0,
                 "capture resets sampled chunk-manager gauges");
+        require(reset.current[VoxelPoolActive] == 0 && reset.peak[VoxelPoolActive] == 0,
+                "voxel pool active resets at capture boundary");
+        require(reset.current[VoxelPoolFree] == 0 && reset.peak[VoxelPoolFree] == 0,
+                "voxel pool free resets at capture boundary");
         require(!reset.events[AllocCreated] && !reset.events[UploadChunks] &&
                 !reset.events[StagingFailures] && !reset.events[OpaqueDraws],
                 "capture clears event categories");
         w.set(StagingUsed, 64 * 1024);
         w.set(ActiveChunks, 4300);
         w.set(DeferredChunks, 7);
+        w.set(VoxelPoolActive, 3500);
+        w.set(VoxelPoolFree, 1100);
         const auto measured = w.snapshot();
         require(measured.current[StagingUsed] == 64 * 1024 &&
                 measured.peak[StagingUsed] == 64 * 1024,
                 "measured staging high-water starts from zero");
         require(measured.peak[ActiveChunks] == 4300 && measured.peak[DeferredChunks] == 7,
                 "measured chunk peaks reflect measured frames only");
+        require(measured.current[VoxelPoolActive] == 3500 && measured.peak[VoxelPoolActive] == 3500,
+                "active peak belongs to measured capture");
+        require(measured.current[VoxelPoolFree] == 1100 && measured.peak[VoxelPoolFree] == 1100,
+                "free peak belongs to measured capture");
+
+        // Two successive captures (benchmark -> reload -> new benchmark in
+        // the same process): the previous run's peaks must not contribute to
+        // the next window.
+        w.beginCapture();
+        w.set(VoxelPoolActive, 3900);
+        w.set(VoxelPoolFree, 700);
+        const auto second = w.snapshot();
+        require(second.peak[VoxelPoolActive] == 3900,
+                "second capture active peak is its own, not the previous run's");
+        require(second.peak[VoxelPoolFree] == 700,
+                "second capture free peak is its own, not the previous run's");
 
         // Repeated captures (the warmup=0 path fires beginCapture several
         // times in a row) must keep ownership intact and sampled gauges at
@@ -93,6 +126,9 @@ int main() {
         require(repeated.current[StagingUsed] == 0 && repeated.peak[StagingUsed] == 0 &&
                 repeated.current[ActiveChunks] == 0 && repeated.current[DeferredChunks] == 0,
                 "repeated captures keep sampled gauges at zero");
+        require(repeated.current[VoxelPoolCapacity] == 4600 &&
+                repeated.current[VoxelPoolCapacityBytes] == 4600ull * CHUNK_VOLUME,
+                "repeated captures keep retained voxel pool capacity");
 
         std::cout << "PASS: telemetry concurrency, ownership, capture epochs, reset, "
                      "capture-local gauges\n";


### PR DESCRIPTION
ChunkPool pre-allocates thousands of Chunk objects to maintain pointer stability across view-distance adjustments (~8.9k chunks at view distance 512), but each Chunk constructor previously allocated 64 KiB of raw voxels upfront. As a result, unused pool slots consumed ~556 MiB of RAM regardless of the actual active working set (~500-3000 chunks).

Implementation:
- Decouple raw 64 KiB voxel storage into VoxelStorage (std::array<Voxel, CHUNK_VOLUME>) and introduce thread-safe VoxelPool.
- Constructing and growing ChunkPool now allocates only Chunk metadata; free chunk slots carry null voxel storage (0 bytes).
- Voxel backing follows an explicit prepare-before-generation contract: storage is prepared on the main thread immediately before generation dispatch (`Chunk::prepareVoxelStorageForGeneration()` / `ChunkManager::prepareAndGenerateChunk()`); workers never acquire or release voxel backing. Manual edits allocate lazily via ensureVoxelStorage().
- On chunk retirement (Chunk::reset with ResetMode::Full and ChunkPool::release), voxel storage is returned to VoxelPool's free list for reuse, preventing steady-state heap churn.
- Preserve #78 and #93 invariants: TerrainGenerator::generateChunkInto() writes directly into caller-owned VoxelStorage with no temporary ChunkData, no post-generation copy, and no redundant AIR clearing before generation.
- Update Chunk move constructor, move assignment, and destructor to safely transfer or return VoxelStorage ownership.
- Expose voxel storage statistics on ChunkPool (capacity, activeCount, freeCount).

Tests and measurements:
- Update test_chunk_lifecycle with VoxelView wrapper to verify that chunk construction allocates no voxel memory, storage is acquired on demand, move preserves ownership, full reset returns storage, and pool recycle reuses existing storage without capacity growth.
- Verify that telemetry gauge voxel.bytes reports resident storage of active chunks rather than total ChunkPool capacity: startup voxel RAM drops from 556 MiB to 0 MiB, and 15s benchmark peak voxel memory drops from 555.875 MiB to 143.25 MiB (~75% reduction).
- Benchmark run (--seed 42 --benchmark 15) scores 9918 (Grade S, ~673 avg FPS) with zero staging failures and zero pool rejects; TerrainGen averages 1.59 ms.

Validation:
- Windows/MSVC Release build passes with 0 warnings/errors.
- CTest passes 14/14 tests in 42.11 s (including VulkanResourceSmoke, ChunkLifecycle, TerrainGeneration, WorkloadTelemetry).
- git diff --check passes with no whitespace or style issues.

Close #102


## Review fix (2b92493): bootstrap contract, VoxelPool ownership, cross-pool moves

- `generateInitialArea()` used to call `generateTerrain()` without the storage contract and would assert; it now goes through the shared `ChunkManager::prepareAndGenerateChunk()` helper (prepare on the calling thread, generate, return the chunk to the pool on allocation failure). All `generateTerrain()` call sites audited: async streaming prepares on the main thread before dispatch, bootstrap uses the helper.
- VoxelPool no longer writes the ChunkPool-owned `pool.*` gauges from `acquire`/`release` (it also did so under its own mutex from workers). Dedicated `voxel.pool.*` gauges (capacity, active, free, capacityBytes) are published as a coherent per-frame snapshot on the main thread; `voxel.pool.growEvents` counts allocations beyond the free list. `m_telemetry` removed — the pool is a plain thread-safe component again.
- `VoxelPool::release()` is Release-safe: wrong-pool and double releases are refused instead of corrupting the free list, and the active-count decrement is underflow-guarded.
- `operator=(Chunk&&)` stays `noexcept` and O(1): the voxel storage and the pool that owns it travel together instead of re-acquiring (allocation + 64 KiB copy, source zeroed before the throwing call) inside the move.
- New `test_voxel_pool` target: acquire/release/reuse, reserve + high-water, concurrent stress, foreign and double release refusal, growth events. Lifecycle test: cross-pool move-construct/assign verify generated content travels with ownership, ChunkPool destructor retires live storage, bootstrap contract exercised through ChunkManager.

## Interleaved A/B reference (3x 60s, 15s warmup, seed 42, telemetry on)

Reports: [docs/benchmarks/issue112-ab](docs/benchmarks/issue112-ab) (base `da00e51` vs HEAD `2b92493`, medians):

| Metric | Base | PR | Delta |
| --- | ---: | ---: | ---: |
| voxel.bytes peak | 555.88 MiB | 290.69 MiB | **-47.7%** |
| voxel.pool capacityBytes (retained high-water) | n/a | 290.69 MiB | new |
| voxel.pool capacity / active peak | n/a | 4,651 blocks | new |
| voxel.pool.growEvents (measurement) | n/a | 68-86 | new |
| Frame avg / p95 / p99 | 2.803 / 6.267 / 8.171 ms | 2.525 / 5.439 / 5.991 ms | -9.9% / -13.2% / -26.7% |
| TerrainGen avg/job | 1.537 ms | 1.565 ms | +1.8% |
| Streaming avg | 0.380 ms | 0.382 ms | +0.5% |
| MeshBuild avg/job | 2.782 ms | 2.953 ms | +6.1% |
| Pool rejects / staging failures | 0 / 0 | 0 / 0 | = |

**Timing caveat:** the machine's GPU and CPU were also loaded by other programs while these runs were captured, so ALL timing deltas in this table (frame avg/p95/p99, TerrainGen, Streaming, MeshBuild) are unreliable and must not be read as performance conclusions - the <=5% acceptance bar cannot be honestly evaluated from this pair. A re-run on an idle machine is required before any timing claim. The memory results are unaffected: voxel.bytes peak, voxel.pool.* and growEvents are structural counters, not timings.

Validation: build clean; ctest 15/15 (new VoxelPool test); ASan/TSan intentionally not run this round.

